### PR TITLE
Refactor unit spacing

### DIFF
--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -787,22 +787,28 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 */
 	public function set_units( $units = [] ) {
 		$this->data['units'] = Strings::maybe_split_parameters( $units );
-		$this->update_unit_pattern( $this->data['units'] );
+		$this->custom_units  = $this->update_unit_pattern( $this->data['units'] );
 	}
 
 	/**
-	 * Update components and pattern for matching both standard and custom units.
+	 * Update pattern for matching custom units.
+	 *
+	 * @since 6.4.0 Visibility changed to protected, return value added.
 	 *
 	 * @param array $units An array of unit names.
+	 *
+	 * @return string
 	 */
-	private function update_unit_pattern( array $units ) {
-		// Update components & regex pattern.
+	protected function update_unit_pattern( array $units ) {
+		// Update unit regex pattern.
 		foreach ( $units as $index => $unit ) {
-			// Escape special chars.
-			$units[ $index ] = \preg_replace( '#([\[\\\^\$\.\|\?\*\+\(\)\{\}])#', '\\\\$1', $unit );
+			$units[ $index ] = \preg_quote( $unit, '/' );
 		}
-		$this->custom_units  = \implode( '|', $units );
-		$this->custom_units .= ( $this->custom_units ) ? '|' : '';
+
+		$custom_units  = \implode( '|', $units );
+		$custom_units .= ! empty( $custom_units ) ? '|' : '';
+
+		return $custom_units;
 	}
 
 	/**

--- a/src/fixes/node-fixes/class-unit-spacing-fix.php
+++ b/src/fixes/node-fixes/class-unit-spacing-fix.php
@@ -65,7 +65,7 @@ class Unit_Spacing_Fix extends Simple_Regex_Replacement_Fix {
 		[kKMGT]?(?:[oBb]|[oBb]ps|flops)|
 
 		### Money
-		¢|M?(?:£|¥|€|$)|
+		¢|M?(?:£|¥|€|\$)|
 
 		### Other units
 		°[CF]? |

--- a/src/fixes/node-fixes/class-unit-spacing-fix.php
+++ b/src/fixes/node-fixes/class-unit-spacing-fix.php
@@ -57,7 +57,7 @@ class Unit_Spacing_Fix extends Simple_Regex_Replacement_Fix {
 
 		### Metric units (with prefixes)
 		(?:p|µ|[mcdhkMGT])?
-		(?:[mgstAKNJWCVFSTHBL]|mol|cd|rad|Hz|Pa|Wb|lm|lx|Bq|Gy|Sv|kat|Ω|Ohm|&Omega;|&\#0*937;|&\#[xX]0*3[Aa]9;)|
+		(?:[mgstAKNJWCVFSTHBL]|mol|cd|rad|Hz|Pa|Wb|lm|lx|Bq|Gy|Sv|kat|Ω)|
 		(?:nano|micro|milli|centi|deci|deka|hecto|kilo|mega|giga|tera)?
 		(?:liters?|meters?|grams?|newtons?|pascals?|watts?|joules?|amperes?)|
 

--- a/src/fixes/node-fixes/class-unit-spacing-fix.php
+++ b/src/fixes/node-fixes/class-unit-spacing-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2014-2017 Peter Putzer.
+ *  Copyright 2014-2019 Peter Putzer.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -42,7 +42,7 @@ class Unit_Spacing_Fix extends Simple_Regex_Replacement_Fix {
 
 	const SETTING     = 'unitSpacing';
 	const REPLACEMENT = '$1' . U::NO_BREAK_NARROW_SPACE . '$2';
-	const REGEX       = '/(\d\.?)\s(' . self::_STANDARD_UNITS . ')\b/Sx';
+	const REGEX       = '/(\d\.?)\s(' . self::_STANDARD_UNITS . ')' . self::WORD_BOUNDARY . '/Sxu';
 
 	const _STANDARD_UNITS = '
 		### Temporal units
@@ -70,7 +70,10 @@ class Unit_Spacing_Fix extends Simple_Regex_Replacement_Fix {
 		### Other units
 		°[CF]? |
 		%|pi|M?px|em|en|[NSEOW]|[NS][EOW]|mbar
-	'; // required modifiers: x (multiline pattern).
+	'; // required modifiers: x (multiline pattern), u (unicode).
+
+	// (?=\p{^L})|\z) is used instead of \b because otherwise the special symbols ($, € etc.) would not match properly (they are not word characters).
+	const WORD_BOUNDARY = '(?:(?=\p{^L})|\z)';
 
 	/**
 	 * Creates a new fix object.
@@ -93,7 +96,7 @@ class Unit_Spacing_Fix extends Simple_Regex_Replacement_Fix {
 		$this->replacement = "\$1{$settings->no_break_narrow_space()}\$2";
 
 		// Update regex with custom units.
-		$this->regex = "/(\d\.?)\s({$settings->custom_units()}" . self::_STANDARD_UNITS . ')\b/Sx';
+		$this->regex = "/(\d\.?)\s({$settings->custom_units()}" . self::_STANDARD_UNITS . ')' . self::WORD_BOUNDARY . '/Sxu';
 
 		parent::apply( $textnode, $settings, $is_title );
 	}

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -954,8 +954,8 @@ class Settings_Test extends PHP_Typography_Testcase {
 	 * Tests set_units.
 	 *
 	 * @covers ::set_units
-	 * @covers ::update_unit_pattern
 	 *
+	 * @uses ::update_unit_pattern
 	 * @uses PHP_Typography\Strings::maybe_split_parameters
 	 */
 	public function test_set_units() {
@@ -976,6 +976,40 @@ class Settings_Test extends PHP_Typography_Testcase {
 		foreach ( $units_as_array as $unit ) {
 			$this->assertContains( $unit, $this->settings['units'] );
 		}
+	}
+
+	/**
+	 * Provides data for testing update_unit_pattern.
+	 *
+	 * @return array
+	 */
+	public function provide_update_unit_pattern_data() {
+		return [
+			[
+				[ 'km/h', 'T$' ],
+				'km\/h|T\$|',
+			],
+			[
+				[ '¥', 'm[a]', 'n.', 'm^2' ],
+				'¥|m\[a\]|n\.|m\^2|',
+			],
+		];
+	}
+
+	/**
+	 * Tests update_unit_pattern.
+	 *
+	 * @covers ::update_unit_pattern
+	 *
+	 * @dataProvider provide_update_unit_pattern_data
+	 *
+	 * @param  string[] $units An array of units.
+	 * @param  string   $regex The resulting regular expression.
+	 */
+	public function test_update_unit_pattern( array $units, $regex ) {
+		$result = $this->invokeMethod( $this->settings, 'update_unit_pattern', [ $units ] );
+
+		$this->assertSame( $regex, $result );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
@@ -67,6 +67,13 @@ class Unit_Spacing_Fix_Test extends Node_Fix_Testcase {
 			[ '3 km/h', '3&#8239;km/h' ],
 			[ '5 sg 44 kg', '5 sg 44&#8239;kg' ],
 			[ '100 &deg;C', '100&#8239;&deg;C' ],
+			[ '10 &euro;', '10&#8239;&euro;' ],
+			[ '10 €', '10&#8239;&euro;' ],
+			[ '1 ¢', '1&#8239;&cent;' ],
+			[ '1 $', '1&#8239;$' ],
+			[ '5 nanoamperes', '5&#8239;nanoamperes' ],
+			[ '1 Ω', '1&#8239;&Omega;' ],
+			[ '1 &Omega;', '1&#8239;&Omega;' ],
 		];
 	}
 


### PR DESCRIPTION
Problems:
- Monetary (and other) symbols are not word characters, therefore `\b` won't match.
- Custom units were insufficiently escaped (e.g. `/` was left as-is).

Solution: 
- Instead of trying to match a standard word boundary, we now check for following non-word characters or the end of the string. Fixes #93.
- Custom units are now escaped via `preg_quote`. 