### PR TITLE
Release 6.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change History
 
+## 6.1.3 - March 02, 2081
+*   _Bugfix_: In rare cases, UTF-8 characters were broken by a missing 'u' flag in a regular expression.
+
 ## 6.1.2 - February 25, 2018
 *   _Bugfix_: The `Quotes` class was missing from the signature of `Settings::set_smart_quotes_*`.
 

--- a/src/fixes/node-fixes/class-space-collapse-fix.php
+++ b/src/fixes/node-fixes/class-space-collapse-fix.php
@@ -42,7 +42,7 @@ use PHP_Typography\U;
  */
 class Space_Collapse_Fix extends Abstract_Node_Fix {
 
-	const COLLAPSE_NORMAL_SPACES            = '/[' . RE::NORMAL_SPACES . ']+/Sx';
+	const COLLAPSE_NORMAL_SPACES            = '/[' . RE::NORMAL_SPACES . ']+/Sxu';
 	const COLLAPSE_NON_BREAKABLE_SPACES     = '/(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*' . U::NO_BREAK_SPACE . '(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*/Sxu';
 	const COLLAPSE_OTHER_SPACES             = '/(?:[' . RE::NORMAL_SPACES . '])*(' . RE::HTML_SPACES . ')(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*/Sxu';
 	const COLLAPSE_SPACES_AT_START_OF_BLOCK = '/\A(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')+/Sxu';

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -465,6 +465,7 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 			[ 'ช่วยฉัน/ผมหน่อยได้ไหม คะ/ครับ333', 'ช่วยฉัน/ผมหน่อยได้ไหม คะ/ครับ<span class="numbers">333</span>', false ], // Unicode characters in regular expressions.
 			[ '&lt;<a href="http://example.org">test</a>&gt;', '<<a href="http://example.org">test</a>>', false ],
 			[ '3 &lt; 4 &gt; 5', '<span class="numbers">3</span> < <span class="numbers">4</span> >&nbsp;<span class="numbers">5</span>', false ],
+			[ 'Årø Bilsenter', '&Aring;r&oslash; Bilsen&shy;ter', false ],
 		];
 	}
 

--- a/tests/fixes/node-fixes/class-space-collapse-fix-test.php
+++ b/tests/fixes/node-fixes/class-space-collapse-fix-test.php
@@ -64,6 +64,7 @@ class Space_Collapse_Fix_Test extends Node_Fix_Testcase {
 		return [
 			[ 'A  new hope&nbsp;  arises.', 'A new hope&nbsp;arises.' ],
 			[ 'A &thinsp;new hope &nbsp;  arises.', 'A&thinsp;new hope&nbsp;arises.' ],
+			[ 'Årø Bilsenter', 'Årø Bilsenter' ],
 		];
 	}
 


### PR DESCRIPTION
Fixes &Aring; (resulted in empty nodes due to a missing `u` flag).