### PR TITLE
Fix smart fractions followed by a comma (parity with 6.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change History
 
-## 6.1.3 - March 02, 2081
+## 6.1.4 - April 08, 2018
+*   _Bugfix_: Smart fractions were not matched correctly if the were followed by a comma (i.e. `1/4,`).
+
+## 6.1.3 - March 02, 2018
 *   _Bugfix_: In rare cases, UTF-8 characters were broken by a missing 'u' flag in a regular expression.
 
 ## 6.1.2 - February 25, 2018

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "5.*||6.*",
+        "phpunit/phpunit": "5.*||6.*|7.*",
         "brain/monkey": "^2.2.0",
         "squizlabs/php_codesniffer": "^3.2",
         "wp-coding-standards/wpcs": "^0.14.0",

--- a/src/fixes/node-fixes/class-smart-fractions-fix.php
+++ b/src/fixes/node-fixes/class-smart-fractions-fix.php
@@ -63,7 +63,7 @@ class Smart_Fractions_Fix extends Abstract_Node_Fix {
 			(?:\<sup\>(?:st|nd|rd|th)<\/sup\>)?
 
 			# makes sure we are not messing up a url
-			(?:\Z|\s|' . U::NO_BREAK_SPACE . '|' . U::NO_BREAK_NARROW_SPACE . '|\.|\!|\?|\)|\;|\:|\'|")
+			(?:\Z|\s|' . U::NO_BREAK_SPACE . '|' . U::NO_BREAK_NARROW_SPACE . '|\.|,|\!|\?|\)|\;|\:|\'|")
 		)
 		/xu';
 

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -1353,6 +1353,30 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 				'num',
 				'denom',
 			],
+			[
+				'3 1/4 works',
+				'3 <sup class="num">1</sup>&frasl;<sub class="denom">4</sub> works',
+				'num',
+				'denom',
+			],
+			[
+				'3 1/4" works',
+				'3 <sup class="num">1</sup>&frasl;<sub class="denom">4</sub>&Prime; works',
+				'num',
+				'denom',
+			],
+			[
+				'3 1/4". works',
+				'3 <sup class="num">1</sup>&frasl;<sub class="denom">4</sub>&Prime;. works',
+				'num',
+				'denom',
+			],
+			[
+				'3 1/4", works',
+				'3 <sup class="num">1</sup>&frasl;<sub class="denom">4</sub>&Prime;, works',
+				'num',
+				'denom',
+			],
 		];
 	}
 

--- a/tests/fixes/node-fixes/class-smart-fractions-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-fractions-fix-test.php
@@ -99,6 +99,42 @@ class Smart_Fractions_Fix_Test extends Node_Fix_Testcase {
 				'num',
 				'denom',
 			],
+			[
+				'1/4.',
+				'<sup class="num">1</sup>&frasl;<sub class="denom">4</sub>.',
+				'num',
+				'denom',
+			],
+			[
+				'1/4,',
+				'<sup class="num">1</sup>&frasl;<sub class="denom">4</sub>,',
+				'num',
+				'denom',
+			],
+			[
+				'1/4;',
+				'<sup class="num">1</sup>&frasl;<sub class="denom">4</sub>;',
+				'num',
+				'denom',
+			],
+			[
+				'1/4:',
+				'<sup class="num">1</sup>&frasl;<sub class="denom">4</sub>:',
+				'num',
+				'denom',
+			],
+			[
+				'1/4?',
+				'<sup class="num">1</sup>&frasl;<sub class="denom">4</sub>?',
+				'num',
+				'denom',
+			],
+			[
+				'1/4!',
+				'<sup class="num">1</sup>&frasl;<sub class="denom">4</sub>!',
+				'num',
+				'denom',
+			],
 		];
 	}
 


### PR DESCRIPTION
_Bugfix_: Smart fractions were not matched correctly if the were followed by a comma (i.e. `1/4,`).