### PR TITLE
Release 6.1.2

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -18,16 +18,20 @@ build:
         memcached: false
         neo4j: false
         php:
-            version: 7.1
-    tests:
+            version: 7.2
+
+    dependencies:
         override:
-            - phpcs-run -p src/ tests/ --ignore=tests/perf.php,tests/coverage --extensions=php
+            - composer install --ignore-platform-reqs --no-interaction
+
     nodes:
         analysis:
             project_setup:
                 override: true
             tests:
-                override: [php-scrutinizer-run --disable-security-analysis]
+                override:
+                  - phpcs-run -p src/ tests/ --ignore=tests/perf.php,tests/coverage --extensions=php
+                  - php-scrutinizer-run --disable-security-analysis
 
 tools:
     php_code_sniffer: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change History
 
+## 6.1.2 - February 25, 2018
+*   _Bugfix_: The `Quotes` class was missing from the signature of `Settings::set_smart_quotes_*`.
+
 ## 6.1.1 - February 04, 2018
 *   _Bugfix_: < and > where silently dropped when replacing nodes due to HTML injection.
 

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -29,6 +29,7 @@ namespace PHP_Typography;
 
 use PHP_Typography\Settings\Dash_Style;
 use PHP_Typography\Settings\Quote_Style;
+use PHP_Typography\Settings\Quotes;
 
 /**
  * Store settings for the PHP_Typography class.
@@ -49,14 +50,14 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	/**
 	 * Primary quote style.
 	 *
-	 * @var Settings\Quotes
+	 * @var Quotes
 	 */
 	protected $primary_quote_style;
 
 	/**
 	 * Secondary quote style.
 	 *
-	 * @var Settings\Quotes
+	 * @var Quotes
 	 */
 	protected $secondary_quote_style;
 
@@ -208,7 +209,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	/**
 	 * Retrieves the primary (double) quote style.
 	 *
-	 * @return Settings\Quotes
+	 * @return Quotes
 	 */
 	public function primary_quote_style() {
 		return $this->primary_quote_style;
@@ -217,7 +218,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	/**
 	 * Retrieves the secondary (single) quote style.
 	 *
-	 * @return Settings\Quotes
+	 * @return Quotes
 	 */
 	public function secondary_quote_style() {
 		return $this->secondary_quote_style;
@@ -401,7 +402,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 * "cornerBrackets" => "&#x300c;foo&#x300d;",
 	 * "whiteCornerBracket" => "&#x300e;foo&#x300f;"
 	 *
-	 * @param string $style Defaults to 'doubleCurled.
+	 * @param  Quotes|string $style Optional. A Quotes instance or a quote style constant. Defaults to 'doubleCurled'.
 	 *
 	 * @throws \DomainException Thrown if $style constant is invalid.
 	 */
@@ -429,7 +430,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 * "cornerBrackets" => "&#x300c;foo&#x300d;",
 	 * "whiteCornerBracket" => "&#x300e;foo&#x300f;"
 	 *
-	 * @param string $style Defaults to 'singleCurled'.
+	 * @param  Quotes|string $style Optional. A Quotes instance or a quote style constant. Defaults to 'singleCurled'.
 	 *
 	 * @throws \DomainException Thrown if $style constant is invalid.
 	 */
@@ -440,14 +441,14 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	/**
 	 * Retrieves a Quotes instance from a given style.
 	 *
-	 * @param  Settings\Quotes|string $style A Quotes instance or a quote style constant.
+	 * @param  Quotes|string $style A Quotes instance or a quote style constant.
 	 *
 	 * @throws \DomainException Thrown if $style constant is invalid.
 	 *
-	 * @return Settings\Quotes
+	 * @return Quotes
 	 */
 	protected function get_quote_style( $style ) {
-		return $this->get_style( $style, Settings\Quotes::class, [ Quote_Style::class, 'get_styled_quotes' ], 'quote' );
+		return $this->get_style( $style, Quotes::class, [ Quote_Style::class, 'get_styled_quotes' ], 'quote' );
 	}
 
 	/**

--- a/src/class-u.php
+++ b/src/class-u.php
@@ -49,7 +49,7 @@ interface U {
 	const HAIR_SPACE                 = "\xe2\x80\x8a";
 	const ZERO_WIDTH_SPACE           = "\xe2\x80\x8b";
 	const HYPHEN_MINUS               = '-';
-	const HYPHEN                     = self::HYPHEN_MINUS; // "\xe2\x80\x90"; // should be Strings::_uchr(8208), but IE6 chokes.
+	const HYPHEN                     = self::HYPHEN_MINUS; // Should be "\xe2\x80\x90" (\u8208), but IE6 chokes.
 	const NO_BREAK_HYPHEN            = "\xe2\x80\x91";
 	const EN_DASH                    = "\xe2\x80\x93";
 	const EM_DASH                    = "\xe2\x80\x94";


### PR DESCRIPTION
- Scrutinizer configuration updated.
- Signature for `Settings::set_smart_quotes_*` was missing the `Quotes` type as a possibility.