### PR TITLE
Cleanup

### DIFF
--- a/src/class-dom.php
+++ b/src/class-dom.php
@@ -76,11 +76,11 @@ abstract class DOM {
 	 */
 	public static function block_tags( $reset = false ) {
 		if ( empty( self::$block_tags ) || $reset ) {
-			self::$block_tags = array_merge(
-				array_flip( array_filter( array_keys( Elements::$html5 ), function( $tag ) {
+			self::$block_tags = \array_merge(
+				\array_flip( \array_filter( \array_keys( Elements::$html5 ), function( $tag ) {
 					return Elements::isA( $tag, Elements::BLOCK_TAG );
 				} ) ),
-				array_flip( [ 'li', 'td', 'dt' ] ) // not included as "block tags" in current HTML5-PHP version.
+				\array_flip( [ 'li', 'td', 'dt' ] ) // not included as "block tags" in current HTML5-PHP version.
 			);
 		}
 
@@ -100,8 +100,8 @@ abstract class DOM {
 	 */
 	public static function inappropriate_tags( $reset = false ) {
 		if ( empty( self::$inappropriate_tags ) || $reset ) {
-			self::$inappropriate_tags = array_flip( array_merge(
-				array_filter( array_keys( Elements::$html5 ), function( $tag ) {
+			self::$inappropriate_tags = \array_flip( \array_merge(
+				\array_filter( \array_keys( Elements::$html5 ), function( $tag ) {
 					return Elements::isA( $tag, Elements::VOID_TAG )
 						|| Elements::isA( $tag, Elements::TEXT_RAW )
 						|| Elements::isA( $tag, Elements::TEXT_RCDATA );
@@ -124,7 +124,7 @@ abstract class DOM {
 		$out = [];
 
 		foreach ( $list as $node ) {
-			$out[ spl_object_hash( $node ) ] = $node;
+			$out[ \spl_object_hash( $node ) ] = $node;
 		}
 
 		return $out;
@@ -168,12 +168,12 @@ abstract class DOM {
 		}
 
 		// Ensure we always have an array of classnames.
-		if ( ! is_array( $classnames ) ) {
+		if ( ! \is_array( $classnames ) ) {
 			$classnames = [ $classnames ];
 		}
 
 		if ( $tag->hasAttribute( 'class' ) ) {
-			$tag_classes = array_flip( explode( ' ', $tag->getAttribute( 'class' ) ) );
+			$tag_classes = \array_flip( \explode( ' ', $tag->getAttribute( 'class' ) ) );
 
 			foreach ( $classnames as $classname ) {
 				if ( isset( $tag_classes[ $classname ] ) ) {
@@ -227,7 +227,7 @@ abstract class DOM {
 			$func = Strings::functions( $textnode->data );
 
 			if ( ! empty( $func ) ) {
-				return preg_replace( '/\p{C}/Su', '', $func['substr']( $textnode->data, $position, $length ) );
+				return \preg_replace( '/\p{C}/Su', '', $func['substr']( $textnode->data, $position, $length ) );
 			}
 		}
 

--- a/src/class-hyphenator.php
+++ b/src/class-hyphenator.php
@@ -131,11 +131,11 @@ class Hyphenator {
 			}
 
 			$exception                    = $f['strtolower']( $exception );
-			$exception_keys[ $exception ] = preg_replace( "#-#{$f['u']}", '', $exception );
+			$exception_keys[ $exception ] = \preg_replace( "#-#{$f['u']}", '', $exception );
 		}
 
 		// Update exceptions.
-		$this->custom_exceptions      = array_flip( $exception_keys );
+		$this->custom_exceptions      = \array_flip( $exception_keys );
 		$this->custom_exceptions_hash = $new_hash;
 
 		// Force remerging of patgen and custom exception patterns.
@@ -150,7 +150,7 @@ class Hyphenator {
 	 * @return string
 	 */
 	protected static function get_object_hash( $object ) {
-		return md5( json_encode( $object ), false );
+		return \md5( \json_encode( $object ), false );
 	}
 
 	/**
@@ -166,13 +166,13 @@ class Hyphenator {
 		}
 
 		$success            = false;
-		$language_file_name = dirname( __FILE__ ) . '/lang/' . $lang . '.json';
+		$language_file_name = \dirname( __FILE__ ) . '/lang/' . $lang . '.json';
 
-		if ( file_exists( $language_file_name ) ) {
-			$raw_language_file = file_get_contents( $language_file_name );
+		if ( \file_exists( $language_file_name ) ) {
+			$raw_language_file = \file_get_contents( $language_file_name );
 
 			if ( false !== $raw_language_file ) {
-				$language_file = json_decode( $raw_language_file, true );
+				$language_file = \json_decode( $raw_language_file, true );
 
 				if ( false !== $language_file ) {
 					$this->language           = $lang;

--- a/src/class-php-typography.php
+++ b/src/class-php-typography.php
@@ -138,7 +138,7 @@ class PHP_Typography {
 	 * @return string The processed $html.
 	 */
 	public function process_textnodes( $html, callable $fixer, Settings $settings, $is_title = false, array $body_classes = [] ) {
-		if ( isset( $settings['ignoreTags'] ) && $is_title && ( in_array( 'h1', $settings['ignoreTags'], true ) || in_array( 'h2', $settings['ignoreTags'], true ) ) ) {
+		if ( isset( $settings['ignoreTags'] ) && $is_title && ( \in_array( 'h1', $settings['ignoreTags'], true ) || \in_array( 'h2', $settings['ignoreTags'], true ) ) ) {
 			return $html;
 		}
 
@@ -190,7 +190,7 @@ class PHP_Typography {
 	 */
 	protected static function arrays_intersect( array $array1, array $array2 ) {
 		foreach ( $array1 as $value ) {
-			if ( isset( $array2[ spl_object_hash( $value ) ] ) ) {
+			if ( isset( $array2[ \spl_object_hash( $value ) ] ) ) {
 				return true;
 			}
 		}
@@ -213,20 +213,20 @@ class PHP_Typography {
 	 */
 	public function parse_html( \Masterminds\HTML5 $parser, $html, Settings $settings, array $body_classes = [] ) {
 		// Silence some parsing errors for invalid HTML.
-		set_error_handler( [ $this, 'handle_parsing_errors' ] ); // @codingStandardsIgnoreLine
-		$xml_error_handling = libxml_use_internal_errors( true );
+		\set_error_handler( [ $this, 'handle_parsing_errors' ] ); // @codingStandardsIgnoreLine
+		$xml_error_handling = \libxml_use_internal_errors( true );
 
 		// Inject <body> classes.
-		$body = empty( $body_classes ) ? 'body' : 'body class="' . implode( ' ', $body_classes ) . '"';
+		$body = empty( $body_classes ) ? 'body' : 'body class="' . \implode( ' ', $body_classes ) . '"';
 
 		// Do the actual parsing.
 		$dom           = $parser->loadHTML( "<!DOCTYPE html><html><{$body}>{$html}</body></html>" );
 		$dom->encoding = 'UTF-8';
 
 		// Restore original error handling.
-		libxml_clear_errors();
-		libxml_use_internal_errors( $xml_error_handling );
-		restore_error_handler();
+		\libxml_clear_errors();
+		\libxml_use_internal_errors( $xml_error_handling );
+		\restore_error_handler();
 
 		// Handle any parser errors.
 		$errors = $parser->getErrors();
@@ -254,12 +254,12 @@ class PHP_Typography {
 	 * @return boolean Returns true if the error was handled, false otherwise.
 	 */
 	public function handle_parsing_errors( $errno, $errstr, $errfile ) {
-		if ( ! ( error_reporting() & $errno ) ) { // @codingStandardsIgnoreLine.
+		if ( ! ( \error_reporting() & $errno ) ) { // @codingStandardsIgnoreLine.
 			return true; // not interesting.
 		}
 
 		// Ignore warnings from parser & let PHP handle the rest.
-		return $errno & E_USER_WARNING && 0 === substr_compare( $errfile, 'DOMTreeBuilder.php', -18 );
+		return $errno & E_USER_WARNING && 0 === \substr_compare( $errfile, 'DOMTreeBuilder.php', -18 );
 	}
 
 	/**
@@ -275,17 +275,17 @@ class PHP_Typography {
 		$elements    = [];
 		$query_parts = [];
 		if ( ! empty( $settings['ignoreTags'] ) ) {
-			$query_parts[] = '//' . implode( ' | //', $settings['ignoreTags'] );
+			$query_parts[] = '//' . \implode( ' | //', $settings['ignoreTags'] );
 		}
 		if ( ! empty( $settings['ignoreClasses'] ) ) {
-			$query_parts[] = "//*[contains(concat(' ', @class, ' '), ' " . implode( " ') or contains(concat(' ', @class, ' '), ' ", $settings['ignoreClasses'] ) . " ')]";
+			$query_parts[] = "//*[contains(concat(' ', @class, ' '), ' " . \implode( " ') or contains(concat(' ', @class, ' '), ' ", $settings['ignoreClasses'] ) . " ')]";
 		}
 		if ( ! empty( $settings['ignoreIDs'] ) ) {
-			$query_parts[] = '//*[@id=\'' . implode( '\' or @id=\'', $settings['ignoreIDs'] ) . '\']';
+			$query_parts[] = '//*[@id=\'' . \implode( '\' or @id=\'', $settings['ignoreIDs'] ) . '\']';
 		}
 
 		if ( ! empty( $query_parts ) ) {
-			$ignore_query = implode( ' | ', $query_parts );
+			$ignore_query = \implode( ' | ', $query_parts );
 
 			$nodelist = $xpath->query( $ignore_query, $initial_node );
 			if ( false !== $nodelist ) {
@@ -312,7 +312,7 @@ class PHP_Typography {
 			return $node; // abort early to save cycles.
 		}
 
-		set_error_handler( [ $this, 'handle_parsing_errors' ] ); // @codingStandardsIgnoreLine.
+		\set_error_handler( [ $this, 'handle_parsing_errors' ] ); // @codingStandardsIgnoreLine.
 
 		$html_fragment = $this->get_html5_parser()->loadHTMLFragment( $content );
 		if ( ! empty( $html_fragment ) ) {
@@ -330,7 +330,7 @@ class PHP_Typography {
 			}
 		}
 
-		restore_error_handler();
+		\restore_error_handler();
 
 		return $result;
 	}
@@ -404,29 +404,29 @@ class PHP_Typography {
 	private static function get_language_plugin_list( $path ) {
 		$language_name_pattern = '/"language"\s*:\s*((".+")|(\'.+\'))\s*,/';
 		$languages             = [];
-		$handle                = opendir( $path );
+		$handle                = \opendir( $path );
 
 		// Read all files in directory.
-		$file = readdir( $handle );
+		$file = \readdir( $handle );
 		while ( $file ) {
 			// We only want the JSON files.
-			if ( '.json' === substr( $file, -5 ) ) {
-				$file_content = file_get_contents( $path . $file );
-				if ( preg_match( $language_name_pattern, $file_content, $matches ) ) {
-					$language_name = substr( $matches[1], 1, -1 );
-					$language_code = substr( $file, 0, -5 );
+			if ( '.json' === \substr( $file, -5 ) ) {
+				$file_content = \file_get_contents( $path . $file );
+				if ( \preg_match( $language_name_pattern, $file_content, $matches ) ) {
+					$language_name = \substr( $matches[1], 1, -1 );
+					$language_code = \substr( $file, 0, -5 );
 
 					$languages[ $language_code ] = $language_name;
 				}
 			}
 
 			// Read next file.
-			$file = readdir( $handle );
+			$file = \readdir( $handle );
 		}
-		closedir( $handle );
+		\closedir( $handle );
 
 		// Sort translated language names according to current locale.
-		asort( $languages );
+		\asort( $languages );
 
 		return $languages;
 	}

--- a/src/class-re.php
+++ b/src/class-re.php
@@ -108,20 +108,20 @@ abstract class RE {
 	private static function get_top_level_domains_from_file( $path ) {
 		$domains = [];
 
-		if ( file_exists( $path ) ) {
+		if ( \file_exists( $path ) ) {
 			$file = new \SplFileObject( $path );
 
 			while ( ! $file->eof() ) {
 				$line = $file->fgets();
 
-				if ( preg_match( '#^[a-zA-Z0-9][a-zA-Z0-9-]*$#', $line, $matches ) ) {
-					$domains[] = strtolower( $matches[0] );
+				if ( \preg_match( '#^[a-zA-Z0-9][a-zA-Z0-9-]*$#', $line, $matches ) ) {
+					$domains[] = \strtolower( $matches[0] );
 				}
 			}
 		}
 
-		if ( count( $domains ) > 0 ) {
-			return implode( '|', $domains );
+		if ( \count( $domains ) > 0 ) {
+			return \implode( '|', $domains );
 		} else {
 			return 'ac|ad|aero|ae|af|ag|ai|al|am|an|ao|aq|arpa|ar|asia|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|biz|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|cat|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|com|coop|co|cr|cu|cv|cx|cy|cz|de|dj|dk|dm|do|dz|ec|edu|ee|eg|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gov|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|info|int|in|io|iq|ir|is|it|je|jm|jobs|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mil|mk|ml|mm|mn|mobi|mo|mp|mq|mr|ms|mt|museum|mu|mv|mw|mx|my|mz|name|na|nc|net|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|org|pa|pe|pf|pg|ph|pk|pl|pm|pn|pro|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|so|sr|st|su|sv|sy|sz|tc|td|tel|tf|tg|th|tj|tk|tl|tm|tn|to|tp|travel|tr|tt|tv|tw|tz|ua|ug|uk|um|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw';
 		}

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -529,10 +529,10 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		}
 
 		$this->data['diacriticLanguage'] = $lang;
-		$language_file_name              = dirname( __FILE__ ) . '/diacritics/' . $lang . '.json';
+		$language_file_name              = \dirname( __FILE__ ) . '/diacritics/' . $lang . '.json';
 
-		if ( file_exists( $language_file_name ) ) {
-			$diacritics_file              = json_decode( file_get_contents( $language_file_name ), true );
+		if ( \file_exists( $language_file_name ) ) {
+			$diacritics_file              = \json_decode( \file_get_contents( $language_file_name ), true );
 			$this->data['diacriticWords'] = $diacritics_file['diacritic_words'];
 		} else {
 			unset( $this->data['diacriticWords'] );
@@ -548,13 +548,13 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 *                                          or a string formatted `"needle"=>"replacement","needle"=>"replacement",...
 	 */
 	public function set_diacritic_custom_replacements( $custom_replacements = [] ) {
-		if ( ! is_array( $custom_replacements ) ) {
+		if ( ! \is_array( $custom_replacements ) ) {
 			$custom_replacements = $this->parse_diacritics_replacement_string( $custom_replacements );
 		}
 
 		$this->data['diacriticCustomReplacements'] = self::array_map_assoc( function( $key, $replacement ) {
-			$key         = strip_tags( trim( $key ) );
-			$replacement = strip_tags( trim( $replacement ) );
+			$key         = \strip_tags( \trim( $key ) );
+			$replacement = \strip_tags( \trim( $replacement ) );
 
 			if ( ! empty( $key ) && ! empty( $replacement ) ) {
 				return [ $key => $replacement ];
@@ -577,17 +577,17 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		return self::array_map_assoc( function( $key, $replacement ) {
 
 			// Account for single and double quotes in keys ...
-			if ( preg_match( '/("|\')((?:(?!\1).)+)(?:\1\s*=>)/', $replacement, $match ) ) {
+			if ( \preg_match( '/("|\')((?:(?!\1).)+)(?:\1\s*=>)/', $replacement, $match ) ) {
 				$key = $match[2];
 			}
 
 			// ... and values.
-			if ( preg_match( '/(?:=>\s*("|\'))((?:(?!\1).)+)(?:\1)/', $replacement, $match ) ) {
+			if ( \preg_match( '/(?:=>\s*("|\'))((?:(?!\1).)+)(?:\1)/', $replacement, $match ) ) {
 				$replacement = $match[2];
 			}
 
 			return [ $key => $replacement ];
-		}, preg_split( '/,/', $custom_replacements, -1, PREG_SPLIT_NO_EMPTY ) );
+		}, \preg_split( '/,/', $custom_replacements, -1, PREG_SPLIT_NO_EMPTY ) );
 	}
 
 	/**
@@ -765,9 +765,9 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		// Update components & regex pattern.
 		foreach ( $units as $index => $unit ) {
 			// Escape special chars.
-			$units[ $index ] = preg_replace( '#([\[\\\^\$\.\|\?\*\+\(\)\{\}])#', '\\\\$1', $unit );
+			$units[ $index ] = \preg_replace( '#([\[\\\^\$\.\|\?\*\+\(\)\{\}])#', '\\\\$1', $unit );
 		}
-		$this->custom_units  = implode( '|', $units );
+		$this->custom_units  = \implode( '|', $units );
 		$this->custom_units .= ( $this->custom_units ) ? '|' : '';
 	}
 
@@ -921,12 +921,12 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 */
 	public function set_initial_quote_tags( $tags = [ 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'li', 'dd', 'dt' ] ) {
 		// Make array if handed a list of tags as a string.
-		if ( ! is_array( $tags ) ) {
-			$tags = preg_split( '/[^a-z0-9]+/', $tags, -1, PREG_SPLIT_NO_EMPTY );
+		if ( ! \is_array( $tags ) ) {
+			$tags = \preg_split( '/[^a-z0-9]+/', $tags, -1, PREG_SPLIT_NO_EMPTY );
 		}
 
 		// Store the tag array inverted (with the tagName as its index for faster lookup).
-		$this->data['initialQuoteTags'] = array_change_key_case( array_flip( $tags ), CASE_LOWER );
+		$this->data['initialQuoteTags'] = \array_change_key_case( \array_flip( $tags ), CASE_LOWER );
 	}
 
 	/**
@@ -1041,10 +1041,10 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 * @return string A binary hash value for the current settings limited to $max_length.
 	 */
 	public function get_hash( $max_length = 16, $raw_output = true ) {
-		$hash = md5( json_encode( $this ), $raw_output );
+		$hash = \md5( \json_encode( $this ), $raw_output );
 
-		if ( $max_length < strlen( $hash ) && $max_length > 0 ) {
-			$hash = substr( $hash, 0, $max_length );
+		if ( $max_length < \strlen( $hash ) && $max_length > 0 ) {
+			$hash = \substr( $hash, 0, $max_length );
 		}
 
 		return $hash;

--- a/src/class-strings.php
+++ b/src/class-strings.php
@@ -142,7 +142,7 @@ abstract class Strings {
 		// Deal with an array of character codes.
 		$json = '"';
 		foreach ( $codes as $code ) {
-			$json .= sprintf( '\u%04x', $code );
+			$json .= \sprintf( '\u%04x', $code );
 		}
 		$json .= '"';
 

--- a/src/class-text-parser.php
+++ b/src/class-text-parser.php
@@ -301,12 +301,12 @@ class Text_Parser {
 	 * @return bool Returns `true` on successful completion, `false` otherwise.
 	 */
 	public function load( $raw_text ) {
-		if ( ! is_string( $raw_text ) ) {
+		if ( ! \is_string( $raw_text ) ) {
 			return false; // we have an error, abort.
 		}
 
 		// Abort if a simple string exceeds 500 characters (security concern).
-		if ( preg_match( self::_RE_MAX_STRING_LENGTH, $raw_text ) ) {
+		if ( \preg_match( self::_RE_MAX_STRING_LENGTH, $raw_text ) ) {
 			return false;
 		}
 
@@ -318,7 +318,7 @@ class Text_Parser {
 		$this->current_strtoupper = $str_functions['strtoupper'];
 
 		// Tokenize the raw text parts.
-		$this->text = self::tokenize( preg_split( self::_RE_ANY_TEXT, $raw_text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY ) );
+		$this->text = self::tokenize( \preg_split( self::_RE_ANY_TEXT, $raw_text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY ) );
 
 		// The token array should never be empty.
 		return ! empty( $this->text );
@@ -336,11 +336,11 @@ class Text_Parser {
 		$index  = 0;
 
 		foreach ( $parts as $part ) {
-			if ( preg_match( self::_RE_SPACE, $part ) ) {
+			if ( \preg_match( self::_RE_SPACE, $part ) ) {
 				$tokens[ $index ] = new Token( $part, Token::SPACE );
-			} elseif ( preg_match( self::_RE_PUNCTUATION, $part ) ) {
+			} elseif ( \preg_match( self::_RE_PUNCTUATION, $part ) ) {
 				$tokens[ $index ] = new Token( $part, Token::PUNCTUATION );
-			} elseif ( preg_match( self::_RE_WORD, $part ) ) {
+			} elseif ( \preg_match( self::_RE_WORD, $part ) ) {
 				// Make sure that things like email addresses and URLs are not broken up
 				// into words and punctuation not preceeded by an 'other'.
 				self::parse_ambiguous_token( Token::WORD, $part, $tokens, $index );
@@ -530,7 +530,7 @@ class Text_Parser {
 	 */
 	protected function conforms_to_letters_policy( Token $token, $policy ) {
 		return $this->check_policy( $token, $policy, self::ALLOW_ALL_LETTERS, self::REQUIRE_ALL_LETTERS, self::NO_ALL_LETTERS, function( $value ) {
-			return preg_replace( self::_RE_HTML_LETTER_CONNECTORS, '', $value );
+			return \preg_replace( self::_RE_HTML_LETTER_CONNECTORS, '', $value );
 		} );
 	}
 
@@ -556,7 +556,7 @@ class Text_Parser {
 	 */
 	protected function conforms_to_compounds_policy( Token $token, $policy ) {
 		return $this->check_policy( $token, $policy, self::ALLOW_COMPOUNDS, self::NO_COMPOUNDS, self::REQUIRE_COMPOUNDS, function( $value ) {
-			return preg_replace( '/-/S', '', $value );
+			return \preg_replace( '/-/S', '', $value );
 		} );
 	}
 

--- a/src/fixes/class-default-registry.php
+++ b/src/fixes/class-default-registry.php
@@ -80,7 +80,7 @@ class Default_Registry extends Registry {
 				$arguments = [];
 
 				if ( ! empty( $params['classes'] ) ) {
-					$arguments += array_map( function( $index ) use ( $css_classes ) {
+					$arguments += \array_map( function( $index ) use ( $css_classes ) {
 						return $css_classes[ $index ];
 					}, $params['classes'] );
 				}

--- a/src/fixes/node-fixes/class-dash-spacing-fix.php
+++ b/src/fixes/node-fixes/class-dash-spacing-fix.php
@@ -120,9 +120,9 @@ class Dash_Spacing_Fix extends Abstract_Node_Fix {
 		// Cache $textnode->data for this fix.
 		$node_data = $textnode->data;
 
-		$node_data = preg_replace( self::EM_DASH_SPACING,             $this->em_dash_replacement,            $node_data );
-		$node_data = preg_replace( $this->parenthetical_dash_spacing, $this->parenthetical_dash_replacement, $node_data );
-		$node_data = preg_replace( $this->interval_dash_spacing,      $this->interval_dash_replacement,      $node_data );
+		$node_data = \preg_replace( self::EM_DASH_SPACING,             $this->em_dash_replacement,            $node_data );
+		$node_data = \preg_replace( $this->parenthetical_dash_spacing, $this->parenthetical_dash_replacement, $node_data );
+		$node_data = \preg_replace( $this->interval_dash_spacing,      $this->interval_dash_replacement,      $node_data );
 
 		// Restore textnode content.
 		$textnode->data = $node_data;

--- a/src/fixes/node-fixes/class-dewidow-fix.php
+++ b/src/fixes/node-fixes/class-dewidow-fix.php
@@ -115,7 +115,7 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 		}
 
 		// Do what we have to do.
-		return preg_replace_callback( self::REGEX_START . ( $word_number - 1 ) . self::REGEX_END, function( array $widow ) use ( $func, $max_pull, $max_length, $word_number, $narrow_space ) {
+		return \preg_replace_callback( self::REGEX_START . ( $word_number - 1 ) . self::REGEX_END, function( array $widow ) use ( $func, $max_pull, $max_length, $word_number, $narrow_space ) {
 
 			// If we are here, we know that widows are being protected in some fashion
 			// with that, we will assert that widows should never be hyphenated or wrapped
@@ -149,7 +149,7 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 	 * @return string
 	 */
 	protected static function strip_breaking_characters( $string ) {
-		return str_replace( [ U::ZERO_WIDTH_SPACE, U::SOFT_HYPHEN ], '', $string );
+		return \str_replace( [ U::ZERO_WIDTH_SPACE, U::SOFT_HYPHEN ], '', $string );
 	}
 
 	/**
@@ -175,7 +175,7 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 	 * @return string
 	 */
 	protected static function make_space_nonbreaking( $string, $narrow_space, $u ) {
-		return preg_replace(
+		return \preg_replace(
 			[
 				'/\s*' . U::THIN_SPACE . '\s*/u',
 				'/\s*' . U::NO_BREAK_NARROW_SPACE . '\s*/u',

--- a/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
+++ b/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
@@ -73,12 +73,12 @@ class French_Punctuation_Spacing_Fix extends Abstract_Node_Fix {
 		$node_data          = "{$previous_character}{$textnode->data}"; // $next_character is not included on purpose.
 		$f                  = Strings::functions( "{$node_data}{$next_character}" ); // Include $next_character for determining encodiing.
 
-		$node_data = preg_replace( self::INSERT_SPACE_BEFORE_CLOSING_QUOTE, '$1' . $no_break_narrow_space . '$3$4', $node_data );
-		$node_data = preg_replace( self::INSERT_NARROW_SPACE,               '$1' . $no_break_narrow_space . '$3$4', $node_data );
-		$node_data = preg_replace( self::INSERT_FULL_SPACE,                 '$1' . U::NO_BREAK_SPACE . '$3$4',      $node_data );
+		$node_data = \preg_replace( self::INSERT_SPACE_BEFORE_CLOSING_QUOTE, '$1' . $no_break_narrow_space . '$3$4', $node_data );
+		$node_data = \preg_replace( self::INSERT_NARROW_SPACE,               '$1' . $no_break_narrow_space . '$3$4', $node_data );
+		$node_data = \preg_replace( self::INSERT_FULL_SPACE,                 '$1' . U::NO_BREAK_SPACE . '$3$4',      $node_data );
 
 		// The next rule depends on the following characters as well.
-		$node_data = preg_replace( self::INSERT_SPACE_AFTER_OPENING_QUOTE,  '$1$2' . $no_break_narrow_space . '$4', "{$node_data}{$next_character}" );
+		$node_data = \preg_replace( self::INSERT_SPACE_AFTER_OPENING_QUOTE,  '$1$2' . $no_break_narrow_space . '$4', "{$node_data}{$next_character}" );
 
 		// If we have adjacent characters remove them from the text.
 		$textnode->data = self::remove_adjacent_characters( $node_data, $f['strlen'], $f['substr'], $f['strlen']( $previous_character ), $f['strlen']( $next_character ) );

--- a/src/fixes/node-fixes/class-simple-regex-replacement-fix.php
+++ b/src/fixes/node-fixes/class-simple-regex-replacement-fix.php
@@ -89,6 +89,6 @@ abstract class Simple_Regex_Replacement_Fix extends Abstract_Node_Fix {
 			return;
 		}
 
-		$textnode->data = preg_replace( $this->regex, $this->replacement, $textnode->data );
+		$textnode->data = \preg_replace( $this->regex, $this->replacement, $textnode->data );
 	}
 }

--- a/src/fixes/node-fixes/class-simple-style-fix.php
+++ b/src/fixes/node-fixes/class-simple-style-fix.php
@@ -91,6 +91,6 @@ abstract class Simple_Style_Fix extends Classes_Dependent_Fix {
 			return;
 		}
 
-		$textnode->data = preg_replace( $this->regex, '<span class="' . $this->css_class . '">$1</span>', $textnode->data );
+		$textnode->data = \preg_replace( $this->regex, '<span class="' . $this->css_class . '">$1</span>', $textnode->data );
 	}
 }

--- a/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
+++ b/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
@@ -70,7 +70,7 @@ class Single_Character_Word_Spacing_Fix extends Abstract_Node_Fix {
 		$f                  = Strings::functions( $node_data );
 
 		// Replace spaces.
-		$node_data = preg_replace( self::REGEX . $f['u'], '$1$2' . U::NO_BREAK_SPACE, $node_data );
+		$node_data = \preg_replace( self::REGEX . $f['u'], '$1$2' . U::NO_BREAK_SPACE, $node_data );
 
 		// If we have adjacent characters remove them from the text.
 		$textnode->data = self::remove_adjacent_characters( $node_data, $f['strlen'], $f['substr'], $f['strlen']( $previous_character ), $f['strlen']( $next_character ) );

--- a/src/fixes/node-fixes/class-smart-dashes-fix.php
+++ b/src/fixes/node-fixes/class-smart-dashes-fix.php
@@ -130,23 +130,23 @@ class Smart_Dashes_Fix extends Abstract_Node_Fix {
 		// Cache textnode content.
 		$node_data = $textnode->data;
 
-		$node_data = str_replace( '---', U::EM_DASH, $node_data );
-		$node_data = preg_replace( self::PARENTHETICAL_DOUBLE_DASH, "\$1{$s->parenthetical_dash()}\$2", $node_data );
-		$node_data = str_replace( '--', U::EN_DASH, $node_data );
-		$node_data = preg_replace( self::PARENTHETICAL_SINGLE_DASH, "\$1{$s->parenthetical_dash()}\$2", $node_data );
+		$node_data = \str_replace( '---', U::EM_DASH, $node_data );
+		$node_data = \preg_replace( self::PARENTHETICAL_DOUBLE_DASH, "\$1{$s->parenthetical_dash()}\$2", $node_data );
+		$node_data = \str_replace( '--', U::EN_DASH, $node_data );
+		$node_data = \preg_replace( self::PARENTHETICAL_SINGLE_DASH, "\$1{$s->parenthetical_dash()}\$2", $node_data );
 
-		$node_data = preg_replace( self::EN_DASH_WORDS ,        '$1' . U::EN_DASH . '$2',         $node_data );
-		$node_data = preg_replace( self::EN_DASH_NUMBERS,       "\$1{$s->interval_dash()}\$3",    $node_data );
-		$node_data = preg_replace( self::EN_DASH_PHONE_NUMBERS, '$1' . U::NO_BREAK_HYPHEN . '$2', $node_data ); // phone numbers.
-		$node_data = str_replace( 'xn' . U::EN_DASH,            'xn--',                           $node_data ); // revert messed-up punycode.
+		$node_data = \preg_replace( self::EN_DASH_WORDS ,        '$1' . U::EN_DASH . '$2',         $node_data );
+		$node_data = \preg_replace( self::EN_DASH_NUMBERS,       "\$1{$s->interval_dash()}\$3",    $node_data );
+		$node_data = \preg_replace( self::EN_DASH_PHONE_NUMBERS, '$1' . U::NO_BREAK_HYPHEN . '$2', $node_data ); // phone numbers.
+		$node_data = \str_replace( 'xn' . U::EN_DASH,            'xn--',                           $node_data ); // revert messed-up punycode.
 
 		// Revert dates back to original formats
 		// YYYY-MM-DD.
-		$node_data = preg_replace( self::DATE_YYYY_MM_DD, '$1-$2-$3',     $node_data );
+		$node_data = \preg_replace( self::DATE_YYYY_MM_DD, '$1-$2-$3',     $node_data );
 		// MM-DD-YYYY or DD-MM-YYYY.
-		$node_data = preg_replace( self::DATE_MM_DD_YYYY, '$1$3-$2$4-$5', $node_data );
+		$node_data = \preg_replace( self::DATE_MM_DD_YYYY, '$1$3-$2$4-$5', $node_data );
 		// YYYY-MM or YYYY-DDDD next.
-		$node_data = preg_replace( self::DATE_YYYY_MM,    '$1-$2',        $node_data );
+		$node_data = \preg_replace( self::DATE_YYYY_MM,    '$1-$2',        $node_data );
 
 		// Restore textnode content.
 		$textnode->data = $node_data;

--- a/src/fixes/node-fixes/class-smart-diacritics-fix.php
+++ b/src/fixes/node-fixes/class-smart-diacritics-fix.php
@@ -58,7 +58,7 @@ class Smart_Diacritics_Fix extends Abstract_Node_Fix {
 
 			// Uses "word" => "replacement" pairs from an array to make fast preg_* replacements.
 			$replacements   = $settings['diacriticReplacement']['replacements'];
-			$textnode->data = preg_replace_callback( $settings['diacriticReplacement']['patterns'], function( $match ) use ( $replacements ) {
+			$textnode->data = \preg_replace_callback( $settings['diacriticReplacement']['patterns'], function( $match ) use ( $replacements ) {
 				if ( isset( $replacements[ $match[0] ] ) ) {
 					return $replacements[ $match[0] ];
 				} else {

--- a/src/fixes/node-fixes/class-smart-ellipses-fix.php
+++ b/src/fixes/node-fixes/class-smart-ellipses-fix.php
@@ -54,8 +54,8 @@ class Smart_Ellipses_Fix extends Abstract_Node_Fix {
 		// Cache textnode content.
 		$node_data = $textnode->data;
 
-		$node_data = str_replace( [ '....', '. . . .' ], '.' . U::ELLIPSIS, $node_data );
-		$node_data = str_replace( [ '...', '. . .' ],          U::ELLIPSIS, $node_data );
+		$node_data = \str_replace( [ '....', '. . . .' ], '.' . U::ELLIPSIS, $node_data );
+		$node_data = \str_replace( [ '...', '. . .' ],          U::ELLIPSIS, $node_data );
 
 		// Restore textnode content.
 		$textnode->data = $node_data;

--- a/src/fixes/node-fixes/class-smart-fractions-fix.php
+++ b/src/fixes/node-fixes/class-smart-fractions-fix.php
@@ -147,21 +147,21 @@ class Smart_Fractions_Fix extends Abstract_Node_Fix {
 		$node_data = $textnode->data;
 
 		if ( ! empty( $settings['fractionSpacing'] ) && ! empty( $settings['smartFractions'] ) ) {
-			$node_data = preg_replace( self::SPACING, '$1' . $settings->no_break_narrow_space() . '$2', $node_data );
+			$node_data = \preg_replace( self::SPACING, '$1' . $settings->no_break_narrow_space() . '$2', $node_data );
 		} elseif ( ! empty( $settings['fractionSpacing'] ) && empty( $settings['smartFractions'] ) ) {
-			$node_data = preg_replace( self::SPACING, '$1' . U::NO_BREAK_SPACE . '$2', $node_data );
+			$node_data = \preg_replace( self::SPACING, '$1' . U::NO_BREAK_SPACE . '$2', $node_data );
 		}
 
 		if ( ! empty( $settings['smartFractions'] ) ) {
 			// Escape sequences we don't want fractionified.
-			$node_data = preg_replace( $this->escape_consecutive_years, '$1' . RE::ESCAPE_MARKER . '$2$3$4', $node_data );
-			$node_data = preg_replace( self::ESCAPE_DATE_MM_YYYY,       '$1' . RE::ESCAPE_MARKER . '$2$3$4', $node_data );
+			$node_data = \preg_replace( $this->escape_consecutive_years, '$1' . RE::ESCAPE_MARKER . '$2$3$4', $node_data );
+			$node_data = \preg_replace( self::ESCAPE_DATE_MM_YYYY,       '$1' . RE::ESCAPE_MARKER . '$2$3$4', $node_data );
 
 			// Replace fractions.
-			$node_data = preg_replace( self::FRACTION_MATCHING, $this->replacement, $node_data );
+			$node_data = \preg_replace( self::FRACTION_MATCHING, $this->replacement, $node_data );
 
 			// Unescape escaped sequences.
-			$node_data = str_replace( RE::ESCAPE_MARKER, '', $node_data );
+			$node_data = \str_replace( RE::ESCAPE_MARKER, '', $node_data );
 		}
 
 		// Restore textnode content.

--- a/src/fixes/node-fixes/class-smart-marks-fix.php
+++ b/src/fixes/node-fixes/class-smart-marks-fix.php
@@ -58,16 +58,16 @@ class Smart_Marks_Fix extends Abstract_Node_Fix {
 		$node_data = $textnode->data;
 
 		// Escape usage of "501(c)(1...29)" (US non-profit).
-		$node_data = preg_replace( self::ESCAPE_501C, '$1' . RE::ESCAPE_MARKER . '$2' . RE::ESCAPE_MARKER . '$3', $node_data );
+		$node_data = \preg_replace( self::ESCAPE_501C, '$1' . RE::ESCAPE_MARKER . '$2' . RE::ESCAPE_MARKER . '$3', $node_data );
 
 		// Replace marks.
-		$node_data = str_replace( [ '(c)', '(C)' ],   U::COPYRIGHT,       $node_data );
-		$node_data = str_replace( [ '(r)', '(R)' ],   U::REGISTERED_MARK, $node_data );
-		$node_data = str_replace( [ '(p)', '(P)' ],   U::SOUND_COPY_MARK, $node_data );
-		$node_data = str_replace( [ '(sm)', '(SM)' ], U::SERVICE_MARK,    $node_data );
-		$node_data = str_replace( [ '(tm)', '(TM)' ], U::TRADE_MARK,      $node_data );
+		$node_data = \str_replace( [ '(c)', '(C)' ],   U::COPYRIGHT,       $node_data );
+		$node_data = \str_replace( [ '(r)', '(R)' ],   U::REGISTERED_MARK, $node_data );
+		$node_data = \str_replace( [ '(p)', '(P)' ],   U::SOUND_COPY_MARK, $node_data );
+		$node_data = \str_replace( [ '(sm)', '(SM)' ], U::SERVICE_MARK,    $node_data );
+		$node_data = \str_replace( [ '(tm)', '(TM)' ], U::TRADE_MARK,      $node_data );
 
 		// Un-escape escaped sequences & resetore textnode content.
-		$textnode->data = str_replace( RE::ESCAPE_MARKER, '', $node_data );
+		$textnode->data = \str_replace( RE::ESCAPE_MARKER, '', $node_data );
 	}
 }

--- a/src/fixes/node-fixes/class-smart-marks-fix.php
+++ b/src/fixes/node-fixes/class-smart-marks-fix.php
@@ -42,6 +42,49 @@ class Smart_Marks_Fix extends Abstract_Node_Fix {
 
 	const ESCAPE_501C = '/\b(501\()(c)(\)\((?:[1-9]|[1-2][0-9])\))/S';
 
+	const MARKS = [
+		'(c)'  => U::COPYRIGHT,
+		'(C)'  => U::COPYRIGHT,
+		'(r)'  => U::REGISTERED_MARK,
+		'(R)'  => U::REGISTERED_MARK,
+		'(p)'  => U::SOUND_COPY_MARK,
+		'(P)'  => U::SOUND_COPY_MARK,
+		'(sm)' => U::SERVICE_MARK,
+		'(SM)' => U::SERVICE_MARK,
+		'(tm)' => U::TRADE_MARK,
+		'(TM)' => U::TRADE_MARK,
+	];
+
+	/**
+	 * An array of marks to match.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var array
+	 */
+	private $marks;
+
+	/**
+	 * An array of replacement marks.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @var array
+	 */
+	private $replacements;
+
+	/**
+	 * Creates a new fix instance.
+	 *
+	 * @param bool $feed_compatible Optional. Default false.
+	 */
+	public function __construct( $feed_compatible = false ) {
+		parent::__construct( $feed_compatible );
+
+		$this->marks        = \array_keys( self::MARKS );
+		$this->replacements = \array_values( self::MARKS );
+	}
+
 	/**
 	 * Apply the fix to a given textnode.
 	 *
@@ -61,11 +104,7 @@ class Smart_Marks_Fix extends Abstract_Node_Fix {
 		$node_data = \preg_replace( self::ESCAPE_501C, '$1' . RE::ESCAPE_MARKER . '$2' . RE::ESCAPE_MARKER . '$3', $node_data );
 
 		// Replace marks.
-		$node_data = \str_replace( [ '(c)', '(C)' ],   U::COPYRIGHT,       $node_data );
-		$node_data = \str_replace( [ '(r)', '(R)' ],   U::REGISTERED_MARK, $node_data );
-		$node_data = \str_replace( [ '(p)', '(P)' ],   U::SOUND_COPY_MARK, $node_data );
-		$node_data = \str_replace( [ '(sm)', '(SM)' ], U::SERVICE_MARK,    $node_data );
-		$node_data = \str_replace( [ '(tm)', '(TM)' ], U::TRADE_MARK,      $node_data );
+		$node_data = \str_replace( $this->marks, $this->replacements, $node_data );
 
 		// Un-escape escaped sequences & resetore textnode content.
 		$textnode->data = \str_replace( RE::ESCAPE_MARKER, '', $node_data );

--- a/src/fixes/node-fixes/class-smart-maths-fix.php
+++ b/src/fixes/node-fixes/class-smart-maths-fix.php
@@ -180,6 +180,31 @@ class Smart_Maths_Fix extends Abstract_Node_Fix {
 			)
 		/Sxu';
 
+	const REVERT_MATCHES = [
+		// Revert 4-4 to plain minus-hyphen so as to not mess with ranges of numbers (i.e. pp. 46-50).
+		self::REVERT_RANGE,
+		// Revert fractions to basic slash.
+		// We'll leave styling fractions to smart_fractions.
+		self::REVERT_FRACTION,
+		// Revert date back to original formats.
+		// YYYY-MM-DD.
+		self::REVERT_DATE_YYYY_MM_DD,
+		// MM-DD-YYYY or DD-MM-YYYY.
+		self::REVERT_DATE_MM_DD_YYYY,
+		// YYYY-MM or YYYY-DDD next.
+		self::REVERT_DATE_YYYY_MM,
+		self::REVERT_DATE_MM_DD_YYYY_SLASHED,
+	];
+
+	const REVERT_REPLACEMENTS = [
+		'$1-$2',
+		'$1/$2',
+		'$1-$2-$3',
+		'$1$3-$2$4-$5',
+		'$1-$2',
+		'$1$3/$2$4/$5',
+	];
+
 	/**
 	 * Apply the fix to a given textnode.
 	 *
@@ -213,24 +238,7 @@ class Smart_Maths_Fix extends Abstract_Node_Fix {
 			);
 		}, $node_data );
 
-		// Revert 4-4 to plain minus-hyphen so as to not mess with ranges of numbers (i.e. pp. 46-50).
-		$node_data = \preg_replace( self::REVERT_RANGE, '$1-$2', $node_data );
-
-		// Revert fractions to basic slash.
-		// We'll leave styling fractions to smart_fractions.
-		$node_data = \preg_replace( self::REVERT_FRACTION, '$1/$2', $node_data );
-
-		// Revert date back to original formats.
-		// YYYY-MM-DD.
-		$node_data = \preg_replace( self::REVERT_DATE_YYYY_MM_DD,         '$1-$2-$3',     $node_data );
-		// MM-DD-YYYY or DD-MM-YYYY.
-		$node_data = \preg_replace( self::REVERT_DATE_MM_DD_YYYY,         '$1$3-$2$4-$5', $node_data );
-		// YYYY-MM or YYYY-DDD next.
-		$node_data = \preg_replace( self::REVERT_DATE_YYYY_MM,            '$1-$2',        $node_data );
-		// MM/DD/YYYY or DD/MM/YYYY.
-		$node_data = \preg_replace( self::REVERT_DATE_MM_DD_YYYY_SLASHED, '$1$3/$2$4/$5', $node_data );
-
-		// Restore textnode content.
-		$textnode->data = $node_data;
+		// Revert some non-desired changes and restore textnode content.
+		$textnode->data = \preg_replace( self::REVERT_MATCHES, self::REVERT_REPLACEMENTS, $node_data );
 	}
 }

--- a/src/fixes/node-fixes/class-smart-maths-fix.php
+++ b/src/fixes/node-fixes/class-smart-maths-fix.php
@@ -196,8 +196,8 @@ class Smart_Maths_Fix extends Abstract_Node_Fix {
 		$node_data = $textnode->data;
 
 		// First, let's find math equations.
-		$node_data = preg_replace_callback( self::MATH_EQUATION, function( array $matches ) {
-			return str_replace(
+		$node_data = \preg_replace_callback( self::MATH_EQUATION, function( array $matches ) {
+			return \str_replace(
 				[
 					'-',
 					'/',
@@ -214,21 +214,21 @@ class Smart_Maths_Fix extends Abstract_Node_Fix {
 		}, $node_data );
 
 		// Revert 4-4 to plain minus-hyphen so as to not mess with ranges of numbers (i.e. pp. 46-50).
-		$node_data = preg_replace( self::REVERT_RANGE, '$1-$2', $node_data );
+		$node_data = \preg_replace( self::REVERT_RANGE, '$1-$2', $node_data );
 
 		// Revert fractions to basic slash.
 		// We'll leave styling fractions to smart_fractions.
-		$node_data = preg_replace( self::REVERT_FRACTION, '$1/$2', $node_data );
+		$node_data = \preg_replace( self::REVERT_FRACTION, '$1/$2', $node_data );
 
 		// Revert date back to original formats.
 		// YYYY-MM-DD.
-		$node_data = preg_replace( self::REVERT_DATE_YYYY_MM_DD,         '$1-$2-$3',     $node_data );
+		$node_data = \preg_replace( self::REVERT_DATE_YYYY_MM_DD,         '$1-$2-$3',     $node_data );
 		// MM-DD-YYYY or DD-MM-YYYY.
-		$node_data = preg_replace( self::REVERT_DATE_MM_DD_YYYY,         '$1$3-$2$4-$5', $node_data );
+		$node_data = \preg_replace( self::REVERT_DATE_MM_DD_YYYY,         '$1$3-$2$4-$5', $node_data );
 		// YYYY-MM or YYYY-DDD next.
-		$node_data = preg_replace( self::REVERT_DATE_YYYY_MM,            '$1-$2',        $node_data );
+		$node_data = \preg_replace( self::REVERT_DATE_YYYY_MM,            '$1-$2',        $node_data );
 		// MM/DD/YYYY or DD/MM/YYYY.
-		$node_data = preg_replace( self::REVERT_DATE_MM_DD_YYYY_SLASHED, '$1$3/$2$4/$5', $node_data );
+		$node_data = \preg_replace( self::REVERT_DATE_MM_DD_YYYY_SLASHED, '$1$3/$2$4/$5', $node_data );
 
 		// Restore textnode content.
 		$textnode->data = $node_data;

--- a/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
+++ b/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
@@ -73,6 +73,6 @@ class Smart_Ordinal_Suffix_Fix extends Abstract_Node_Fix {
 			return;
 		}
 
-		$textnode->data = preg_replace( "/\b(\d+)(st|nd|rd|th)\b/", $this->replacement, $textnode->data );
+		$textnode->data = \preg_replace( "/\b(\d+)(st|nd|rd|th)\b/", $this->replacement, $textnode->data );
 	}
 }

--- a/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
+++ b/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
@@ -73,6 +73,6 @@ class Smart_Ordinal_Suffix_Fix extends Abstract_Node_Fix {
 			return;
 		}
 
-		$textnode->data = \preg_replace( "/\b(\d+)(st|nd|rd|th)\b/", $this->replacement, $textnode->data );
+		$textnode->data = \preg_replace( "/\b(\d+)(st|nd|rd|th)\b/S", $this->replacement, $textnode->data );
 	}
 }

--- a/src/fixes/node-fixes/class-smart-quotes-fix.php
+++ b/src/fixes/node-fixes/class-smart-quotes-fix.php
@@ -57,14 +57,9 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 
 	const NUMBERS_BEFORE_PRIME = '\b(?:\d+\/)?\d{1,3}';
 
-	const DOUBLE_PRIME                  = '/(' . self::NUMBERS_BEFORE_PRIME . ")''(?=\W|\Z)/";
-	const DOUBLE_PRIME_COMPOUND         = '/(' . self::NUMBERS_BEFORE_PRIME . ")''(?=-\w)/";
-	const DOUBLE_PRIME_1_GLYPH          = '/(' . self::NUMBERS_BEFORE_PRIME . ')"(?=\W|\Z)/';
-	const DOUBLE_PRIME_1_GLYPH_COMPOUND = '/(' . self::NUMBERS_BEFORE_PRIME . ')"(?=-\w)/';
-	const SINGLE_PRIME                  = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(?=\W|\Z)/";
-	const SINGLE_PRIME_COMPOUND         = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(?=-\w)/";
-	const SINGLE_DOUBLE_PRIME           = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(\s*)(\b(?:\d+\/)?\d+)''(?=\W|\Z)/";
-	const SINGLE_DOUBLE_PRIME_1_GLYPH   = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(\s*)(\b(?:\d+\/)?\d+)\"(?=\W|\Z)/";
+	const DOUBLE_PRIME        = '/(' . self::NUMBERS_BEFORE_PRIME . ")(?:''|\")(?=\W|\Z|-\w)/";
+	const SINGLE_PRIME        = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(?=\W|\Z|-\w)/";
+	const SINGLE_DOUBLE_PRIME = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(\s*)(\b(?:\d+\/)?\d+)(?:''|\")(?=\W|\Z)/";
 
 	const SINGLE_QUOTED_NUMBERS      = "/(?<=\W|\A)'([^\"]*\d+)'(?=\W|\Z)/";
 	const DOUBLE_QUOTED_NUMBERS      = '/(?<=\W|\A)"([^"]*\d+)"(?=\W|\Z)/';
@@ -178,15 +173,9 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 		$node_data = \str_replace( [ '<<', '>>' ], [ U::GUILLEMET_OPEN, U::GUILLEMET_CLOSE ],  $node_data );
 
 		// Primes.
-		$node_data = \preg_replace( self::SINGLE_DOUBLE_PRIME . $f['u'],           '$1' . U::SINGLE_PRIME . '$2$3' . U::DOUBLE_PRIME, $node_data );
-		$node_data = \preg_replace( self::SINGLE_DOUBLE_PRIME_1_GLYPH . $f['u'],   '$1' . U::SINGLE_PRIME . '$2$3' . U::DOUBLE_PRIME, $node_data );
-		$node_data = \preg_replace( self::DOUBLE_PRIME . $f['u'],                  '$1' . U::DOUBLE_PRIME,                            $node_data ); // should not interfere with regular quote matching.
-		$node_data = \preg_replace( self::SINGLE_PRIME . $f['u'],                  '$1' . U::SINGLE_PRIME,                            $node_data );
-		$node_data = \preg_replace( self::SINGLE_PRIME_COMPOUND . $f['u'],         '$1' . U::SINGLE_PRIME,                            $node_data );
-		$node_data = \preg_replace( self::DOUBLE_PRIME_COMPOUND . $f['u'],         '$1' . U::DOUBLE_PRIME,                            $node_data );
-		$node_data = \preg_replace( self::DOUBLE_PRIME_1_GLYPH . $f['u'],          '$1' . U::DOUBLE_PRIME,                            $node_data ); // should not interfere with regular quote matching.
-		$node_data = \preg_replace( self::DOUBLE_PRIME_1_GLYPH_COMPOUND . $f['u'], '$1' . U::DOUBLE_PRIME,                            $node_data );
-		//$node_data = \preg_replace( self::DOUBLE_PRIME_1_GLYPH_COMPOUND . $f['u'], '$1' . U::DOUBLE_PRIME,                            $node_data );
+		$node_data = \preg_replace( self::SINGLE_DOUBLE_PRIME . $f['u'], '$1' . U::SINGLE_PRIME . '$2$3' . U::DOUBLE_PRIME, $node_data );
+		$node_data = \preg_replace( self::DOUBLE_PRIME . $f['u'],        '$1' . U::DOUBLE_PRIME,                            $node_data ); // should not interfere with regular quote matching.
+		$node_data = \preg_replace( self::SINGLE_PRIME . $f['u'],        '$1' . U::SINGLE_PRIME,                            $node_data );
 
 		// Backticks & comma quotes.
 		$node_data = \str_replace(

--- a/src/fixes/node-fixes/class-smart-quotes-fix.php
+++ b/src/fixes/node-fixes/class-smart-quotes-fix.php
@@ -57,19 +57,19 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 
 	const NUMBERS_BEFORE_PRIME = '\b(?:\d+\/)?\d{1,3}';
 
-	const DOUBLE_PRIME        = '/(' . self::NUMBERS_BEFORE_PRIME . ")(?:''|\")(?=\W|\Z|-\w)/";
-	const SINGLE_PRIME        = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(?=\W|\Z|-\w)/";
-	const SINGLE_DOUBLE_PRIME = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(\s*)(\b(?:\d+\/)?\d+)(?:''|\")(?=\W|\Z)/";
+	const DOUBLE_PRIME        = '/(' . self::NUMBERS_BEFORE_PRIME . ")(?:''|\")(?=\W|\Z|-\w)/S";
+	const SINGLE_PRIME        = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(?=\W|\Z|-\w)/S";
+	const SINGLE_DOUBLE_PRIME = '/(' . self::NUMBERS_BEFORE_PRIME . ")'(\s*)(\b(?:\d+\/)?\d+)(?:''|\")(?=\W|\Z)/S";
 
-	const SINGLE_QUOTED_NUMBERS = "/(?<=\W|\A)'([^\"]*\d+)'(?=\W|\Z)/";
-	const DOUBLE_QUOTED_NUMBERS = '/(?<=\W|\A)"([^"]*\d+)"(?=\W|\Z)/';
-	const COMMA_QUOTE           = '/(?<=\s|\A),(?=\S)/';
-	const APOSTROPHE_WORDS      = "/(?<=\w)'(?=\w)/";
-	const APOSTROPHE_DECADES    = "/'(\d\d\b)/";
-	const SINGLE_QUOTE_OPEN     = "/(?: '(?=\w) )  | (?: (?<=\s|\A)'(?=\S) )/x"; // Alternative is for expressions like _'¿hola?'_.
-	const SINGLE_QUOTE_CLOSE    = "/(?: (?<=\w)' ) | (?: (?<=\S)'(?=\s|\Z) )/x";
-	const DOUBLE_QUOTE_OPEN     = '/(?: "(?=\w) )  | (?: (?<=\s|\A)"(?=\S) )/x';
-	const DOUBLE_QUOTE_CLOSE    = '/(?: (?<=\w)" ) | (?: (?<=\S)"(?=\s|\Z) )/x';
+	const SINGLE_QUOTED_NUMBERS = "/(?<=\W|\A)'([^\"]*\d+)'(?=\W|\Z)/S";
+	const DOUBLE_QUOTED_NUMBERS = '/(?<=\W|\A)"([^"]*\d+)"(?=\W|\Z)/S';
+	const COMMA_QUOTE           = '/(?<=\s|\A),(?=\S)/S';
+	const APOSTROPHE_WORDS      = "/(?<=\w)'(?=\w)/S";
+	const APOSTROPHE_DECADES    = "/'(\d\d\b)/S";
+	const SINGLE_QUOTE_OPEN     = "/(?: '(?=\w) )  | (?: (?<=\s|\A)'(?=\S) )/Sx"; // Alternative is for expressions like _'¿hola?'_.
+	const SINGLE_QUOTE_CLOSE    = "/(?: (?<=\w)' ) | (?: (?<=\S)'(?=\s|\Z) )/Sx";
+	const DOUBLE_QUOTE_OPEN     = '/(?: "(?=\w) )  | (?: (?<=\s|\A)"(?=\S) )/Sx';
+	const DOUBLE_QUOTE_CLOSE    = '/(?: (?<=\w)" ) | (?: (?<=\S)"(?=\s|\Z) )/Sx';
 
 
 	/**

--- a/src/fixes/node-fixes/class-smart-quotes-fix.php
+++ b/src/fixes/node-fixes/class-smart-quotes-fix.php
@@ -175,8 +175,7 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 		$node_data = \preg_replace( self::DOUBLE_QUOTED_NUMBERS . $f['u'], "{$double_open}\$1{$double_close}", $node_data );
 
 		// Guillemets.
-		$node_data = \str_replace( '<<', U::GUILLEMET_OPEN,  $node_data );
-		$node_data = \str_replace( '>>', U::GUILLEMET_CLOSE, $node_data );
+		$node_data = \str_replace( [ '<<', '>>' ], [ U::GUILLEMET_OPEN, U::GUILLEMET_CLOSE ],  $node_data );
 
 		// Primes.
 		$node_data = \preg_replace( self::SINGLE_DOUBLE_PRIME . $f['u'],           '$1' . U::SINGLE_PRIME . '$2$3' . U::DOUBLE_PRIME, $node_data );
@@ -187,35 +186,50 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 		$node_data = \preg_replace( self::DOUBLE_PRIME_COMPOUND . $f['u'],         '$1' . U::DOUBLE_PRIME,                            $node_data );
 		$node_data = \preg_replace( self::DOUBLE_PRIME_1_GLYPH . $f['u'],          '$1' . U::DOUBLE_PRIME,                            $node_data ); // should not interfere with regular quote matching.
 		$node_data = \preg_replace( self::DOUBLE_PRIME_1_GLYPH_COMPOUND . $f['u'], '$1' . U::DOUBLE_PRIME,                            $node_data );
+		//$node_data = \preg_replace( self::DOUBLE_PRIME_1_GLYPH_COMPOUND . $f['u'], '$1' . U::DOUBLE_PRIME,                            $node_data );
 
-		// Backticks.
-		$node_data = \str_replace( '``', $double_open,  $node_data );
-		$node_data = \str_replace( '`',  $single_open,  $node_data );
-		$node_data = \str_replace( "''", $double_close, $node_data );
-
-		// Comma quotes.
-		$node_data = \str_replace( ',,', U::DOUBLE_LOW_9_QUOTE, $node_data );
+		// Backticks & comma quotes.
+		$node_data = \str_replace(
+			[ '``', '`', "''", ',,' ],
+			[ $double_open, $single_open, $double_close, U::DOUBLE_LOW_9_QUOTE ],
+			$node_data
+		);
 		$node_data = \preg_replace( self::COMMA_QUOTE . $f['u'], U::SINGLE_LOW_9_QUOTE, $node_data ); // like _,¿hola?'_.
 
 		// Apostrophes.
-		$node_data = \preg_replace( self::APOSTROPHE_WORDS . $f['u'],   U::APOSTROPHE,        $node_data );
-		$node_data = \preg_replace( self::APOSTROPHE_DECADES . $f['u'], U::APOSTROPHE . '$1', $node_data ); // decades: '98.
+		$node_data = \preg_replace(
+			[ self::APOSTROPHE_WORDS . $f['u'], self::APOSTROPHE_DECADES . $f['u'] ],
+			[ U::APOSTROPHE, U::APOSTROPHE . '$1' ],
+			$node_data
+		);
 		$node_data = \str_replace( $this->apostrophe_exception_matches, $this->apostrophe_exception_replacements, $node_data );
 
 		// Quotes.
 		$node_data = \str_replace( $this->brackets_matches, $this->brackets_replacements, $node_data );
-		$node_data = \preg_replace( self::SINGLE_QUOTE_OPEN . $f['u'],          $single_open,  $node_data );
-		$node_data = \preg_replace( self::SINGLE_QUOTE_CLOSE . $f['u'],         $single_close, $node_data );
-		$node_data = \preg_replace( self::SINGLE_QUOTE_OPEN_SPECIAL . $f['u'],  $single_open,  $node_data ); // like _'¿hola?'_.
-		$node_data = \preg_replace( self::SINGLE_QUOTE_CLOSE_SPECIAL . $f['u'], $single_close, $node_data );
-		$node_data = \preg_replace( self::DOUBLE_QUOTE_OPEN . $f['u'],          $double_open,  $node_data );
-		$node_data = \preg_replace( self::DOUBLE_QUOTE_CLOSE . $f['u'],         $double_close, $node_data );
-		$node_data = \preg_replace( self::DOUBLE_QUOTE_OPEN_SPECIAL . $f['u'],  $double_open,  $node_data );
-		$node_data = \preg_replace( self::DOUBLE_QUOTE_CLOSE_SPECIAL . $f['u'], $double_close, $node_data );
+		$node_data = \preg_replace(
+			[
+				self::SINGLE_QUOTE_OPEN . $f['u'],
+				self::SINGLE_QUOTE_CLOSE . $f['u'],
+				self::SINGLE_QUOTE_OPEN_SPECIAL . $f['u'], // like _'¿hola?'_.
+				self::SINGLE_QUOTE_CLOSE_SPECIAL . $f['u'],
+				self::DOUBLE_QUOTE_OPEN . $f['u'],
+				self::DOUBLE_QUOTE_CLOSE . $f['u'],
+				self::DOUBLE_QUOTE_OPEN_SPECIAL . $f['u'],
+				self::DOUBLE_QUOTE_CLOSE_SPECIAL . $f['u'],
+			], [
+				$single_open,
+				$single_close,
+				$single_open,
+				$single_close,
+				$double_open,
+				$double_close,
+				$double_open,
+				$double_close,
+			], $node_data
+		);
 
 		// Quote catch-alls - assume left over quotes are closing - as this is often the most complicated position, thus most likely to be missed.
-		$node_data = \str_replace( "'", $single_close, $node_data );
-		$node_data = \str_replace( '"', $double_close, $node_data );
+		$node_data = \str_replace( [ "'", '"' ], [ $single_close, $double_close ], $node_data );
 
 		// Check if adjacent characters where replaced with multi-byte replacements.
 		$quotes          = [ $double_open, $double_close, $single_open, $single_close ];

--- a/src/fixes/node-fixes/class-smart-quotes-fix.php
+++ b/src/fixes/node-fixes/class-smart-quotes-fix.php
@@ -175,10 +175,8 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 		$node_data = \preg_replace( self::DOUBLE_QUOTED_NUMBERS . $f['u'], "{$double_open}\$1{$double_close}", $node_data );
 
 		// Guillemets.
-		$node_data = \str_replace( '<<',       U::GUILLEMET_OPEN,  $node_data );
-		$node_data = \str_replace( '&lt;&lt;', U::GUILLEMET_OPEN,  $node_data );
-		$node_data = \str_replace( '>>',       U::GUILLEMET_CLOSE, $node_data );
-		$node_data = \str_replace( '&gt;&gt;', U::GUILLEMET_CLOSE, $node_data );
+		$node_data = \str_replace( '<<', U::GUILLEMET_OPEN,  $node_data );
+		$node_data = \str_replace( '>>', U::GUILLEMET_CLOSE, $node_data );
 
 		// Primes.
 		$node_data = \preg_replace( self::SINGLE_DOUBLE_PRIME . $f['u'],           '$1' . U::SINGLE_PRIME . '$2$3' . U::DOUBLE_PRIME, $node_data );

--- a/src/fixes/node-fixes/class-smart-quotes-fix.php
+++ b/src/fixes/node-fixes/class-smart-quotes-fix.php
@@ -131,8 +131,8 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 	public function __construct( $feed_compatible = false ) {
 		parent::__construct( $feed_compatible );
 
-		$this->apostrophe_exception_matches      = array_keys( self::APOSTROPHE_EXCEPTIONS );
-		$this->apostrophe_exception_replacements = array_values( self::APOSTROPHE_EXCEPTIONS );
+		$this->apostrophe_exception_matches      = \array_keys( self::APOSTROPHE_EXCEPTIONS );
+		$this->apostrophe_exception_replacements = \array_values( self::APOSTROPHE_EXCEPTIONS );
 	}
 
 	/**
@@ -171,53 +171,53 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 		}
 
 		// Before primes, handle quoted numbers (and quotes ending in numbers).
-		$node_data = preg_replace( self::SINGLE_QUOTED_NUMBERS . $f['u'], "{$single_open}\$1{$single_close}", $node_data );
-		$node_data = preg_replace( self::DOUBLE_QUOTED_NUMBERS . $f['u'], "{$double_open}\$1{$double_close}", $node_data );
+		$node_data = \preg_replace( self::SINGLE_QUOTED_NUMBERS . $f['u'], "{$single_open}\$1{$single_close}", $node_data );
+		$node_data = \preg_replace( self::DOUBLE_QUOTED_NUMBERS . $f['u'], "{$double_open}\$1{$double_close}", $node_data );
 
 		// Guillemets.
-		$node_data = str_replace( '<<',       U::GUILLEMET_OPEN,  $node_data );
-		$node_data = str_replace( '&lt;&lt;', U::GUILLEMET_OPEN,  $node_data );
-		$node_data = str_replace( '>>',       U::GUILLEMET_CLOSE, $node_data );
-		$node_data = str_replace( '&gt;&gt;', U::GUILLEMET_CLOSE, $node_data );
+		$node_data = \str_replace( '<<',       U::GUILLEMET_OPEN,  $node_data );
+		$node_data = \str_replace( '&lt;&lt;', U::GUILLEMET_OPEN,  $node_data );
+		$node_data = \str_replace( '>>',       U::GUILLEMET_CLOSE, $node_data );
+		$node_data = \str_replace( '&gt;&gt;', U::GUILLEMET_CLOSE, $node_data );
 
 		// Primes.
-		$node_data = preg_replace( self::SINGLE_DOUBLE_PRIME . $f['u'],           '$1' . U::SINGLE_PRIME . '$2$3' . U::DOUBLE_PRIME, $node_data );
-		$node_data = preg_replace( self::SINGLE_DOUBLE_PRIME_1_GLYPH . $f['u'],   '$1' . U::SINGLE_PRIME . '$2$3' . U::DOUBLE_PRIME, $node_data );
-		$node_data = preg_replace( self::DOUBLE_PRIME . $f['u'],                  '$1' . U::DOUBLE_PRIME,                            $node_data ); // should not interfere with regular quote matching.
-		$node_data = preg_replace( self::SINGLE_PRIME . $f['u'],                  '$1' . U::SINGLE_PRIME,                            $node_data );
-		$node_data = preg_replace( self::SINGLE_PRIME_COMPOUND . $f['u'],         '$1' . U::SINGLE_PRIME,                            $node_data );
-		$node_data = preg_replace( self::DOUBLE_PRIME_COMPOUND . $f['u'],         '$1' . U::DOUBLE_PRIME,                            $node_data );
-		$node_data = preg_replace( self::DOUBLE_PRIME_1_GLYPH . $f['u'],          '$1' . U::DOUBLE_PRIME,                            $node_data ); // should not interfere with regular quote matching.
-		$node_data = preg_replace( self::DOUBLE_PRIME_1_GLYPH_COMPOUND . $f['u'], '$1' . U::DOUBLE_PRIME,                            $node_data );
+		$node_data = \preg_replace( self::SINGLE_DOUBLE_PRIME . $f['u'],           '$1' . U::SINGLE_PRIME . '$2$3' . U::DOUBLE_PRIME, $node_data );
+		$node_data = \preg_replace( self::SINGLE_DOUBLE_PRIME_1_GLYPH . $f['u'],   '$1' . U::SINGLE_PRIME . '$2$3' . U::DOUBLE_PRIME, $node_data );
+		$node_data = \preg_replace( self::DOUBLE_PRIME . $f['u'],                  '$1' . U::DOUBLE_PRIME,                            $node_data ); // should not interfere with regular quote matching.
+		$node_data = \preg_replace( self::SINGLE_PRIME . $f['u'],                  '$1' . U::SINGLE_PRIME,                            $node_data );
+		$node_data = \preg_replace( self::SINGLE_PRIME_COMPOUND . $f['u'],         '$1' . U::SINGLE_PRIME,                            $node_data );
+		$node_data = \preg_replace( self::DOUBLE_PRIME_COMPOUND . $f['u'],         '$1' . U::DOUBLE_PRIME,                            $node_data );
+		$node_data = \preg_replace( self::DOUBLE_PRIME_1_GLYPH . $f['u'],          '$1' . U::DOUBLE_PRIME,                            $node_data ); // should not interfere with regular quote matching.
+		$node_data = \preg_replace( self::DOUBLE_PRIME_1_GLYPH_COMPOUND . $f['u'], '$1' . U::DOUBLE_PRIME,                            $node_data );
 
 		// Backticks.
-		$node_data = str_replace( '``', $double_open,  $node_data );
-		$node_data = str_replace( '`',  $single_open,  $node_data );
-		$node_data = str_replace( "''", $double_close, $node_data );
+		$node_data = \str_replace( '``', $double_open,  $node_data );
+		$node_data = \str_replace( '`',  $single_open,  $node_data );
+		$node_data = \str_replace( "''", $double_close, $node_data );
 
 		// Comma quotes.
-		$node_data = str_replace( ',,', U::DOUBLE_LOW_9_QUOTE, $node_data );
-		$node_data = preg_replace( self::COMMA_QUOTE . $f['u'], U::SINGLE_LOW_9_QUOTE, $node_data ); // like _,¿hola?'_.
+		$node_data = \str_replace( ',,', U::DOUBLE_LOW_9_QUOTE, $node_data );
+		$node_data = \preg_replace( self::COMMA_QUOTE . $f['u'], U::SINGLE_LOW_9_QUOTE, $node_data ); // like _,¿hola?'_.
 
 		// Apostrophes.
-		$node_data = preg_replace( self::APOSTROPHE_WORDS . $f['u'],   U::APOSTROPHE,        $node_data );
-		$node_data = preg_replace( self::APOSTROPHE_DECADES . $f['u'], U::APOSTROPHE . '$1', $node_data ); // decades: '98.
-		$node_data = str_replace( $this->apostrophe_exception_matches, $this->apostrophe_exception_replacements, $node_data );
+		$node_data = \preg_replace( self::APOSTROPHE_WORDS . $f['u'],   U::APOSTROPHE,        $node_data );
+		$node_data = \preg_replace( self::APOSTROPHE_DECADES . $f['u'], U::APOSTROPHE . '$1', $node_data ); // decades: '98.
+		$node_data = \str_replace( $this->apostrophe_exception_matches, $this->apostrophe_exception_replacements, $node_data );
 
 		// Quotes.
-		$node_data = str_replace( $this->brackets_matches, $this->brackets_replacements, $node_data );
-		$node_data = preg_replace( self::SINGLE_QUOTE_OPEN . $f['u'],          $single_open,  $node_data );
-		$node_data = preg_replace( self::SINGLE_QUOTE_CLOSE . $f['u'],         $single_close, $node_data );
-		$node_data = preg_replace( self::SINGLE_QUOTE_OPEN_SPECIAL . $f['u'],  $single_open,  $node_data ); // like _'¿hola?'_.
-		$node_data = preg_replace( self::SINGLE_QUOTE_CLOSE_SPECIAL . $f['u'], $single_close, $node_data );
-		$node_data = preg_replace( self::DOUBLE_QUOTE_OPEN . $f['u'],          $double_open,  $node_data );
-		$node_data = preg_replace( self::DOUBLE_QUOTE_CLOSE . $f['u'],         $double_close, $node_data );
-		$node_data = preg_replace( self::DOUBLE_QUOTE_OPEN_SPECIAL . $f['u'],  $double_open,  $node_data );
-		$node_data = preg_replace( self::DOUBLE_QUOTE_CLOSE_SPECIAL . $f['u'], $double_close, $node_data );
+		$node_data = \str_replace( $this->brackets_matches, $this->brackets_replacements, $node_data );
+		$node_data = \preg_replace( self::SINGLE_QUOTE_OPEN . $f['u'],          $single_open,  $node_data );
+		$node_data = \preg_replace( self::SINGLE_QUOTE_CLOSE . $f['u'],         $single_close, $node_data );
+		$node_data = \preg_replace( self::SINGLE_QUOTE_OPEN_SPECIAL . $f['u'],  $single_open,  $node_data ); // like _'¿hola?'_.
+		$node_data = \preg_replace( self::SINGLE_QUOTE_CLOSE_SPECIAL . $f['u'], $single_close, $node_data );
+		$node_data = \preg_replace( self::DOUBLE_QUOTE_OPEN . $f['u'],          $double_open,  $node_data );
+		$node_data = \preg_replace( self::DOUBLE_QUOTE_CLOSE . $f['u'],         $double_close, $node_data );
+		$node_data = \preg_replace( self::DOUBLE_QUOTE_OPEN_SPECIAL . $f['u'],  $double_open,  $node_data );
+		$node_data = \preg_replace( self::DOUBLE_QUOTE_CLOSE_SPECIAL . $f['u'], $double_close, $node_data );
 
 		// Quote catch-alls - assume left over quotes are closing - as this is often the most complicated position, thus most likely to be missed.
-		$node_data = str_replace( "'", $single_close, $node_data );
-		$node_data = str_replace( '"', $double_close, $node_data );
+		$node_data = \str_replace( "'", $single_close, $node_data );
+		$node_data = \str_replace( '"', $double_close, $node_data );
 
 		// Check if adjacent characters where replaced with multi-byte replacements.
 		$quotes          = [ $double_open, $double_close, $single_open, $single_close ];
@@ -228,7 +228,7 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 		$node_data = self::remove_adjacent_characters( $node_data, $f['strlen'], $f['substr'], $previous_length, $next_length );
 
 		// Remove the escape markers and restore the text to the actual node.
-		$textnode->data = str_replace( RE::ESCAPE_MARKER, '', $node_data );
+		$textnode->data = \str_replace( RE::ESCAPE_MARKER, '', $node_data );
 	}
 
 	/**
@@ -289,7 +289,7 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 			"'\"" => $secondary_close . $primary_close,
 		];
 
-		$this->brackets_matches      = array_keys( $brackets );
-		$this->brackets_replacements = array_values( $brackets );
+		$this->brackets_matches      = \array_keys( $brackets );
+		$this->brackets_replacements = \array_values( $brackets );
 	}
 }

--- a/src/fixes/node-fixes/class-space-collapse-fix.php
+++ b/src/fixes/node-fixes/class-space-collapse-fix.php
@@ -61,19 +61,25 @@ class Space_Collapse_Fix extends Abstract_Node_Fix {
 
 		// Cache textnode content.
 		$node_data = $textnode->data;
-		$f         = Strings::functions( $node_data );
 
-		// Normal spacing.
-		$node_data = \preg_replace( self::COLLAPSE_NORMAL_SPACES . $f['u'], ' ', $node_data );
-
-		// Non-breakable space get's priority. If non-breakable space exists in a string of spaces, it collapses to a single non-breakable space.
-		$node_data = \preg_replace( self::COLLAPSE_NON_BREAKABLE_SPACES, U::NO_BREAK_SPACE, $node_data );
-
-		// For any other spaceing, replace with the first occurance of an unusual space character.
-		$node_data = \preg_replace( self::COLLAPSE_OTHER_SPACES, '$1', $node_data );
+		// Replace spaces.
+		$node_data = \preg_replace(
+			[
+				// Normal spacing.
+				self::COLLAPSE_NORMAL_SPACES,
+				// Non-breakable space get's priority. If non-breakable space exists in a string of spaces, it collapses to a single non-breakable space.
+				self::COLLAPSE_NON_BREAKABLE_SPACES,
+				// For any other spaceing, replace with the first occurance of an unusual space character.
+				self::COLLAPSE_OTHER_SPACES,
+			], [
+				' ',
+				U::NO_BREAK_SPACE,
+				'$1',
+			], $node_data
+		);
 
 		// Remove all spacing at beginning of block level elements.
-		if ( '' === DOM::get_prev_chr( $textnode ) ) { // we have the first text in a block level element.
+		if ( null === DOM::get_previous_textnode( $textnode ) ) {
 			$node_data = \preg_replace( self::COLLAPSE_SPACES_AT_START_OF_BLOCK, '', $node_data );
 		}
 

--- a/src/fixes/node-fixes/class-space-collapse-fix.php
+++ b/src/fixes/node-fixes/class-space-collapse-fix.php
@@ -64,17 +64,17 @@ class Space_Collapse_Fix extends Abstract_Node_Fix {
 		$f         = Strings::functions( $node_data );
 
 		// Normal spacing.
-		$node_data = preg_replace( self::COLLAPSE_NORMAL_SPACES . $f['u'], ' ', $node_data );
+		$node_data = \preg_replace( self::COLLAPSE_NORMAL_SPACES . $f['u'], ' ', $node_data );
 
 		// Non-breakable space get's priority. If non-breakable space exists in a string of spaces, it collapses to a single non-breakable space.
-		$node_data = preg_replace( self::COLLAPSE_NON_BREAKABLE_SPACES, U::NO_BREAK_SPACE, $node_data );
+		$node_data = \preg_replace( self::COLLAPSE_NON_BREAKABLE_SPACES, U::NO_BREAK_SPACE, $node_data );
 
 		// For any other spaceing, replace with the first occurance of an unusual space character.
-		$node_data = preg_replace( self::COLLAPSE_OTHER_SPACES, '$1', $node_data );
+		$node_data = \preg_replace( self::COLLAPSE_OTHER_SPACES, '$1', $node_data );
 
 		// Remove all spacing at beginning of block level elements.
 		if ( '' === DOM::get_prev_chr( $textnode ) ) { // we have the first text in a block level element.
-			$node_data = preg_replace( self::COLLAPSE_SPACES_AT_START_OF_BLOCK, '', $node_data );
+			$node_data = \preg_replace( self::COLLAPSE_SPACES_AT_START_OF_BLOCK, '', $node_data );
 		}
 
 		// Restore textnode content.

--- a/src/fixes/node-fixes/class-style-ampersands-fix.php
+++ b/src/fixes/node-fixes/class-style-ampersands-fix.php
@@ -42,10 +42,6 @@ use PHP_Typography\DOM;
  */
 class Style_Ampersands_Fix extends Simple_Style_Fix {
 
-	const REGEX           = '/(&)/u';
-	const SETTINGS_SWITCH = 'styleAmpersands';
-
-
 	/**
 	 * Creates a new node fix with a class.
 	 *
@@ -53,6 +49,6 @@ class Style_Ampersands_Fix extends Simple_Style_Fix {
 	 * @param bool   $feed_compatible Optional. Default false.
 	 */
 	public function __construct( $css_class, $feed_compatible = false ) {
-		parent::__construct( self::REGEX, self::SETTINGS_SWITCH, $css_class, $feed_compatible );
+		parent::__construct( '/(&)/S', 'styleAmpersands', $css_class, $feed_compatible );
 	}
 }

--- a/src/fixes/node-fixes/class-style-caps-fix.php
+++ b/src/fixes/node-fixes/class-style-caps-fix.php
@@ -90,9 +90,7 @@ class Style_Caps_Fix extends Simple_Style_Fix {
 			)
 		)
 		(?![\w\-_' . U::ZERO_WIDTH_SPACE . U::SOFT_HYPHEN . ']) # negative lookahead assertion
-	/xu';
-
-	const SETTINGS_SWITCH = 'styleCaps';
+	/Sxu';
 
 	/**
 	 * Creates a new node fix with a class.
@@ -101,6 +99,6 @@ class Style_Caps_Fix extends Simple_Style_Fix {
 	 * @param bool   $feed_compatible Optional. Default false.
 	 */
 	public function __construct( $css_class, $feed_compatible = false ) {
-		parent::__construct( self::REGEX, self::SETTINGS_SWITCH, $css_class, $feed_compatible );
+		parent::__construct( self::REGEX, 'styleCaps', $css_class, $feed_compatible );
 	}
 }

--- a/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
+++ b/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
@@ -86,10 +86,10 @@ class Style_Hanging_Punctuation_Fix extends Classes_Dependent_Fix {
 		U::APOSTROPHE; // requires modifiers: x (multiline pattern) u (utf8).
 
 	// Style hanging punctuation.
-	const STYLE_DOUBLE         = '/(\s)([' . self::_DOUBLE_HANGING_PUNCTUATION . '])(\w+)/';
-	const STYLE_SINGLE         = '/(\s)([' . self::_SINGLE_HANGING_PUNCTUATION . '])(\w+)/';
-	const STYLE_INITIAL_DOUBLE = '/(?:\A)([' . self::_DOUBLE_HANGING_PUNCTUATION . '])(\w+)/';
-	const STYLE_INITIAL_SINGLE = '/(?:\A)([' . self::_SINGLE_HANGING_PUNCTUATION . '])(\w+)/';
+	const STYLE_DOUBLE         = '/(\s)([' . self::_DOUBLE_HANGING_PUNCTUATION . '])(\w+)/S';
+	const STYLE_SINGLE         = '/(\s)([' . self::_SINGLE_HANGING_PUNCTUATION . '])(\w+)/S';
+	const STYLE_INITIAL_DOUBLE = '/(?:\A)([' . self::_DOUBLE_HANGING_PUNCTUATION . '])(\w+)/S';
+	const STYLE_INITIAL_SINGLE = '/(?:\A)([' . self::_SINGLE_HANGING_PUNCTUATION . '])(\w+)/S';
 
 	/**
 	 * Creates a new classes dependent fix.

--- a/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
+++ b/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
@@ -133,15 +133,15 @@ class Style_Hanging_Punctuation_Fix extends Classes_Dependent_Fix {
 		$node_data      = "{$textnode->data}$next_character"; // We have no interest in preceeding characters for this fix.
 		$f              = Strings::functions( $node_data );
 
-		$node_data = preg_replace( self::STYLE_DOUBLE . $f['u'], '$1<span class="' . $this->push_double_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_double_class . '">$2</span>$3', $node_data );
-		$node_data = preg_replace( self::STYLE_SINGLE . $f['u'], '$1<span class="' . $this->push_single_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_single_class . '">$2</span>$3', $node_data );
+		$node_data = \preg_replace( self::STYLE_DOUBLE . $f['u'], '$1<span class="' . $this->push_double_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_double_class . '">$2</span>$3', $node_data );
+		$node_data = \preg_replace( self::STYLE_SINGLE . $f['u'], '$1<span class="' . $this->push_single_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_single_class . '">$2</span>$3', $node_data );
 
 		if ( empty( $block ) || $firstnode === $textnode ) {
-			$node_data = preg_replace( self::STYLE_INITIAL_DOUBLE . $f['u'], '<span class="' . $this->pull_double_class . '">$1</span>$2', $node_data );
-			$node_data = preg_replace( self::STYLE_INITIAL_SINGLE . $f['u'], '<span class="' . $this->pull_single_class . '">$1</span>$2', $node_data );
+			$node_data = \preg_replace( self::STYLE_INITIAL_DOUBLE . $f['u'], '<span class="' . $this->pull_double_class . '">$1</span>$2', $node_data );
+			$node_data = \preg_replace( self::STYLE_INITIAL_SINGLE . $f['u'], '<span class="' . $this->pull_single_class . '">$1</span>$2', $node_data );
 		} else {
-			$node_data = preg_replace( self::STYLE_INITIAL_DOUBLE . $f['u'], '<span class="' . $this->push_double_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_double_class . '">$1</span>$2', $node_data );
-			$node_data = preg_replace( self::STYLE_INITIAL_SINGLE . $f['u'], '<span class="' . $this->push_single_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_single_class . '">$1</span>$2', $node_data );
+			$node_data = \preg_replace( self::STYLE_INITIAL_DOUBLE . $f['u'], '<span class="' . $this->push_double_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_double_class . '">$1</span>$2', $node_data );
+			$node_data = \preg_replace( self::STYLE_INITIAL_SINGLE . $f['u'], '<span class="' . $this->push_single_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_single_class . '">$1</span>$2', $node_data );
 		}
 
 		// Remove any added characters.

--- a/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
+++ b/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
@@ -123,9 +123,9 @@ class Style_Hanging_Punctuation_Fix extends Classes_Dependent_Fix {
 			return;
 		}
 
-		// We need the parent.
-		$block     = DOM::get_block_parent( $textnode );
-		$firstnode = ! empty( $block ) ? DOM::get_first_textnode( $block ) : null;
+		// Look for the first textnode.
+		$firstnode = DOM::get_first_textnode( DOM::get_block_parent( $textnode ) );
+		$block     = null === $firstnode || $textnode === $firstnode;
 
 		// Need to get context of adjacent characters outside adjacent inline tags or HTML comment
 		// if we have adjacent characters add them to the text.
@@ -133,16 +133,19 @@ class Style_Hanging_Punctuation_Fix extends Classes_Dependent_Fix {
 		$node_data      = "{$textnode->data}$next_character"; // We have no interest in preceeding characters for this fix.
 		$f              = Strings::functions( $node_data );
 
-		$node_data = \preg_replace( self::STYLE_DOUBLE . $f['u'], '$1<span class="' . $this->push_double_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_double_class . '">$2</span>$3', $node_data );
-		$node_data = \preg_replace( self::STYLE_SINGLE . $f['u'], '$1<span class="' . $this->push_single_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_single_class . '">$2</span>$3', $node_data );
-
-		if ( empty( $block ) || $firstnode === $textnode ) {
-			$node_data = \preg_replace( self::STYLE_INITIAL_DOUBLE . $f['u'], '<span class="' . $this->pull_double_class . '">$1</span>$2', $node_data );
-			$node_data = \preg_replace( self::STYLE_INITIAL_SINGLE . $f['u'], '<span class="' . $this->pull_single_class . '">$1</span>$2', $node_data );
-		} else {
-			$node_data = \preg_replace( self::STYLE_INITIAL_DOUBLE . $f['u'], '<span class="' . $this->push_double_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_double_class . '">$1</span>$2', $node_data );
-			$node_data = \preg_replace( self::STYLE_INITIAL_SINGLE . $f['u'], '<span class="' . $this->push_single_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_single_class . '">$1</span>$2', $node_data );
-		}
+		$node_data = \preg_replace(
+			[
+				self::STYLE_DOUBLE . $f['u'],
+				self::STYLE_SINGLE . $f['u'],
+				self::STYLE_INITIAL_DOUBLE . $f['u'],
+				self::STYLE_INITIAL_SINGLE . $f['u'],
+			], [
+				'$1<span class="' . $this->push_double_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_double_class . '">$2</span>$3',
+				'$1<span class="' . $this->push_single_class . '"></span>' . U::ZERO_WIDTH_SPACE . '<span class="' . $this->pull_single_class . '">$2</span>$3',
+				( ! $block ? ( '<span class="' . $this->push_double_class . '"></span>' . U::ZERO_WIDTH_SPACE ) : '' ) . '<span class="' . $this->pull_double_class . '">$1</span>$2',
+				( ! $block ? ( '<span class="' . $this->push_single_class . '"></span>' . U::ZERO_WIDTH_SPACE ) : '' ) . '<span class="' . $this->pull_single_class . '">$1</span>$2',
+			], $node_data
+		);
 
 		// Remove any added characters.
 		$textnode->data = self::remove_adjacent_characters( $node_data, $f['strlen'], $f['substr'], 0, $f['strlen']( $next_character ) );

--- a/src/fixes/node-fixes/class-style-numbers-fix.php
+++ b/src/fixes/node-fixes/class-style-numbers-fix.php
@@ -43,10 +43,6 @@ use PHP_Typography\DOM;
  */
 class Style_Numbers_Fix extends Simple_Style_Fix {
 
-	const REGEX           = '/([0-9]+)/u';
-	const SETTINGS_SWITCH = 'styleNumbers';
-
-
 	/**
 	 * Creates a new node fix with a class.
 	 *
@@ -54,6 +50,6 @@ class Style_Numbers_Fix extends Simple_Style_Fix {
 	 * @param bool   $feed_compatible Optional. Default false.
 	 */
 	public function __construct( $css_class, $feed_compatible = false ) {
-		parent::__construct( self::REGEX, self::SETTINGS_SWITCH, $css_class, $feed_compatible );
+		parent::__construct( '/([0-9]+)/S', 'styleNumbers', $css_class, $feed_compatible );
 	}
 }

--- a/src/fixes/node-fixes/class-unit-spacing-fix.php
+++ b/src/fixes/node-fixes/class-unit-spacing-fix.php
@@ -42,7 +42,7 @@ class Unit_Spacing_Fix extends Simple_Regex_Replacement_Fix {
 
 	const SETTING     = 'unitSpacing';
 	const REPLACEMENT = '$1' . U::NO_BREAK_NARROW_SPACE . '$2';
-	const REGEX       = '/(\d\.?)\s(' . self::_STANDARD_UNITS . ')\b/x';
+	const REGEX       = '/(\d\.?)\s(' . self::_STANDARD_UNITS . ')\b/Sx';
 
 	const _STANDARD_UNITS = '
 		### Temporal units

--- a/src/fixes/token-fixes/class-hyphenate-compounds-fix.php
+++ b/src/fixes/token-fixes/class-hyphenate-compounds-fix.php
@@ -71,11 +71,11 @@ class Hyphenate_Compounds_Fix extends Hyphenate_Fix {
 		// Hyphenate compound words.
 		foreach ( $tokens as $key => $word_token ) {
 			$component_words = [];
-			foreach ( preg_split( '/(-)/', $word_token->value, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE ) as $word_part ) {
+			foreach ( \preg_split( '/(-)/', $word_token->value, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE ) as $word_part ) {
 				$component_words[] = new Text_Parser\Token( $word_part, Text_Parser\Token::WORD );
 			}
 
-			$tokens[ $key ] = $word_token->with_value( array_reduce( parent::apply( $component_words, $settings, $is_title, $textnode ), function( $carry, $item ) {
+			$tokens[ $key ] = $word_token->with_value( \array_reduce( parent::apply( $component_words, $settings, $is_title, $textnode ), function( $carry, $item ) {
 				return $carry . $item->value;
 			} ) );
 		}

--- a/src/fixes/token-fixes/class-wrap-emails-fix.php
+++ b/src/fixes/token-fixes/class-wrap-emails-fix.php
@@ -41,8 +41,6 @@ use PHP_Typography\U;
  */
 class Wrap_Emails_Fix extends Abstract_Token_Fix {
 
-	const REPLACE_EMAILS = '/([^a-zA-Z])/';
-
 	/**
 	 * A regular expression matching email addresses.
 	 *
@@ -76,7 +74,7 @@ class Wrap_Emails_Fix extends Abstract_Token_Fix {
 				" . RE::top_level_domains() . '
 			)
 			\Z
-		)/xi'; // required modifiers: x (multiline pattern) i (case insensitive).
+		)/Sxi'; // required modifiers: x (multiline pattern) i (case insensitive).
 	}
 
 	/**
@@ -98,7 +96,7 @@ class Wrap_Emails_Fix extends Abstract_Token_Fix {
 		foreach ( $tokens as $index => $token ) {
 			$value = $token->value;
 			if ( \preg_match( $this->email_pattern, $value, $email_match ) ) {
-				$tokens[ $index ] = $token->with_value( \preg_replace( self::REPLACE_EMAILS, '$1' . U::ZERO_WIDTH_SPACE, $value ) );
+				$tokens[ $index ] = $token->with_value( \preg_replace( '/([^a-zA-Z0-9])/S', '$1' . U::ZERO_WIDTH_SPACE, $value ) );
 			}
 		}
 

--- a/src/fixes/token-fixes/class-wrap-emails-fix.php
+++ b/src/fixes/token-fixes/class-wrap-emails-fix.php
@@ -97,8 +97,8 @@ class Wrap_Emails_Fix extends Abstract_Token_Fix {
 		// Test for and parse urls.
 		foreach ( $tokens as $index => $token ) {
 			$value = $token->value;
-			if ( preg_match( $this->email_pattern, $value, $email_match ) ) {
-				$tokens[ $index ] = $token->with_value( preg_replace( self::REPLACE_EMAILS, '$1' . U::ZERO_WIDTH_SPACE, $value ) );
+			if ( \preg_match( $this->email_pattern, $value, $email_match ) ) {
+				$tokens[ $index ] = $token->with_value( \preg_replace( self::REPLACE_EMAILS, '$1' . U::ZERO_WIDTH_SPACE, $value ) );
 			}
 		}
 

--- a/src/fixes/token-fixes/class-wrap-hard-hyphens-fix.php
+++ b/src/fixes/token-fixes/class-wrap-hard-hyphens-fix.php
@@ -62,8 +62,8 @@ class Wrap_Hard_Hyphens_Fix extends Abstract_Token_Fix {
 	public function __construct( $feed_compatible = false ) {
 		parent::__construct( Token_Fix::MIXED_WORDS, $feed_compatible );
 
-		$this->hyphens_array             = array_unique( [ '-', U::HYPHEN ] );
-		$this->remove_ending_space_regex = '/(' . implode( '|', $this->hyphens_array ) . ')' . U::ZERO_WIDTH_SPACE . '$/';
+		$this->hyphens_array             = \array_unique( [ '-', U::HYPHEN ] );
+		$this->remove_ending_space_regex = '/(' . \implode( '|', $this->hyphens_array ) . ')' . U::ZERO_WIDTH_SPACE . '$/';
 	}
 
 	/**
@@ -83,16 +83,16 @@ class Wrap_Hard_Hyphens_Fix extends Abstract_Token_Fix {
 				$value = $text_token->value;
 
 				if ( isset( $settings['hyphenHardWrap'] ) && $settings['hyphenHardWrap'] ) {
-					$value = str_replace( $this->hyphens_array, '-' . U::ZERO_WIDTH_SPACE, $value );
-					$value = str_replace( '_', '_' . U::ZERO_WIDTH_SPACE, $value );
-					$value = str_replace( '/', '/' . U::ZERO_WIDTH_SPACE, $value );
+					$value = \str_replace( $this->hyphens_array, '-' . U::ZERO_WIDTH_SPACE, $value );
+					$value = \str_replace( '_', '_' . U::ZERO_WIDTH_SPACE, $value );
+					$value = \str_replace( '/', '/' . U::ZERO_WIDTH_SPACE, $value );
 
-					$value = preg_replace( $this->remove_ending_space_regex, '$1', $value );
+					$value = \preg_replace( $this->remove_ending_space_regex, '$1', $value );
 				}
 
 				if ( ! empty( $settings['smartDashes'] ) ) {
 					// Handled here because we need to know we are inside a word and not a URL.
-					$value = str_replace( '-', U::HYPHEN, $value );
+					$value = \str_replace( '-', U::HYPHEN, $value );
 				}
 
 				$tokens[ $index ] = $text_token->with_value( $value );

--- a/src/fixes/token-fixes/class-wrap-urls-fix.php
+++ b/src/fixes/token-fixes/class-wrap-urls-fix.php
@@ -114,14 +114,14 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 
 		// Test for and parse urls.
 		foreach ( $tokens as $token_index => $text_token ) {
-			if ( preg_match( $this->url_pattern, $text_token->value, $url_match ) ) {
+			if ( \preg_match( $this->url_pattern, $text_token->value, $url_match ) ) {
 
 				// $url_match['schema'] holds "http://".
 				// $url_match['domain'] holds "subdomains.domain.tld".
 				// $url_match['path']   holds the path after the domain.
 				$http = ( $url_match['schema'] ) ? $url_match[1] . U::ZERO_WIDTH_SPACE : '';
 
-				$domain_parts = preg_split( self::WRAP_URLS_DOMAIN_PARTS, $url_match['domain'], -1, PREG_SPLIT_DELIM_CAPTURE );
+				$domain_parts = \preg_split( self::WRAP_URLS_DOMAIN_PARTS, $url_match['domain'], -1, PREG_SPLIT_DELIM_CAPTURE );
 
 				// This is a hack, but it works.
 				// First, we hyphenate each part, we need it formated like a group of words.
@@ -137,7 +137,7 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 				foreach ( $parsed_words_like as $key => $parsed_word ) {
 					$value = $parsed_word->value;
 
-					if ( $key > 0 && 1 === strlen( $value ) ) {
+					if ( $key > 0 && 1 === \strlen( $value ) ) {
 						$domain_parts[ $key ] = U::ZERO_WIDTH_SPACE . $value;
 					} else {
 						$domain_parts[ $key ] = $value;
@@ -145,11 +145,11 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 				}
 
 				// Lastly let's recombine.
-				$domain = implode( $domain_parts );
+				$domain = \implode( $domain_parts );
 
 				// Break up the URL path to individual characters.
-				$path_parts = str_split( $url_match['path'], 1 );
-				$path_count = count( $path_parts );
+				$path_parts = \str_split( $url_match['path'], 1 );
+				$path_count = \count( $path_parts );
 				$path       = '';
 				foreach ( $path_parts as $index => $path_part ) {
 					if ( 0 === $index || $path_count - $index < $settings['urlMinAfterWrap'] ) {

--- a/src/hyphenator/class-trie-node.php
+++ b/src/hyphenator/class-trie-node.php
@@ -114,7 +114,7 @@ final class Trie_Node {
 				$node = $node->get_node( $char );
 			}
 
-			preg_match_all( '/([1-9])/S', $pattern, $offsets, PREG_OFFSET_CAPTURE );
+			\preg_match_all( '/([1-9])/S', $pattern, $offsets, PREG_OFFSET_CAPTURE );
 			$node->offsets = $offsets[1];
 		}
 

--- a/src/text-parser/class-token.php
+++ b/src/text-parser/class-token.php
@@ -100,7 +100,7 @@ final class Token {
 				throw new \UnexpectedValueException( "Invalid type $type." );
 		}
 
-		if ( ! is_string( $value ) ) {
+		if ( ! \is_string( $value ) ) {
 			throw new \UnexpectedValueException( 'Value has to be a string.' );
 		} else {
 			$this->value = $value;
@@ -117,7 +117,7 @@ final class Token {
 	 * @return mixed
 	 */
 	public function __get( $property ) {
-		if ( property_exists( $this, $property ) ) {
+		if ( \property_exists( $this, $property ) ) {
 			return $this->$property;
 		}
 	}

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -2222,7 +2222,7 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 		return [
 			[ 'code@example.org',         'code@&#8203;example.&#8203;org' ],
 			[ 'some.name@sub.domain.org', 'some.&#8203;name@&#8203;sub.&#8203;domain.&#8203;org' ],
-			[ 'funny123@summer1.org',     'funny1&#8203;2&#8203;3&#8203;@&#8203;summer1&#8203;.&#8203;org' ],
+			[ 'funny123@summer1.org',     'funny123@&#8203;summer1.&#8203;org' ],
 		];
 	}
 

--- a/tests/fixes/node-fixes/class-smart-marks-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-marks-fix-test.php
@@ -34,6 +34,7 @@ use PHP_Typography\Settings;
  * @usesDefaultClass \PHP_Typography\Fixes\Node_Fixes\Smart_Marks_Fix
  *
  * @uses ::__construct
+ * @uses PHP_Typography\Fixes\Node_Fixes\Abstract_Node_Fix::__construct
  * @uses PHP_Typography\DOM
  * @uses PHP_Typography\Settings
  * @uses PHP_Typography\Settings\Dash_Style
@@ -52,6 +53,18 @@ class Smart_Marks_Fix_Test extends Node_Fix_Testcase {
 		parent::setUp();
 
 		$this->fix = new Node_Fixes\Smart_Marks_Fix();
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 */
+	public function test_constructor() {
+		$this->fix = $this->getMockForAbstractClass( Node_Fixes\Smart_Marks_Fix::class, [ false ] );
+
+		$this->assertAttributeInternalType( 'array', 'marks', $this->fix );
+		$this->assertAttributeInternalType( 'array', 'replacements', $this->fix );
 	}
 
 	/**

--- a/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
@@ -79,7 +79,7 @@ class Wrap_Emails_Fix_Test extends Token_Fix_Testcase {
 		return [
 			[ 'code@example.org',         'code@&#8203;example.&#8203;org' ],
 			[ 'some.name@sub.domain.org', 'some.&#8203;name@&#8203;sub.&#8203;domain.&#8203;org' ],
-			[ 'funny123@summer1.org',     'funny1&#8203;2&#8203;3&#8203;@&#8203;summer1&#8203;.&#8203;org' ],
+			[ 'funny123@summer1.org',     'funny123@&#8203;summer1.&#8203;org' ],
 		];
 	}
 


### PR DESCRIPTION
- Use root namespace for builtin function calls.
- Use fewer `str_replace` and `preg_replace` calls by using their array notation.