### PR TITLE
Clean-up deprecated methods, properties, and parameters

### DIFF
--- a/src/class-dom.php
+++ b/src/class-dom.php
@@ -126,7 +126,7 @@ abstract class DOM {
 	/**
 	 * Converts a DOMNodeList to array.
 	 *
-	 * @since 6.8.0 The Parameter $list has been renamed to $node_list.
+	 * @since 7.0.0 The Parameter $list has been renamed to $node_list.
 	 *
 	 * @param \DOMNodeList $node_list Required.
 	 *

--- a/src/class-hyphenator.php
+++ b/src/class-hyphenator.php
@@ -150,7 +150,7 @@ class Hyphenator {
 	/**
 	 * Calculates binary-safe hash from data object.
 	 *
-	 * @since 6.8.0 Parameter $object renamed to $data.
+	 * @since 7.0.0 Parameter $object renamed to $data.
 	 *
 	 * @param mixed $data Any datatype.
 	 *

--- a/src/class-php-typography.php
+++ b/src/class-php-typography.php
@@ -184,7 +184,7 @@ class PHP_Typography {
 	 * Processes the text nodes below the <body> node.
 	 *
 	 * @since 6.7.0
-	 * @since 6.8.0 Parameter $dom added.
+	 * @since 7.0.0 Parameter $dom added.
 	 *
 	 * @param \DOMDocument $dom        The document.
 	 * @param \DOMNode     $body_node  The body node containing the HTML fragment to process.

--- a/src/class-re.php
+++ b/src/class-re.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2014-2022 Peter Putzer.
+ *  Copyright 2014-2024 Peter Putzer.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -118,7 +118,8 @@ abstract class RE {
 			while ( ! $file->eof() ) {
 				$line = $file->fgets();
 				if ( ! \is_string( $line ) ) {
-					break; // File could not be read, let's bail.
+					// File could not be read, let's bail.
+					break;  // @codeCoverageIgnore
 				}
 
 				if ( \preg_match( '#^[a-zA-Z0-9][a-zA-Z0-9-]*$#', $line, $matches ) ) {

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -38,6 +38,7 @@ use PHP_Typography\Settings\Quotes;
  *
  * @since 4.0.0
  * @since 6.5.0 The protected property $no_break_narrow_space has been deprecated.
+ * @since 7.0.0 Deprecated properties and methods relating to $no_break_narrow_space have been removed.
  *
  * @implements \ArrayAccess<string,mixed>
  */
@@ -107,15 +108,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	// Parser error handling.
 	const PARSER_ERRORS_IGNORE  = 'parserErrorsIgnore';
 	const PARSER_ERRORS_HANDLER = 'parserErrorsHandler';
-
-	/**
-	 * The current no-break narrow space character.
-	 *
-	 * @deprecated 6.5.0
-	 *
-	 * @var string
-	 */
-	protected $no_break_narrow_space;
 
 	/**
 	 * Primary quote style.
@@ -190,11 +182,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 
 		// Merge default character mapping with given mapping.
 		$this->unicode_mapping = $mapping;
-
-		// Keep backwards compatibility.
-		if ( isset( $this->unicode_mapping[ U::NO_BREAK_NARROW_SPACE ] ) ) {
-			$this->no_break_narrow_space = $this->unicode_mapping[ U::NO_BREAK_NARROW_SPACE ];
-		}
 	}
 
 	/**
@@ -313,11 +300,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		} else {
 			unset( $this->unicode_mapping[ $char ] );
 		}
-
-		// Compatibility with the old way of setting the no-break narrow space.
-		if ( U::NO_BREAK_NARROW_SPACE === $char ) {
-			$this->no_break_narrow_space = $new_char;
-		}
 	}
 
 	/**
@@ -346,18 +328,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		}
 
 		return $native_array ? $data : $data[0]; // @phpstan-ignore-line -- Ignore generics/array clash
-	}
-
-	/**
-	 * Retrieves the current non-breaking narrow space character (either the
-	 * regular non-breaking space &nbsp; or the the true non-breaking narrow space &#8239;).
-	 *
-	 * @deprecated 6.5.0 Use U::NO_BREAK_NARROW_SPACE instead and let Settings::apply_character_mapping() do the rest.
-	 *
-	 * @return string
-	 */
-	public function no_break_narrow_space() {
-		return $this->no_break_narrow_space;
 	}
 
 	/**
@@ -440,7 +410,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		$this->set_email_wrap();
 		$this->set_min_after_url_wrap();
 		$this->set_space_collapse();
-		$this->set_true_no_break_narrow_space();
 
 		// Character styling.
 		$this->set_style_ampersands();
@@ -484,22 +453,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 */
 	public function set_parser_errors_handler( callable $handler = null ): void {
 		$this->data[ self::PARSER_ERRORS_HANDLER ] = $handler;
-	}
-
-	/**
-	 * Enable usage of true "no-break narrow space" (&#8239;) instead of the normal no-break space (&nbsp;).
-	 *
-	 * @deprecated 6.5.0 Use ::remap_character() instead.
-	 *
-	 * @param bool $on Optional. Default false.
-	 */
-	public function set_true_no_break_narrow_space( $on = false ): void {
-
-		if ( $on ) {
-			$this->remap_character( U::NO_BREAK_NARROW_SPACE, U::NO_BREAK_NARROW_SPACE );
-		} else {
-			$this->remap_character( U::NO_BREAK_NARROW_SPACE, U::NO_BREAK_SPACE );
-		}
 	}
 
 	/**

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -39,6 +39,7 @@ use PHP_Typography\Settings\Quotes;
  * @since 4.0.0
  * @since 6.5.0 The protected property $no_break_narrow_space has been deprecated.
  * @since 7.0.0 Deprecated properties and methods relating to $no_break_narrow_space have been removed.
+ *              The deprecated method array_map_assoc has been removed.
  *
  * @implements \ArrayAccess<string,mixed>
  */
@@ -727,35 +728,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		}
 
 		return $replacements;
-	}
-
-	/**
-	 * Provides an array_map implementation with control over resulting array's keys.
-	 *
-	 * Based on https://gist.github.com/jasand-pereza/84ecec7907f003564584.
-	 *
-	 * @since 6.0.0
-	 * @deprecated 6.7.0
-	 *
-	 * @template T
-	 *
-	 * @param  callable $callback A callback function that needs to return [ $key => $value ] pairs.
-	 * @param  array<T> $array    The array.
-	 *
-	 * @return array<T>
-	 */
-	protected static function array_map_assoc( callable $callback, array $array ): array { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.arrayFound -- method is already deprecated.
-		$new = [];
-
-		foreach ( $array as $k => $v ) {
-			$u = $callback( $k, $v );
-
-			if ( ! empty( $u ) ) {
-				$new[ \key( $u ) ] = \current( $u );
-			}
-		}
-
-		return $new;
 	}
 
 	/**

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -607,7 +607,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		if ( $style instanceof $expected_class ) {
 			$object = $style;
 		} else {
-			$object = $get_style( $style, $this );
+			$object = $get_style( $style );
 		}
 
 		if ( ! \is_object( $object ) || ! $object instanceof $expected_class ) {

--- a/src/class-strings.php
+++ b/src/class-strings.php
@@ -31,6 +31,7 @@ namespace PHP_Typography;
  * A utility class to handle fast and save string function access.
  *
  * @since 4.2.0
+ * @since 7.0.0 The deprecated methods mb_str_split have been removed.
  *
  * @phpstan-type String_Functions array{
  *         'strlen'     : callable,
@@ -105,30 +106,6 @@ abstract class Strings {
 		}
 
 		return [];
-	}
-
-	/**
-	 * Multibyte-safe str_split function. Unlike regular str_split, behavior for
-	 * `$split_length` < 1 is undefined and may or may not result in an error
-	 * being raised.
-	 *
-	 * @deprecated 6.7.0
-	 *
-	 * @param string     $string       The input string.
-	 * @param int<1,max> $split_length Optional. Maximum length of the chunk. Default 1.
-	 *
-	 * @return string[]                An array of $split_length character chunks.
-	 */
-	public static function mb_str_split( $string, $split_length = 1 ) {
-		// Checking here is not optimal, the check should be made on instantiation
-		// when the class is refactored.
-		if ( \function_exists( 'mb_str_split' ) ) {
-			// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.mb_str_splitFound, Universal.Operators.DisallowShortTernary -- Ensure array type.
-			return \mb_str_split( $string, $split_length, 'UTF-8' ) ?: [];
-		}
-
-		// We can safely assume an array here, as long as $string convertible to a string.
-		return \preg_split( "/(.{{$split_length}})/us", $string , -1, \PREG_SPLIT_NO_EMPTY | \PREG_SPLIT_DELIM_CAPTURE ) ?: []; // phpcs:ignore Universal.Operators.DisallowShortTernary -- Ensure array type.
 	}
 
 	/**

--- a/src/class-strings.php
+++ b/src/class-strings.php
@@ -31,7 +31,7 @@ namespace PHP_Typography;
  * A utility class to handle fast and save string function access.
  *
  * @since 4.2.0
- * @since 7.0.0 The deprecated methods mb_str_split have been removed.
+ * @since 7.0.0 The deprecated static methods `mb_str_split`, and `uchr` have been removed.
  *
  * @phpstan-type String_Functions array{
  *         'strlen'     : callable,
@@ -106,32 +106,6 @@ abstract class Strings {
 		}
 
 		return [];
-	}
-
-	/**
-	 * Converts decimal value to unicode character.
-	 *
-	 * @deprecated 6.7.0
-	 *
-	 * @param int|string|array<string|int> $codes Decimal value(s) coresponding to unicode character(s).
-	 *
-	 * @return string Unicode character(s).
-	 */
-	public static function uchr( $codes ) {
-
-		// Single character code.
-		if ( \is_scalar( $codes ) ) {
-			$codes = \func_get_args(); // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
-		}
-
-		// Deal with an array of character codes.
-		$json = '"';
-		foreach ( $codes as $code ) {
-			$json .= \sprintf( '\u%04x', $code );
-		}
-		$json .= '"';
-
-		return \json_decode( $json );
 	}
 
 	/**

--- a/src/class-strings.php
+++ b/src/class-strings.php
@@ -27,6 +27,8 @@
 
 namespace PHP_Typography;
 
+use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
+
 /**
  * A utility class to handle fast and save string function access.
  *
@@ -96,7 +98,12 @@ abstract class Strings {
 	 * Retrieves str* functions.
 	 *
 	 * @param  string $str A string to detect the encoding from.
-	 * @return String_Functions|array{}
+	 *
+	 * @return array
+	 *
+	 * @throws Invalid_Encoding_Exception Throws an exception if the string is not encoded in ASCII or UTF-8.
+	 *
+	 * @phpstan-return String_Functions
 	 */
 	public static function functions( $str ) {
 		foreach ( self::ENCODINGS as $encoding ) {
@@ -105,7 +112,7 @@ abstract class Strings {
 			}
 		}
 
-		return [];
+		throw new Invalid_Encoding_Exception( "String '$str' uses neither ASCII nor UTF-8 encoding." );
 	}
 
 	/**

--- a/src/class-text-parser.php
+++ b/src/class-text-parser.php
@@ -256,7 +256,6 @@ class Text_Parser {
 	private const RE_PUNCTUATION            = '/\A' . self::PUNCTUATION . '\Z/Ssxiu';
 	private const RE_WORD                   = '/\A' . self::WORD . '\Z/Sxu';
 	private const RE_HTML_LETTER_CONNECTORS = '/' . self::HTML_LETTER_CONNECTORS . '|[0-9\-_&#;\/]/Sxu';
-	private const RE_MAX_STRING_LENGTH      = '/\w{500}/Ss';
 
 	/**
 	 * The current strtoupper function to use (either 'strtoupper' or 'mb_strtoupper').
@@ -285,11 +284,9 @@ class Text_Parser {
 	 *
 	 * @return bool Returns `true` on successful completion, `false` otherwise.
 	 */
-	public function load( $raw_text ) {
-		if ( ! \is_string( $raw_text ) || \preg_match( self::RE_MAX_STRING_LENGTH, $raw_text ) ) {
-			// Abort if called on a non-string or the string exceeds 500 characters
-			// (security concern). TODO: Evaluate limit.
-			return false;
+	public function load( string $raw_text ) {
+		if ( empty( $raw_text ) ) {
+			return false; // Can't tokenize an empty string.
 		}
 
 		// Detect encoding.

--- a/src/class-text-parser.php
+++ b/src/class-text-parser.php
@@ -28,6 +28,7 @@
 
 namespace PHP_Typography;
 
+use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 use PHP_Typography\Text_Parser\Token;
 
 /**
@@ -292,11 +293,7 @@ class Text_Parser {
 		}
 
 		// Detect encoding.
-		$str_functions = Strings::functions( $raw_text );
-		if ( empty( $str_functions ) ) { // TODO: Refactor encoding check.
-			return false; // unknown encoding.
-		}
-		$this->current_strtoupper = $str_functions['strtoupper'];
+		$this->current_strtoupper = Strings::functions( $raw_text )['strtoupper'];
 
 		// Tokenize the raw text parts.
 		$this->text = self::tokenize( \preg_split( self::RE_ANY_TEXT, $raw_text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY ) ?: [] ); // phpcs:ignore Universal.Operators.DisallowShortTernary -- Ensure array type in case of error.

--- a/src/class-text-parser.php
+++ b/src/class-text-parser.php
@@ -3,7 +3,6 @@
  *  This file is part of PHP-Typography.
  *
  *  Copyright 2014-2024 Peter Putzer.
- *  Copyright 2012-2013 Marie Hogebrandt.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or modify

--- a/src/exceptions/class-invalid-encoding-exception.php
+++ b/src/exceptions/class-invalid-encoding-exception.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ *  This file is part of PHP-Typography.
+ *
+ *  Copyright 2024 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/php-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace PHP_Typography\Exceptions;
+
+/**
+ * An invalid encoding was given.
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ *
+ * @since 7.0.0
+ */
+class Invalid_Encoding_Exception extends \UnexpectedValueException {
+}

--- a/src/exceptions/class-invalid-path-exception.php
+++ b/src/exceptions/class-invalid-path-exception.php
@@ -31,7 +31,7 @@ namespace PHP_Typography\Exceptions;
  *
  * @author Peter Putzer <github@mundschenk.at>
  *
- * @since 6.8.0
+ * @since 7.0.0
  */
 class Invalid_Path_Exception extends \RuntimeException {
 }

--- a/src/fixes/class-node-fix.php
+++ b/src/fixes/class-node-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -40,13 +40,15 @@ interface Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
 	 *
 	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false );
+	public function apply( \DOMText $textnode, Settings $settings, $is_title );
 
 	/**
 	 * Determines whether the fix should be applied to (RSS) feeds.

--- a/src/fixes/class-token-fix.php
+++ b/src/fixes/class-token-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -44,16 +44,18 @@ interface Token_Fix {
 	const OTHER          = 4;
 
 	/**
-	 * Apply the fix to a given textnode.
+	 * Apply the fix to a given set of tokens
 	 *
-	 * @param Token[]       $tokens   Required.
-	 * @param Settings      $settings Required.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param \DOMText|null $textnode Optional. Default null.
+	 * @since 7.0.0 The parameter order has been re-arranged to mirror Node_Fix.
 	 *
-	 * @return Token[] An array of tokens.
+	 * @param Token[]  $tokens   The set of tokens.
+	 * @param \DOMText $textnode The context DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return Token[]           The fixed set of tokens.
 	 */
-	public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null );
+	public function apply( array $tokens, \DOMText $textnode, Settings $settings, $is_title );
 
 	/**
 	 * Determines whether the fix should be applied to (RSS) feeds.

--- a/src/fixes/node-fixes/class-abstract-node-fix.php
+++ b/src/fixes/node-fixes/class-abstract-node-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify modify
  *  it under the terms of the GNU General Public License as published by
@@ -58,13 +58,15 @@ abstract class Abstract_Node_Fix implements Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
 	 *
 	 * @return void
 	 */
-	abstract public function apply( \DOMText $textnode, Settings $settings, $is_title = false );
+	abstract public function apply( \DOMText $textnode, Settings $settings, $is_title );
 
 	/**
 	 * Determines whether the fix should be applied to (RSS) feeds.

--- a/src/fixes/node-fixes/class-classes-dependent-fix.php
+++ b/src/fixes/node-fixes/class-classes-dependent-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2022 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify modify
  *  it under the terms of the GNU General Public License as published by
@@ -64,13 +64,15 @@ abstract class Classes_Dependent_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode if the nodes class(es) allow it.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
 	 *
 	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( ! DOM::has_class( $textnode, $this->classes_to_avoid ) ) {
 			$this->apply_internal( $textnode, $settings, $is_title );
 		}
@@ -80,12 +82,13 @@ abstract class Classes_Dependent_Fix extends Abstract_Node_Fix {
 	 * Apply the fix to a given textnode.
 	 *
 	 * @since 6.0.0 The method was accidentally made public and is now protected.
+	 * @since 7.0.0 All parameters are now required.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
 	 *
 	 * @return void
 	 */
-	abstract protected function apply_internal( \DOMText $textnode, Settings $settings, $is_title = false );
+	abstract protected function apply_internal( \DOMText $textnode, Settings $settings, $is_title );
 }

--- a/src/fixes/node-fixes/class-classes-dependent-fix.php
+++ b/src/fixes/node-fixes/class-classes-dependent-fix.php
@@ -28,6 +28,7 @@ namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\Settings;
 use PHP_Typography\DOM;
+use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 
 /**
  * All fixes that depend on certain HTML classes not being present should extend this baseclass.

--- a/src/fixes/node-fixes/class-dash-spacing-fix.php
+++ b/src/fixes/node-fixes/class-dash-spacing-fix.php
@@ -100,11 +100,15 @@ class Dash_Spacing_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::DASH_SPACING ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-dewidow-fix.php
+++ b/src/fixes/node-fixes/class-dewidow-fix.php
@@ -80,11 +80,15 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		// Intervening inline tags may interfere with widow identification, but that is a sacrifice of using the parser.
 		// Intervening tags will only interfere if they separate the widow from previous or preceding whitespace.
 		if ( empty( $settings[ Settings::DEWIDOW ] ) || empty( $settings[ Settings::DEWIDOW_MAX_PULL ] ) || empty( $settings[ Settings::DEWIDOW_MAX_LENGTH ] ) ) {

--- a/src/fixes/node-fixes/class-dewidow-fix.php
+++ b/src/fixes/node-fixes/class-dewidow-fix.php
@@ -39,6 +39,8 @@ use PHP_Typography\U;
  * @author Peter Putzer <github@mundschenk.at>
  *
  * @since 5.0.0
+ *
+ * @phpstan-import-type String_Functions from \PHP_Typography\Strings
  */
 class Dewidow_Fix extends Abstract_Node_Fix {
 	const SPACE_BETWEEN = '[\s]+'; // \s includes all special spaces (but not ZWSP) with the u flag.
@@ -114,6 +116,8 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 	 * @param  int     $word_number  Maximum number of words allowed in widow.
 	 *
 	 * @return string
+	 *
+	 * @phpstan-param String_Functions $func
 	 */
 	protected function dewidow( $text, array $func, $max_pull, $max_length, $word_number ) {
 		if ( $word_number < 1 ) {

--- a/src/fixes/node-fixes/class-dewidow-fix.php
+++ b/src/fixes/node-fixes/class-dewidow-fix.php
@@ -129,7 +129,7 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 				// with that, we will assert that widows should never be hyphenated or wrapped
 				// as such, we will strip soft hyphens and zero-width-spaces.
 				$widow['widow']    = self::strip_breaking_characters( $widow['widow'] );
-				$widow['trailing'] = self::strip_breaking_characters( self::make_space_nonbreaking( $widow['trailing'], U::NO_BREAK_NARROW_SPACE, $func['u'] ) );
+				$widow['trailing'] = self::strip_breaking_characters( self::make_space_nonbreaking( $widow['trailing'], $func['u'] ) );
 
 				if (
 					// Eject if widows neighbor is proceeded by a no break space (the pulled text would be too long).
@@ -143,7 +143,7 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 				}
 
 				// Let's protect some widows!
-				return $widow['space_before'] . $widow['neighbor'] . U::NO_BREAK_SPACE . self::make_space_nonbreaking( $widow['widow'], U::NO_BREAK_NARROW_SPACE, $func['u'] ) . $widow['trailing'];
+				return $widow['space_before'] . $widow['neighbor'] . U::NO_BREAK_SPACE . self::make_space_nonbreaking( $widow['widow'], $func['u'] ) . $widow['trailing'];
 			},
 			$text
 		);
@@ -177,14 +177,14 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 	 * Strip zero-width space and soft hyphens from the given string.
 	 *
 	 * @since 6.5.0 Parameter $narrow_space has been deprecated.
+	 * @since 7.0.0 Parameter $deprecated (formerly $narrow_space) removed.
 	 *
 	 * @param  string $string     Required.
-	 * @param  string $deprecated Ignored.
 	 * @param  string $u          Either 'u' or the empty string.
 	 *
 	 * @return string
 	 */
-	protected static function make_space_nonbreaking( $string, $deprecated, $u ) {
+	protected static function make_space_nonbreaking( $string, $u ) {
 		return (string) \preg_replace(
 			[
 				'/\s*(?:' . U::THIN_SPACE . '|' . U::NO_BREAK_NARROW_SPACE . ')\s*/Su',

--- a/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
+++ b/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
@@ -54,11 +54,15 @@ class French_Punctuation_Spacing_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::FRENCH_PUNCTUATION_SPACING ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
+++ b/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
@@ -27,6 +27,7 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\DOM;
+use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 use PHP_Typography\Settings;
 use PHP_Typography\Strings;
 use PHP_Typography\U;
@@ -75,9 +76,6 @@ class French_Punctuation_Spacing_Fix extends Abstract_Node_Fix {
 
 		// Check encoding.
 		$f = Strings::functions( "{$node_data}{$next_character}" ); // Include $next_character for determining encodiing.
-		if ( empty( $f ) ) {
-			return;
-		}
 
 		$node_data = (string) \preg_replace(
 			[

--- a/src/fixes/node-fixes/class-process-words-fix.php
+++ b/src/fixes/node-fixes/class-process-words-fix.php
@@ -91,7 +91,7 @@ class Process_Words_Fix extends Abstract_Node_Fix {
 		foreach ( $this->token_fixes as $fix ) {
 			$t = $fix->target();
 
-			$tokens[ $t ] = $fix->apply( $tokens[ $t ], $settings, $is_title, $textnode );
+			$tokens[ $t ] = $fix->apply( $tokens[ $t ], $textnode, $settings, $is_title );
 		}
 
 		// Apply updates to our text.

--- a/src/fixes/node-fixes/class-process-words-fix.php
+++ b/src/fixes/node-fixes/class-process-words-fix.php
@@ -65,11 +65,15 @@ class Process_Words_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		// Lazy-load text parser.
 		$text_parser = $this->get_text_parser();
 		$tokens      = [];

--- a/src/fixes/node-fixes/class-simple-regex-replacement-fix.php
+++ b/src/fixes/node-fixes/class-simple-regex-replacement-fix.php
@@ -80,11 +80,15 @@ abstract class Simple_Regex_Replacement_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ $this->settings_switch ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-simple-style-fix.php
+++ b/src/fixes/node-fixes/class-simple-style-fix.php
@@ -82,12 +82,15 @@ abstract class Simple_Style_Fix extends Classes_Dependent_Fix {
 	 * Apply the fix to a given textnode.
 	 *
 	 * @since 6.0.0 The method was accidentally made public and is now protected.
+	 * @since 7.0.0 All parameters are now required.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	protected function apply_internal( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	protected function apply_internal( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ $this->settings_switch ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
+++ b/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
@@ -54,11 +54,15 @@ class Single_Character_Word_Spacing_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SINGLE_CHARACTER_WORD_SPACING ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
+++ b/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
@@ -27,6 +27,7 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\DOM;
+use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 use PHP_Typography\RE;
 use PHP_Typography\Settings;
 use PHP_Typography\Strings;
@@ -74,9 +75,6 @@ class Single_Character_Word_Spacing_Fix extends Abstract_Node_Fix {
 
 		// Check encoding.
 		$f = Strings::functions( $node_data );
-		if ( empty( $f ) ) {
-			return;
-		}
 
 		// Replace spaces.
 		$node_data = (string) \preg_replace( self::REGEX . $f['u'], '$1$2' . U::NO_BREAK_SPACE, $node_data );

--- a/src/fixes/node-fixes/class-smart-area-units-fix.php
+++ b/src/fixes/node-fixes/class-smart-area-units-fix.php
@@ -49,11 +49,15 @@ class Smart_Area_Units_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SMART_AREA_UNITS ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-smart-dashes-fix.php
+++ b/src/fixes/node-fixes/class-smart-dashes-fix.php
@@ -127,11 +127,15 @@ class Smart_Dashes_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SMART_DASHES ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-smart-diacritics-fix.php
+++ b/src/fixes/node-fixes/class-smart-diacritics-fix.php
@@ -41,11 +41,15 @@ class Smart_Diacritics_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SMART_DIACRITICS ] ) ) {
 			return; // abort.
 		}

--- a/src/fixes/node-fixes/class-smart-ellipses-fix.php
+++ b/src/fixes/node-fixes/class-smart-ellipses-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify modify
  *  it under the terms of the GNU General Public License as published by
@@ -42,11 +42,15 @@ class Smart_Ellipses_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SMART_ELLIPSES ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-smart-fractions-fix.php
+++ b/src/fixes/node-fixes/class-smart-fractions-fix.php
@@ -131,11 +131,15 @@ class Smart_Fractions_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SMART_FRACTIONS ] ) && empty( $settings[ Settings::FRACTION_SPACING ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-smart-marks-fix.php
+++ b/src/fixes/node-fixes/class-smart-marks-fix.php
@@ -87,11 +87,15 @@ class Smart_Marks_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SMART_MARKS ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-smart-maths-fix.php
+++ b/src/fixes/node-fixes/class-smart-maths-fix.php
@@ -184,11 +184,15 @@ class Smart_Maths_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SMART_MATH ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
+++ b/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
@@ -107,11 +107,15 @@ class Smart_Ordinal_Suffix_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SMART_ORDINAL_SUFFIX ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-smart-quotes-fix.php
+++ b/src/fixes/node-fixes/class-smart-quotes-fix.php
@@ -89,11 +89,15 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SMART_QUOTES ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-space-collapse-fix.php
+++ b/src/fixes/node-fixes/class-space-collapse-fix.php
@@ -50,11 +50,15 @@ class Space_Collapse_Fix extends Abstract_Node_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::SPACE_COLLAPSE ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
+++ b/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
@@ -38,44 +38,10 @@ use PHP_Typography\U;
  * @author Peter Putzer <github@mundschenk.at>
  *
  * @since 5.0.0
+ * @since 7.0.0 The deprecated protected properties `$push_single_class`, `$push_double_class`,
+ *              `$pull_single_class`, and `$pull_double_class` have been removed.
  */
 class Style_Hanging_Punctuation_Fix extends Classes_Dependent_Fix {
-
-	/**
-	 * CSS class for single-width punctuation marks.
-	 *
-	 * @deprecated 6.7.0
-	 *
-	 * @var string
-	 */
-	protected $push_single_class;
-
-	/**
-	 * CSS class for double-width punctuation marks.
-	 *
-	 * @deprecated 6.7.0
-	 *
-	 * @var string
-	 */
-	protected $push_double_class;
-
-	/**
-	 * CSS class for single-width punctuation marks.
-	 *
-	 * @deprecated 6.7.0
-	 *
-	 * @var string
-	 */
-	protected $pull_single_class;
-
-	/**
-	 * CSS class for double-width punctuation marks.
-	 *
-	 * @deprecated 6.7.0
-	 *
-	 * @var string
-	 */
-	protected $pull_double_class;
 
 	/**
 	 * An array of replacment arrays (indexed by the "$block" flag).

--- a/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
+++ b/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
@@ -144,12 +144,15 @@ class Style_Hanging_Punctuation_Fix extends Classes_Dependent_Fix {
 	 * Apply the fix to a given textnode.
 	 *
 	 * @since 6.0.0 The method was accidentally made public and is now protected.
+	 * @since 7.0.0 All parameters are now required.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	protected function apply_internal( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	protected function apply_internal( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::STYLE_HANGING_PUNCTUATION ] ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-style-initial-quotes-fix.php
+++ b/src/fixes/node-fixes/class-style-initial-quotes-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2022 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -73,12 +73,15 @@ class Style_Initial_Quotes_Fix extends Classes_Dependent_Fix {
 	 * Apply the fix to a given textnode.
 	 *
 	 * @since 6.0.0 The method was accidentally made public and is now protected.
+	 * @since 7.0.0 All parameters are now required.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	protected function apply_internal( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	protected function apply_internal( \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::STYLE_INITIAL_QUOTES ] ) || empty( $settings[ Settings::INITIAL_QUOTE_TAGS ] ) || null !== DOM::get_previous_textnode( $textnode ) ) {
 			return;
 		}

--- a/src/fixes/node-fixes/class-unit-spacing-fix.php
+++ b/src/fixes/node-fixes/class-unit-spacing-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2014-2022 Peter Putzer.
+ *  Copyright 2014-2024 Peter Putzer.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -86,11 +86,15 @@ class Unit_Spacing_Fix extends Simple_Regex_Replacement_Fix {
 	/**
 	 * Apply the fix to a given textnode.
 	 *
-	 * @param \DOMText $textnode Required.
-	 * @param Settings $settings Required.
-	 * @param bool     $is_title Optional. Default false.
+	 * @since 7.0.0 All parameters are now required.
+	 *
+	 * @param \DOMText $textnode The DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return void
 	 */
-	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
+	public function apply( \DOMText $textnode, Settings $settings, $is_title ) {
 		// Update regex with custom units.
 		$this->regex = "/(\d\.?)\s({$settings->custom_units()}" . self::STANDARD_UNITS . ')' . self::WORD_BOUNDARY . '/Sxu';
 

--- a/src/fixes/token-fixes/class-abstract-token-fix.php
+++ b/src/fixes/token-fixes/class-abstract-token-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -65,16 +65,18 @@ abstract class Abstract_Token_Fix implements Token_Fix {
 	}
 
 	/**
-	 * Apply the tweak to a given textnode.
+	 * Apply the fix to a given set of tokens
 	 *
-	 * @param Token[]       $tokens   Required.
-	 * @param Settings      $settings Required.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param \DOMText|null $textnode Optional. Default null.
+	 * @since 7.0.0 The parameter order has been re-arranged to mirror Node_Fix.
 	 *
-	 * @return Token[] An array of tokens.
+	 * @param Token[]  $tokens   The set of tokens.
+	 * @param \DOMText $textnode The context DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return Token[]           The fixed set of tokens.
 	 */
-	abstract public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null );
+	abstract public function apply( array $tokens, \DOMText $textnode, Settings $settings, $is_title );
 
 	/**
 	 * Determines whether the fix should be applied to (RSS) feeds.

--- a/src/fixes/token-fixes/class-hyphenate-compounds-fix.php
+++ b/src/fixes/token-fixes/class-hyphenate-compounds-fix.php
@@ -54,16 +54,18 @@ class Hyphenate_Compounds_Fix extends Hyphenate_Fix {
 	}
 
 	/**
-	 * Apply the tweak to a given textnode.
+	 * Apply the fix to a given set of tokens
 	 *
-	 * @param Token[]       $tokens   Required.
-	 * @param Settings      $settings Required.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param \DOMText|null $textnode Optional. Default null.
+	 * @since 7.0.0 The parameter order has been re-arranged to mirror Node_Fix.
 	 *
-	 * @return Token[] An array of tokens.
+	 * @param Token[]  $tokens   The set of tokens.
+	 * @param \DOMText $textnode The context DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return Token[]           The fixed set of tokens.
 	 */
-	public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null ) {
+	public function apply( array $tokens, \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::HYPHENATE_COMPOUNDS ] ) ) {
 			return $tokens; // abort.
 		}
@@ -78,7 +80,7 @@ class Hyphenate_Compounds_Fix extends Hyphenate_Fix {
 
 			$tokens[ $key ] = $word_token->with_value(
 				\array_reduce(
-					parent::apply( $component_words, $settings, $is_title, $textnode ),
+					parent::apply( $component_words, $textnode, $settings, $is_title ),
 					function ( ?string $carry, Token $item ): string {
 						return $carry . $item->value;
 					},

--- a/src/fixes/token-fixes/class-hyphenate-fix.php
+++ b/src/fixes/token-fixes/class-hyphenate-fix.php
@@ -81,22 +81,24 @@ class Hyphenate_Fix extends Abstract_Token_Fix {
 	}
 
 	/**
-	 * Apply the tweak to a given textnode.
+	 * Apply the fix to a given set of tokens
 	 *
-	 * @param Token[]       $tokens   Required.
-	 * @param Settings      $settings Required.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param \DOMText|null $textnode Optional. Default null.
+	 * @since 7.0.0 The parameter order has been re-arranged to mirror Node_Fix.
 	 *
-	 * @return Token[] An array of tokens.
+	 * @param Token[]  $tokens   The set of tokens.
+	 * @param \DOMText $textnode The context DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return Token[]           The fixed set of tokens.
 	 */
-	public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null ) {
+	public function apply( array $tokens, \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::HYPHENATION ] ) ) {
 			return $tokens; // abort.
 		}
 
 		$is_heading = false;
-		if ( null !== $textnode && ! empty( $textnode->parentNode ) ) {
+		if ( ! empty( $textnode->parentNode ) ) {
 			$block_level_parent = DOM::get_block_parent_name( $textnode );
 
 			if ( ! empty( $block_level_parent ) && isset( $this->heading_tags[ $block_level_parent ] ) ) {

--- a/src/fixes/token-fixes/class-smart-dashes-hyphen-fix.php
+++ b/src/fixes/token-fixes/class-smart-dashes-hyphen-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2018 Peter Putzer.
+ *  Copyright 2018-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -50,16 +50,18 @@ class Smart_Dashes_Hyphen_Fix extends Abstract_Token_Fix {
 	}
 
 	/**
-	 * Apply the tweak to a given textnode.
+	 * Apply the fix to a given set of tokens
 	 *
-	 * @param Token[]       $tokens   Required.
-	 * @param Settings      $settings Required.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param \DOMText|null $textnode Optional. Default null.
+	 * @since 7.0.0 The parameter order has been re-arranged to mirror Node_Fix.
 	 *
-	 * @return Token[] An array of tokens.
+	 * @param Token[]  $tokens   The set of tokens.
+	 * @param \DOMText $textnode The context DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return Token[]           The fixed set of tokens.
 	 */
-	public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null ) {
+	public function apply( array $tokens, \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( ! empty( $settings[ Settings::SMART_DASHES ] ) ) {
 			foreach ( $tokens as $index => $text_token ) {
 				// Handled here because we need to know we are inside a word and not a URL.

--- a/src/fixes/token-fixes/class-wrap-emails-fix.php
+++ b/src/fixes/token-fixes/class-wrap-emails-fix.php
@@ -78,16 +78,18 @@ class Wrap_Emails_Fix extends Abstract_Token_Fix {
 	}
 
 	/**
-	 * Apply the tweak to a given textnode.
+	 * Apply the fix to a given set of tokens
 	 *
-	 * @param Token[]       $tokens   Required.
-	 * @param Settings      $settings Required.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param \DOMText|null $textnode Optional. Default null.
+	 * @since 7.0.0 The parameter order has been re-arranged to mirror Node_Fix.
 	 *
-	 * @return Token[] An array of tokens.
+	 * @param Token[]  $tokens   The set of tokens.
+	 * @param \DOMText $textnode The context DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return Token[]           The fixed set of tokens.
 	 */
-	public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null ) {
+	public function apply( array $tokens, \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::EMAIL_WRAP ] ) ) {
 			return $tokens;
 		}

--- a/src/fixes/token-fixes/class-wrap-hard-hyphens-fix.php
+++ b/src/fixes/token-fixes/class-wrap-hard-hyphens-fix.php
@@ -67,16 +67,18 @@ class Wrap_Hard_Hyphens_Fix extends Abstract_Token_Fix {
 	}
 
 	/**
-	 * Apply the tweak to a given textnode.
+	 * Apply the fix to a given set of tokens
 	 *
-	 * @param Token[]       $tokens   Required.
-	 * @param Settings      $settings Required.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param \DOMText|null $textnode Optional. Default null.
+	 * @since 7.0.0 The parameter order has been re-arranged to mirror Node_Fix.
 	 *
-	 * @return Token[] An array of tokens.
+	 * @param Token[]  $tokens   The set of tokens.
+	 * @param \DOMText $textnode The context DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return Token[]           The fixed set of tokens.
 	 */
-	public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null ) {
+	public function apply( array $tokens, \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( ! empty( $settings[ Settings::HYPHEN_HARD_WRAP ] ) ) {
 
 			foreach ( $tokens as $index => $text_token ) {

--- a/src/fixes/token-fixes/class-wrap-urls-fix.php
+++ b/src/fixes/token-fixes/class-wrap-urls-fix.php
@@ -98,16 +98,18 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 	}
 
 	/**
-	 * Apply the tweak to a given textnode.
+	 * Apply the fix to a given set of tokens
 	 *
-	 * @param Token[]       $tokens   Required.
-	 * @param Settings      $settings The settings to apply.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param \DOMText|null $textnode Optional. Default null.
+	 * @since 7.0.0 The parameter order has been re-arranged to mirror Node_Fix.
 	 *
-	 * @return Token[] An array of tokens.
+	 * @param Token[]  $tokens   The set of tokens.
+	 * @param \DOMText $textnode The context DOM node.
+	 * @param Settings $settings The settings to apply.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 *
+	 * @return Token[]           The fixed set of tokens.
 	 */
-	public function apply( array $tokens, Settings $settings, $is_title = false, \DOMText $textnode = null ) {
+	public function apply( array $tokens, \DOMText $textnode, Settings $settings, $is_title ) {
 		if ( empty( $settings[ Settings::URL_WRAP ] ) || empty( $settings[ Settings::URL_MIN_AFTER_WRAP ] ) ) {
 			return $tokens;
 		}

--- a/src/hyphenator/class-trie-node.php
+++ b/src/hyphenator/class-trie-node.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2022 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -110,7 +110,7 @@ final class Trie_Node {
 		foreach ( $patterns as $key => $pattern ) {
 			$node = $trie;
 
-			foreach ( Strings::mb_str_split( $key ) as $char ) {
+			foreach ( \mb_str_split( $key ) as $char ) {
 				$node = $node->get_node( $char );
 			}
 

--- a/src/settings/class-dash-style.php
+++ b/src/settings/class-dash-style.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2022 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -118,7 +118,7 @@ abstract class Dash_Style {
 	 * Creates a new Dashes object in the given style.
 	 *
 	 * @since 6.5.0 The $settings parameter has been deprecated.
-	 * @since 6.8.0 The unused $settings parameter has been removed.
+	 * @since 7.0.0 Deprecated parameter $settings removed.
 	 *
 	 * @param string $style The dash style.
 	 *

--- a/src/settings/class-quote-style.php
+++ b/src/settings/class-quote-style.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2022 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -144,7 +144,7 @@ abstract class Quote_Style {
 	 * Creates a new Quotes object in the given style.
 	 *
 	 * @since 6.5.0 The $settings parameter has been deprecated.
-	 * @since 6.8.0 The unused $settings parameter has been removed.
+	 * @since 7.0.0 Deprecated parameter $settings removed.
 	 *
 	 * @param string $style The quote style.
 	 *

--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2016-2022 Peter Putzer.
+ *  Copyright 2016-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -56,7 +56,6 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::__construct
 	 *
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::__construct
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
@@ -82,7 +81,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::__construct
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_set_language() {
 		$h = $this->h;
@@ -114,7 +112,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_set_language_with_custom_exceptions() {
 		$h = $this->h;
@@ -142,7 +139,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::__construct
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_set_same_hyphenation_language() {
 		$h = $this->h;
@@ -216,7 +212,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
 	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_set_custom_exceptions_again() {
 		$h          = $this->h;
@@ -280,7 +275,6 @@ class Hyphenator_Test extends Testcase {
 	 *
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 * @uses PHP_Typography\Strings::functions
 	 *
 	 * @dataProvider provide_hyphenate_data
@@ -323,7 +317,6 @@ class Hyphenator_Test extends Testcase {
 	 *
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 * @uses PHP_Typography\Strings::functions
 	 *
 	 * @dataProvider provide_hyphenate_with_exceptions_data
@@ -352,7 +345,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_hyphenate_wrong_encoding() {
 		$this->h->set_language( 'de' );
@@ -376,7 +368,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_hyphenate_no_title_case() {
 		$this->h->set_language( 'de' );
@@ -396,7 +387,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_hyphenate_invalid() {
 		$this->h->set_language( 'de' );
@@ -414,7 +404,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_lookup_word_pattern_invalid_pattern_trie() {
 		$string = 'unknown';
@@ -435,7 +424,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_hyphenate_no_custom_exceptions() {
 		$this->h->set_language( 'en-US' );
@@ -457,7 +445,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 */
 	public function test_hyphenate_no_exceptions_at_all() {
 		$this->h->set_language( 'en-US' );
@@ -511,7 +498,6 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::merge_hyphenation_exceptions
 	 *
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_merge_hyphenation_exceptions() {

--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -24,6 +24,8 @@
 
 namespace PHP_Typography\Tests;
 
+use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
+
 /**
  * Test Hyphenator class.
  *
@@ -349,6 +351,7 @@ class Hyphenator_Test extends Testcase {
 	public function test_hyphenate_wrong_encoding() {
 		$this->h->set_language( 'de' );
 
+		$this->expect_exception( Invalid_Encoding_Exception::class );
 		$tokens     = $this->tokenize( mb_convert_encoding( 'Änderungsmeldung', 'ISO-8859-2' ) );
 		$hyphenated = $this->h->hyphenate( $tokens, '|', true, 2, 2, 2 );
 		$this->assert_tokens_same( $hyphenated, $tokens, 'Wrong encoding, value should be unchanged.' );
@@ -473,9 +476,8 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_convert_hyphenation_exception_to_pattern() {
-		$h = $this->h;
-		$this->assertSame( [ 4 => 9 ], $this->invoke_method( $h, 'convert_hyphenation_exception_to_pattern', [ 'KING-desk' ] ) );
-		$this->assertSame( [ 2 => 9 ], $this->invoke_method( $h, 'convert_hyphenation_exception_to_pattern', [ 'ta-ble' ] ) );
+		$this->assertSame( [ 4 => 9 ], $this->invoke_method( $this->h, 'convert_hyphenation_exception_to_pattern', [ 'KING-desk' ] ) );
+		$this->assertSame( [ 2 => 9 ], $this->invoke_method( $this->h, 'convert_hyphenation_exception_to_pattern', [ 'ta-ble' ] ) );
 	}
 
 	/**
@@ -486,10 +488,10 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_convert_hyphenation_exception_to_pattern_unknown_encoding() {
-		$h         = $this->h;
 		$exception = mb_convert_encoding( 'Fö-ba-ß' , 'ISO-8859-2' );
 
-		$this->assertNull( $this->invoke_method( $h, 'convert_hyphenation_exception_to_pattern', [ $exception ] ) );
+		$this->expect_exception( Invalid_Encoding_Exception::class );
+		$this->assertNull( $this->invoke_method( $this->h, 'convert_hyphenation_exception_to_pattern', [ $exception ] ) );
 	}
 
 	/**

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -601,6 +601,7 @@ class PHP_Typography_Test extends Testcase {
 	 * Test process_textnodes.
 	 *
 	 * @covers ::process_textnodes
+	 * @covers ::process_textnodes_internal
 	 *
 	 * @uses PHP_Typography\Hyphenator
 	 * @uses PHP_Typography\Hyphenator\Trie_Node

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -894,7 +894,7 @@ class PHP_Typography_Test extends Testcase {
 		$this->s->set_smart_quotes( true );
 		$this->s->set_smart_quotes_primary( $primary );
 		$this->s->set_smart_quotes_secondary( $secondary );
-		$this->s->set_true_no_break_narrow_space();
+		$this->s->remap_character( U::NO_BREAK_NARROW_SPACE, U::NO_BREAK_SPACE );
 
 		$this->assertSame( $result, $this->clean_html( $this->typo->process( $html, $this->s ) ) );
 	}
@@ -1358,7 +1358,7 @@ class PHP_Typography_Test extends Testcase {
 			]
 		);
 		$this->s->set_smart_fractions( true );
-		$this->s->set_true_no_break_narrow_space( true );
+		$this->s->remap_character( U::NO_BREAK_NARROW_SPACE, U::NO_BREAK_NARROW_SPACE );
 
 		$this->s->set_fraction_spacing( false );
 		$this->assertSame( $result, $this->clean_html( $typo->process( $input, $this->s ) ) );
@@ -1463,7 +1463,7 @@ class PHP_Typography_Test extends Testcase {
 		$this->s->set_smart_quotes( true );
 		$this->s->set_smart_quotes_primary();
 		$this->s->set_smart_quotes_secondary();
-		$this->s->set_true_no_break_narrow_space( true );
+		$this->s->remap_character( U::NO_BREAK_NARROW_SPACE, U::NO_BREAK_NARROW_SPACE );
 		$this->s->set_fraction_spacing( false );
 
 		$this->assertSame( $result, $this->clean_html( $typo->process( $input, $this->s ) ) );
@@ -1849,7 +1849,7 @@ class PHP_Typography_Test extends Testcase {
 	 */
 	public function test_unit_spacing( $input, $result ) {
 		$this->s->set_unit_spacing( true );
-		$this->s->set_true_no_break_narrow_space( true );
+		$this->s->remap_character( U::NO_BREAK_NARROW_SPACE, U::NO_BREAK_NARROW_SPACE );
 
 		$this->assertSame( $result, $this->clean_html( $this->typo->process( $input, $this->s ) ) );
 	}
@@ -1902,7 +1902,7 @@ class PHP_Typography_Test extends Testcase {
 	 */
 	public function test_unit_spacing_dewidow( $input, $result ) {
 		$this->s->set_unit_spacing( true );
-		$this->s->set_true_no_break_narrow_space( true );
+		$this->s->remap_character( U::NO_BREAK_NARROW_SPACE, U::NO_BREAK_NARROW_SPACE );
 		$this->s->set_dewidow( true );
 		$this->s->set_max_dewidow_pull( 10 );
 		$this->s->set_max_dewidow_length( 3 );
@@ -2016,7 +2016,7 @@ class PHP_Typography_Test extends Testcase {
 	 */
 	public function test_french_punctuation_spacing( $input, $result, $use_french_quotes ) {
 		$this->s->set_french_punctuation_spacing( true );
-		$this->s->set_true_no_break_narrow_space( true );
+		$this->s->remap_character( U::NO_BREAK_NARROW_SPACE, U::NO_BREAK_NARROW_SPACE );
 
 		if ( $use_french_quotes ) {
 			$this->s->set_smart_quotes_primary( 'doubleGuillemetsFrench' );

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -68,7 +68,6 @@ class Settings_Test extends Testcase {
 	 *
 	 * @covers ::set_defaults
 	 *
-	 * @uses ::array_map_assoc
 	 * @uses PHP_Typography\Settings\Dash_Style::get_styled_dashes
 	 * @uses PHP_Typography\Settings\Quote_Style::get_styled_quotes
 	 * @uses PHP_Typography\Strings::maybe_split_parameters
@@ -87,7 +86,6 @@ class Settings_Test extends Testcase {
 	 * @covers ::__construct
 	 *
 	 * @uses ::set_defaults
-	 * @uses ::array_map_assoc
 	 * @uses PHP_Typography\Settings\Dash_Style::get_styled_dashes
 	 * @uses PHP_Typography\Settings\Quote_Style::get_styled_quotes
 	 * @uses PHP_Typography\Strings::maybe_split_parameters
@@ -795,8 +793,6 @@ class Settings_Test extends Testcase {
 	 * @covers ::parse_diacritics_replacement_string
 	 * @covers ::update_diacritics_replacement_arrays
 	 * @covers ::parse_diacritics_rules
-	 *
-	 * @uses ::array_map_assoc
 	 *
 	 * @dataProvider provide_set_diacritic_custom_replacements_data
 	 *
@@ -1620,47 +1616,5 @@ class Settings_Test extends Testcase {
 		$s = new Settings( false, $mapping );
 
 		$this->assertSame( $result, $s->apply_character_mapping( $input ) );
-	}
-
-	/**
-	 * Provide data for testing array_map_assoc.
-	 *
-	 * @return array
-	 */
-	public function provide_array_map_assoc_data() {
-		return [
-			[
-				function ( $key, $value ) {
-						return [ $value => $value * 2 ];
-				},
-				[ 1, 2, 3 ],
-				[
-					1 => 2,
-					2 => 4,
-					3 => 6,
-				],
-			],
-			[
-				function ( $key, $value ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- callable signature.
-						return [];
-				},
-				[ 1, 2, 3 ],
-				[],
-			],
-		];
-	}
-
-	/**
-	 * Test array_map_assoc.
-	 *
-	 * @covers ::array_map_assoc
-	 * @dataProvider provide_array_map_assoc_data
-	 *
-	 * @param  callable $callable The function to apply to the array.
-	 * @param  array    $array    Input array.
-	 * @param  array    $result   Expected output array.
-	 */
-	public function test_array_map_assoc( callable $callable, array $array, array $result ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames -- test for deprecated method.
-		$this->assertSame( $result, $this->invoke_static_method( Settings::class, 'array_map_assoc', [ $callable, $array ] ) );
 	}
 }

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -60,7 +60,7 @@ class Settings_Test extends Testcase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->settings = new \PHP_Typography\Settings( false );
+		$this->settings = new \PHP_Typography\Settings( false, [] );
 	}
 
 	/**
@@ -436,12 +436,10 @@ class Settings_Test extends Testcase {
 	 * @covers ::get_quote_style
 	 * @covers ::get_style
 	 *
-	 * @uses ::set_true_no_break_narrow_space
 	 * @uses PHP_Typography\Settings\Quote_Style::get_styled_quotes
 	 */
 	public function test_set_smart_quotes_primary() {
 		$s = $this->settings;
-		$s->set_true_no_break_narrow_space();
 
 		$quote_styles = [
 			'doubleCurled',
@@ -514,12 +512,10 @@ class Settings_Test extends Testcase {
 	 * @covers ::get_quote_style
 	 * @covers ::get_style
 	 *
-	 * @uses ::set_true_no_break_narrow_space
 	 * @uses PHP_Typography\Settings\Quote_Style::get_styled_quotes
 	 */
 	public function test_set_smart_quotes_secondary() {
 		$s = $this->settings;
-		$s->set_true_no_break_narrow_space();
 
 		$quote_styles = [
 			'doubleCurled',
@@ -1552,7 +1548,7 @@ class Settings_Test extends Testcase {
 		$hash5 = $s->get_hash( 10 );
 		$this->assertEquals( 10, strlen( $hash5 ) );
 
-		$s->set_true_no_break_narrow_space( true );
+		$s->remap_character( U::NO_BREAK_NARROW_SPACE, U::NO_BREAK_SPACE );
 		$hash6 = $s->get_hash( 10 );
 		$this->assertEquals( 10, strlen( $hash6 ) );
 
@@ -1564,24 +1560,8 @@ class Settings_Test extends Testcase {
 		$this->assertNotEquals( $hash2, $hash3, 'Hashes after set_smart_quotes_primary are still equal.' );
 		$this->assertNotEquals( $hash3, $hash4, 'Hashes after set_smart_quotes_secondary are still equal.' );
 		$this->assertNotEquals( $hash4, $hash5, 'Hashes after set_smart_dashes_style are still equal.' );
-		$this->assertNotEquals( $hash5, $hash6, 'Hashes after set_true_no_break_narrow_space are still equal.' );
+		$this->assertNotEquals( $hash5, $hash6, 'Hashes after remapping no-break narrow space are still equal.' );
 		$this->assertNotEquals( $hash6, $hash7, 'Hashes after set_units are still equal.' );
-	}
-
-	/**
-	 * Tests set_true_no_break_narrow_space and no_break_narrow_space.
-	 *
-	 * @covers ::set_true_no_break_narrow_space
-	 * @covers ::no_break_narrow_space
-	 */
-	public function test_set_true_no_break_narrow_space() {
-		$s = $this->settings;
-
-		$s->set_true_no_break_narrow_space(); // defaults to false.
-		$this->assertSame( $s->no_break_narrow_space(), U::NO_BREAK_SPACE );
-
-		$s->set_true_no_break_narrow_space( true ); // defaults to false.
-		$this->assertSame( $s->no_break_narrow_space(), U::NO_BREAK_NARROW_SPACE );
 	}
 
 	/**
@@ -1604,7 +1584,6 @@ class Settings_Test extends Testcase {
 		$s->remap_character( U::NO_BREAK_NARROW_SPACE, 'x' );
 		$this->assert_attribute_count( 2, 'unicode_mapping', $s );
 		$this->assert_attribute_contains( 'x', 'unicode_mapping', $s );
-		$this->assert_attribute_same( 'x', 'no_break_narrow_space', $s );
 	}
 
 

--- a/tests/class-strings-test.php
+++ b/tests/class-strings-test.php
@@ -24,6 +24,7 @@
 
 namespace PHP_Typography\Tests;
 
+use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 use PHP_Typography\Strings;
 
 /**
@@ -80,10 +81,9 @@ class Strings_Test extends Testcase {
 	 * @covers ::functions
 	 */
 	public function test_functions_invalid_encoding() {
-		$func = Strings::functions( \mb_convert_encoding( 'Ungültiges Encoding', 'ISO-8859-2' ) );
+		$this->expect_exception( Invalid_Encoding_Exception::class );
 
-		$this->assertTrue( \is_array( $func ) );
-		$this->assertCount( 0, $func );
+		$this->assertEmpty( Strings::functions( \mb_convert_encoding( 'Ungültiges Encoding', 'ISO-8859-2' ) ) );
 	}
 
 	/**

--- a/tests/class-strings-test.php
+++ b/tests/class-strings-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2022 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -143,36 +143,6 @@ class Strings_Test extends Testcase {
 	public function test_uchr_multi( $input, $result ) {
 		$this->assertSame( $result, call_user_func_array( [ 'PHP_Typography\Strings', 'uchr' ], $input ) );
 		$this->assertSame( $result, Strings::uchr( $input ) );
-	}
-
-	/**
-	 * Provide data for testing mb_str_split.
-	 *
-	 * @return array
-	 */
-	public function provide_mb_str_split_data() {
-		return [
-			[ '', 1, [] ],
-			[ 'A ship', 1, [ 'A', ' ', 's', 'h', 'i', 'p' ] ],
-			[ 'Äöüß', 1, [ 'Ä', 'ö', 'ü', 'ß' ] ],
-			[ 'Äöüß', 2, [ 'Äö', 'üß' ] ],
-			[ '那是杂志吗', 2, [ '那是', '杂志', '吗' ] ],
-			[ '不，那不是杂志。那是字典', 3, [ '不，那', '不是杂', '志。那', '是字典' ] ],
-		];
-	}
-
-	/**
-	 * Test mb_str_split.
-	 *
-	 * @covers ::mb_str_split
-	 * @dataProvider provide_mb_str_split_data
-	 *
-	 * @param  string $string   A multibyte string.
-	 * @param  int    $length   Split length.
-	 * @param  array  $result   Expected result.
-	 */
-	public function test_mb_str_split( $string, $length, $result ) {
-		$this->assertSame( $result, Strings::mb_str_split( $string, $length ) );
 	}
 
 	/**

--- a/tests/class-strings-test.php
+++ b/tests/class-strings-test.php
@@ -87,65 +87,6 @@ class Strings_Test extends Testcase {
 	}
 
 	/**
-	 * Provide data for testing uchr.
-	 *
-	 * @return array
-	 */
-	public function provide_uchr_data() {
-		return [
-			[ 33,   '!' ],
-			[ 9,    "\t" ],
-			[ 10,   "\n" ],
-			[ 35,   '#' ],
-			[ 103,  'g' ],
-			[ 336,  'Ő' ],
-			[ 497,  'Ǳ' ],
-			[ 1137, 'ѱ' ],
-			[ 2000, 'ߐ' ],
-		];
-	}
-
-	/**
-	 * Provide data for testing uchr.
-	 *
-	 * @return array
-	 */
-	public function provide_uchr_multi_data() {
-		return [
-			[ [ 33, 9, 103, 2000 ],   "!\tgߐ" ],
-		];
-	}
-
-	/**
-	 * Test uchr.
-	 *
-	 * @covers ::uchr
-	 *
-	 * @dataProvider provide_uchr_data
-	 *
-	 * @param  int    $code   Character code.
-	 * @param  string $result Expected result.
-	 */
-	public function test_uchr( $code, $result ) {
-		$this->assertSame( $result, Strings::uchr( $code ) );
-	}
-
-	/**
-	 * Test uchr.
-	 *
-	 * @covers ::uchr
-	 *
-	 * @dataProvider provide_uchr_multi_data
-	 *
-	 * @param  array  $input  Character codes.
-	 * @param  string $result Expected result.
-	 */
-	public function test_uchr_multi( $input, $result ) {
-		$this->assertSame( $result, call_user_func_array( [ 'PHP_Typography\Strings', 'uchr' ], $input ) );
-		$this->assertSame( $result, Strings::uchr( $input ) );
-	}
-
-	/**
 	 * Provide data for testing maybe_split_parameters.
 	 *
 	 * @return array

--- a/tests/class-text-parser-test.php
+++ b/tests/class-text-parser-test.php
@@ -88,9 +88,9 @@ class Text_Parser_Test extends Testcase {
 
 		$parser = $this->parser;
 
-		// Security check.
-		$this->assertFalse( $parser->load( $too_long ) );
-		$this->assertFalse( $parser->load( $still_too_long ) );
+		// Previously, we didn't allow really long strings, but this is unnecessary with PHP.
+		$this->assertTrue( $parser->load( $too_long ) );
+		$this->assertTrue( $parser->load( $still_too_long ) );
 		$this->assertTrue( $parser->load( $almost_too_long ) );
 
 		$interesting = 'Quoth the raven, "nevermore"! Äöüß?';
@@ -202,17 +202,6 @@ class Text_Parser_Test extends Testcase {
 
 		$this->expect_exception( Invalid_Encoding_Exception::class );
 		$this->assertFalse( $parser->load( $string ) );
-	}
-
-	/**
-	 * Test load with something that is not a string.
-	 *
-	 * @covers ::load
-	 */
-	public function test_load_not_a_string() {
-		$parser = $this->parser;
-
-		$this->assertFalse( $parser->load( [] ) );
 	}
 
 	/**

--- a/tests/class-text-parser-test.php
+++ b/tests/class-text-parser-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,6 +24,7 @@
 
 namespace PHP_Typography\Tests;
 
+use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 use PHP_Typography\Text_Parser\Token;
 use PHP_Typography\Text_Parser;
 
@@ -199,6 +200,7 @@ class Text_Parser_Test extends Testcase {
 		$string = mb_convert_encoding( 'Ein längerer String im falschen Zeichensatz', 'ISO-8859-2' );
 		$parser = $this->parser;
 
+		$this->expect_exception( Invalid_Encoding_Exception::class );
 		$this->assertFalse( $parser->load( $string ) );
 	}
 

--- a/tests/class-text-parser-test.php
+++ b/tests/class-text-parser-test.php
@@ -39,39 +39,11 @@ use PHP_Typography\Text_Parser;
  * @uses PHP_Typography\Strings::functions
  */
 class Text_Parser_Test extends Testcase {
-	/**
-	 * The Text_Parser fixture.
-	 *
-	 * @var Text_Parser
-	 */
-	protected $parser;
-
-	/**
-	 * Sets up the fixture, for example, opens a network connection.
-	 * This method is called before a test is executed.
-	 */
-	protected function set_up() {
-		parent::set_up();
-
-		$this->parser = new \PHP_Typography\Text_Parser();
-	}
-
-	/**
-	 * Test constructor.
-	 *
-	 * @covers ::__construct
-	 */
-	public function test_constructor() {
-		$parser = new Text_Parser();
-
-		$this->assert_attribute_count( 0, 'text', $parser );
-		$this->assert_attribute_same( 'strtoupper', 'current_strtoupper', $parser );
-	}
 
 	/**
 	 * Test load.
 	 *
-	 * @covers ::load
+	 * @covers ::__construct
 	 * @covers ::tokenize
 	 * @covers ::parse_ambiguous_token
 	 * @covers ::is_preceeded_by
@@ -80,21 +52,17 @@ class Text_Parser_Test extends Testcase {
 	 * @uses ::get_all
 	 */
 	public function test_load() {
-		$too_long = 'A really long string with a word that is wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwway too long.';
-
-		$still_too_long = 'A really long string with a word that is aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalmost too long.';
-
+		$too_long        = 'A really long string with a word that is wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwway too long.';
+		$still_too_long  = 'A really long string with a word that is aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalmost too long.';
 		$almost_too_long = 'A really long string with a word that is aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaalmost too long.';
 
-		$parser = $this->parser;
-
 		// Previously, we didn't allow really long strings, but this is unnecessary with PHP.
-		$this->assertTrue( $parser->load( $too_long ) );
-		$this->assertTrue( $parser->load( $still_too_long ) );
-		$this->assertTrue( $parser->load( $almost_too_long ) );
+		$this->assertInstanceOf( Text_Parser::class, new Text_Parser( $too_long ) );
+		$this->assertInstanceOf( Text_Parser::class, new Text_Parser( $still_too_long ) );
+		$this->assertInstanceOf( Text_Parser::class, new Text_Parser( $almost_too_long ) );
 
 		$interesting = 'Quoth the raven, "nevermore"! Äöüß?';
-		$this->assertTrue( $parser->load( $interesting ) );
+		$parser      = new Text_Parser( $interesting );
 
 		$tokens = $parser->get_all();
 
@@ -109,7 +77,7 @@ class Text_Parser_Test extends Testcase {
 	/**
 	 * Test load with email address.
 	 *
-	 * @covers ::load
+	 * @covers ::__construct
 	 * @covers ::tokenize
 	 * @covers ::parse_ambiguous_token
 	 * @covers ::is_preceeded_by
@@ -118,10 +86,8 @@ class Text_Parser_Test extends Testcase {
 	 * @uses ::get_all
 	 */
 	public function test_load_email() {
-		$parser = $this->parser;
-
 		$string = 'Quoth the raven, "nevermore"! Please mail to someone@example.org.';
-		$this->assertTrue( $parser->load( $string ) );
+		$parser = new Text_Parser( $string );
 
 		$tokens = $parser->get_all();
 		$this->assertCount( 19, $tokens );
@@ -136,7 +102,7 @@ class Text_Parser_Test extends Testcase {
 	/**
 	 * Test load with URL.
 	 *
-	 * @covers ::load
+	 * @covers ::__construct
 	 * @covers ::tokenize
 	 * @covers ::parse_ambiguous_token
 	 * @covers ::is_preceeded_by
@@ -145,10 +111,8 @@ class Text_Parser_Test extends Testcase {
 	 * @uses ::get_all
 	 */
 	public function test_load_url() {
-		$parser = $this->parser;
-
 		$string = 'Quoth the raven, "nevermore"! Please open http://example.org or foo:WordPress or foo:W@rdPress or @example or @:@:@:risk.';
-		$this->assertTrue( $parser->load( $string ) );
+		$parser = new Text_Parser( $string );
 
 		$tokens = $parser->get_all();
 		$this->assertCount( 33, $tokens );
@@ -167,7 +131,7 @@ class Text_Parser_Test extends Testcase {
 	/**
 	 * Test load with a compound word.
 	 *
-	 * @covers ::load
+	 * @covers ::__construct
 	 * @covers ::tokenize
 	 * @covers ::parse_ambiguous_token
 	 * @covers ::is_preceeded_by
@@ -176,10 +140,8 @@ class Text_Parser_Test extends Testcase {
 	 * @uses ::get_all
 	 */
 	public function test_load_compound_word() {
-		$parser = $this->parser;
-
 		$string = 'Some don\'t trust the captain-owner.';
-		$this->assertTrue( $parser->load( $string ) );
+		$parser = new Text_Parser( $string );
 
 		$tokens = $parser->get_all();
 		$this->assertCount( 10, $tokens );
@@ -194,94 +156,33 @@ class Text_Parser_Test extends Testcase {
 	/**
 	 * Test load with an invalid encoding.
 	 *
-	 * @covers ::load
+	 * @covers ::__construct
 	 */
 	public function test_load_invalid_encoding() {
 		$string = mb_convert_encoding( 'Ein längerer String im falschen Zeichensatz', 'ISO-8859-2' );
-		$parser = $this->parser;
 
 		$this->expect_exception( Invalid_Encoding_Exception::class );
-		$this->assertFalse( $parser->load( $string ) );
+		new Text_Parser( $string );
 	}
 
 	/**
-	 * Test reload.
+	 * Test get_text.
 	 *
-	 * @covers ::reload
+	 * @covers ::get_text
 	 *
-	 * @depends test_load
-	 * @uses ::clear
-	 * @uses ::get_all
 	 * @uses ::is_not_preceeded_by
 	 * @uses ::is_preceeded_by
-	 * @uses ::load
-	 * @uses ::parse_ambiguous_token
-	 * @uses ::tokenize
-	 * @uses ::unload
-	 * @uses ::update
-
-	 * @param \PHP_Typography\Text_Parser $parser The parser to use.
-	 */
-	public function test_reload( Text_Parser $parser ) {
-		// Parsed string: 'Quoth the raven, "nevermore"! Äöüß?'.
-		$tokens     = $parser->get_all();
-		$tokens[12] = $tokens[12]->with_value( '' ); // "?".
-		$tokens[11] = $tokens[11]->with_value( '' ); // "Äöüß".
-		$tokens[10] = $tokens[10]->with_value( '' ); // " ".
-		$tokens[9]  = $tokens[9]->with_value( $tokens[9]->value . '!' );
-		$parser->update( $tokens );
-
-		$this->assertTrue( $parser->reload() );
-		$this->assertSame( 'Quoth the raven, "nevermore"!!', $parser->unload() );
-
-		return $parser;
-	}
-
-	/**
-	 * Test unload.
-	 *
-	 * @covers ::unload
-	 *
-	 * @uses ::clear
-	 * @uses ::is_not_preceeded_by
-	 * @uses ::is_preceeded_by
-	 * @uses ::load
+	 * @uses ::__construct
 	 * @uses ::parse_ambiguous_token
 	 * @uses ::tokenize
 	 */
-	public function test_unload() {
+	public function test_get_text() {
 		$interesting = 'Quoth the raven, "nevermore"! Äöüß?';
-		$parser      = $this->parser;
+		$parser      = new Text_Parser( $interesting );
 
-		$this->assertTrue( $parser->load( $interesting ) );
-
-		$result = $parser->unload();
+		$result = $parser->get_text();
 
 		$this->assertSame( $interesting, $result );
-		$this->assertNotSame( $result, $parser->unload() ); // the parser is empty now.
-	}
-
-	/**
-	 * Test clear.
-	 *
-	 * @covers ::clear
-	 *
-	 * @uses ::get_all
-	 * @uses ::is_not_preceeded_by
-	 * @uses ::is_preceeded_by
-	 * @uses ::load
-	 * @uses ::parse_ambiguous_token
-	 * @uses ::tokenize
-	 */
-	public function test_clear() {
-		$parser      = $this->parser;
-		$interesting = 'Quoth the raven, "nevermore"!';
-
-		$this->assertTrue( $parser->load( $interesting ) );
-		$this->assertGreaterThan( 0, count( $parser->get_all() ) );
-
-		$parser->clear();
-		$this->assertCount( 0, $parser->get_all() );
 	}
 
 	/**
@@ -289,19 +190,17 @@ class Text_Parser_Test extends Testcase {
 	 *
 	 * @covers ::update
 	 *
-	 * @uses ::clear
 	 * @uses ::get_all
 	 * @uses ::is_not_preceeded_by
 	 * @uses ::is_preceeded_by
-	 * @uses ::load
+	 * @uses ::__construct
 	 * @uses ::parse_ambiguous_token
 	 * @uses ::tokenize
-	 * @uses ::unload
+	 * @uses ::get_text
 	 */
 	public function test_update() {
-		$parser      = $this->parser;
 		$interesting = 'Quoth the raven, "nevermore"! Äöüß?';
-		$this->assertTrue( $parser->load( $interesting ) );
+		$parser      = new Text_Parser( $interesting );
 
 		$tokens     = $parser->get_all();
 		$tokens[12] = $tokens[12]->with_value( '' ); // "?".
@@ -310,7 +209,7 @@ class Text_Parser_Test extends Testcase {
 		$tokens[9]  = $tokens[9]->with_value( $tokens[9]->value . '!' );
 		$parser->update( $tokens );
 
-		$this->assertSame( 'Quoth the raven, "nevermore"!!', $parser->unload() );
+		$this->assertSame( 'Quoth the raven, "nevermore"!!', $parser->get_text() );
 
 		return $parser;
 	}
@@ -320,7 +219,7 @@ class Text_Parser_Test extends Testcase {
 	 *
 	 * @covers ::get_all
 	 *
-	 * @uses ::load
+	 * @uses ::__construct
 	 * @uses ::is_not_preceeded_by
 	 * @uses ::is_preceeded_by
 	 * @uses ::parse_ambiguous_token
@@ -328,8 +227,7 @@ class Text_Parser_Test extends Testcase {
 	 */
 	public function test_get_all() {
 		$interesting = 'Quoth the raven, "nevermore"!';
-		$parser      = $this->parser;
-		$this->assertTrue( $parser->load( $interesting ) );
+		$parser      = new Text_Parser( $interesting );
 
 		$tokens = $parser->get_all();
 		$this->assertCount( 10, $tokens );
@@ -383,7 +281,6 @@ class Text_Parser_Test extends Testcase {
 	 * @uses ::check_policy
 	 * @uses ::get_type
 	 * @uses ::is_preceeded_by
-	 * @uses ::load
 	 * @uses ::parse_ambiguous_token
 	 * @uses ::tokenize
 	 *
@@ -393,7 +290,7 @@ class Text_Parser_Test extends Testcase {
 		$tokens = $parser->get_words();
 		$this->assertCount( 4, $tokens );
 
-		$parser->load( 'A few m1xed W0RDS.' );
+		$parser = new Text_Parser( 'A few m1xed W0RDS.' );
 		$tokens = $parser->get_words( Text_Parser::REQUIRE_ALL_LETTERS, Text_Parser::NO_ALL_CAPS );
 		$this->assertCount( 1, $tokens );
 		$this->assert_contains_equals( new Token( 'few', Token::WORD ), $tokens, '' );
@@ -468,7 +365,7 @@ class Text_Parser_Test extends Testcase {
 	 * @covers ::check_policy
 	 * @dataProvider provide_conforms_to_letters_policy_data
 	 *
-	 * @uses ::load
+	 * @uses ::__construct
 	 * @uses ::is_preceeded_by
 	 * @uses ::parse_ambiguous_token
 	 * @uses ::tokenize
@@ -479,7 +376,8 @@ class Text_Parser_Test extends Testcase {
 	 * @param bool   $result Expected result.
 	 */
 	public function test_conforms_to_letters_policy( $value, $type, $policy, $result ) {
-		$parser = $this->parser;
+		// Ensure that encoding can be determined.
+		$parser = new Text_Parser( $value );
 		$token  = new Token( $value, $type );
 
 		$this->assertSame( $result, $this->invoke_method( $parser, 'conforms_to_letters_policy', [ $token, $policy ] ) );
@@ -515,7 +413,7 @@ class Text_Parser_Test extends Testcase {
 	 * @covers ::check_policy
 	 * @dataProvider provide_conforms_to_caps_policy_data
 	 *
-	 * @uses ::load
+	 * @uses ::__construct
 	 * @uses ::is_preceeded_by
 	 * @uses ::parse_ambiguous_token
 	 * @uses ::tokenize
@@ -526,10 +424,9 @@ class Text_Parser_Test extends Testcase {
 	 * @param bool   $result Expected result.
 	 */
 	public function test_conforms_to_caps_policy( $value, $type, $policy, $result ) {
-		$parser = $this->parser;
-		$parser->load( $value ); // Ensure that encoding can be determined.
-
-		$token = new Token( $value, $type );
+		// Ensure that encoding can be determined.
+		$parser = new Text_Parser( $value );
+		$token  = new Token( $value, $type );
 
 		$this->assertSame( $result, $this->invoke_method( $parser, 'conforms_to_caps_policy', [ $token, $policy ] ) );
 	}
@@ -564,7 +461,7 @@ class Text_Parser_Test extends Testcase {
 	 * @covers ::check_policy
 	 * @dataProvider provide_conforms_to_compounds_policy
 	 *
-	 * @uses ::load
+	 * @uses ::__construct
 	 * @uses ::is_preceeded_by
 	 * @uses ::parse_ambiguous_token
 	 * @uses ::tokenize
@@ -575,38 +472,11 @@ class Text_Parser_Test extends Testcase {
 	 * @param bool   $result Expected result.
 	 */
 	public function test_conforms_to_compounds_policy( $value, $type, $policy, $result ) {
-		$parser = $this->parser;
-		$parser->load( $value ); // Ensure that encoding can be determined.
-
-		$token = new Token( $value, $type );
+		// Ensure that encoding can be determined.
+		$parser = new Text_Parser( $value );
+		$token  = new Token( $value, $type );
 
 		$this->assertSame( $result, $this->invoke_method( $parser, 'conforms_to_compounds_policy', [ $token, $policy ] ) );
-	}
-
-	/**
-	 * Test get_words.
-	 *
-	 * @covers ::get_words
-	 * @depends test_get_all
-	 *
-	 * @uses ::clear
-	 * @uses ::is_preceeded_by
-	 * @uses ::load
-	 * @uses ::parse_ambiguous_token
-	 * @uses ::tokenize
-	 * @uses ::unload
-	 *
-	 * @param \PHP_Typography\Text_Parser $parser The parser to use.
-	 */
-	public function test_get_words_unloaded( Text_Parser $parser ) {
-		$parser->load( 'A few m1xed W0RDS.' );
-		$parser->unload();
-
-		$tokens = $parser->get_words( Text_Parser::REQUIRE_ALL_LETTERS, Text_Parser::NO_ALL_CAPS );
-		$this->assertCount( 0, $tokens );
-		$this->assertSame( [], $tokens );
-
-		return $parser;
 	}
 
 	/**
@@ -630,18 +500,15 @@ class Text_Parser_Test extends Testcase {
 	 * Test get_type.
 	 *
 	 * @covers ::get_type
-	 * @depends test_get_all
 	 *
 	 * @uses ::get_all
 	 * @uses ::is_preceeded_by
-	 * @uses ::load
+	 * @uses ::__construct
 	 * @uses ::parse_ambiguous_token
 	 * @uses ::tokenize
-	 *
-	 * @param \PHP_Typography\Text_Parser $parser The parser to use.
 	 */
-	public function test_get_type( Text_Parser $parser ) {
-		$parser->load( 'A few m1xed W0RDS.' );
+	public function test_get_type() {
+		$parser = new Text_Parser( 'A few m1xed W0RDS.' );
 
 		$words  = [];
 		$tokens = $parser->get_all();

--- a/tests/fixes/node-fixes/class-dewidow-fix-test.php
+++ b/tests/fixes/node-fixes/class-dewidow-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -61,34 +61,34 @@ class Dewidow_Fix_Test extends Node_Fix_Testcase {
 	 */
 	public function provide_dewidow_data() {
 		return [
-			[ 'bla foo b', 'bla foo&nbsp;b', 3, 2, 1, false ],
-			[ 'bla foo&thinsp;b', 'bla foo&thinsp;b', 3, 2, 1, false ], // don't replace thin space...
-			[ 'bla foo&#8202;b', 'bla foo&#8202;b', 3, 2, 1, false ],   // ... or hair space.
-			[ 'bla foo bar', 'bla foo bar', 2, 2, 1, false ],
-			[ 'bla foo bär...', 'bla foo&nbsp;b&auml;r...', 3, 3, 1, false ],
-			[ 'bla foo bär&hellip;!', 'bla foo&nbsp;b&auml;r&hellip;!', 3, 3, 1, false ],
-			[ 'bla foo bär&shy;!', 'bla foo&nbsp;b&auml;r!', 3, 3, 1, false ],
-			[ 'bla foo b&shy;är!', 'bla foo&nbsp;b&auml;r!', 3, 3, 1, false ],
-			[ 'bla foo b&#8203;är!', 'bla foo&nbsp;b&auml;r!', 3, 3, 1, false ],
-			[ 'bla foo&nbsp;bär...', 'bla foo&nbsp;b&auml;r...', 3, 3, 1, false ],
-			[ 'bla föö&#8203;bar s', 'bla f&ouml;&ouml;&#8203;bar&nbsp;s', 3, 2, 1, false ],
-			[ 'bla foo&#8203;bar s', 'bla foo&#8203;bar s', 2, 2, 1, false ],
-			[ 'bla foo&shy;bar', 'bla foo&shy;bar', 3, 3, 1, false ], // &shy; not matched.
-			[ 'bla foo&shy;bar bar', 'bla foo&shy;bar&nbsp;bar', 3, 3, 1, false ], // &shy; not matched, but syllable after is.
-			[ 'bla foo&#8203;bar bar', 'bla foo&#8203;bar&nbsp;bar', 3, 3, 1, false ],
-			[ 'bla foo&nbsp;bar bar', 'bla foo&nbsp;bar bar', 3, 3, 1, false ], // widow not replaced because the &nbsp; would pull too many letters from previous.
-			[ 'bla foo bar bar', 'bla foo bar&nbsp;bar', 3, 3, 1, false ],
-			[ 'bla foo bar bar', 'bla foo bar&nbsp;bar', 3, 3, 2, false ],
-			[ 'bla foo bar bar', 'bla foo bar&nbsp;bar', 3, 3, 3, false ],
-			[ 'bla foo bar bar', 'bla foo bar&nbsp;bar', 3, 7, 1, false ],
-			[ 'bla foo bar bar', 'bla foo&nbsp;bar&nbsp;bar', 3, 7, 2, false ],
-			[ 'bla foo bar bar', 'bla foo&nbsp;bar&nbsp;bar', 3, 7, 3, false ],
-			[ 'bla bla foo bar bar', 'bla bla foo bar&nbsp;bar', 3, 11, 1, false ],
-			[ 'bla bla foo bar bar', 'bla bla foo&nbsp;bar&nbsp;bar', 3, 11, 2, false ],
-			[ 'bla bla foo bar bar', 'bla bla&nbsp;foo&nbsp;bar&nbsp;bar', 3, 11, 3, false ],
-			[ 'bla bla foo bar bar', 'bla bla foo&nbsp;bar&nbsp;bar', 3, 11, 2, true ],
-			[ 'bla bla foo bar&thinsp;bar', 'bla bla foo&nbsp;bar&#8239;bar', 3, 11, 2, true ],
-			[ 'bla bla foo bar&#8239;bar', 'bla bla foo&nbsp;bar&#8239;bar', 3, 11, 2, true ],
+			[ 'bla foo b', 'bla foo&nbsp;b', 3, 2, 1 ],
+			[ 'bla foo&thinsp;b', 'bla foo&thinsp;b', 3, 2, 1 ], // don't replace thin space...
+			[ 'bla foo&#8202;b', 'bla foo&#8202;b', 3, 2, 1 ],   // ... or hair space.
+			[ 'bla foo bar', 'bla foo bar', 2, 2, 1 ],
+			[ 'bla foo bär...', 'bla foo&nbsp;b&auml;r...', 3, 3, 1 ],
+			[ 'bla foo bär&hellip;!', 'bla foo&nbsp;b&auml;r&hellip;!', 3, 3, 1 ],
+			[ 'bla foo bär&shy;!', 'bla foo&nbsp;b&auml;r!', 3, 3, 1 ],
+			[ 'bla foo b&shy;är!', 'bla foo&nbsp;b&auml;r!', 3, 3, 1 ],
+			[ 'bla foo b&#8203;är!', 'bla foo&nbsp;b&auml;r!', 3, 3, 1 ],
+			[ 'bla foo&nbsp;bär...', 'bla foo&nbsp;b&auml;r...', 3, 3, 1 ],
+			[ 'bla föö&#8203;bar s', 'bla f&ouml;&ouml;&#8203;bar&nbsp;s', 3, 2, 1 ],
+			[ 'bla foo&#8203;bar s', 'bla foo&#8203;bar s', 2, 2, 1 ],
+			[ 'bla foo&shy;bar', 'bla foo&shy;bar', 3, 3, 1 ], // &shy; not matched.
+			[ 'bla foo&shy;bar bar', 'bla foo&shy;bar&nbsp;bar', 3, 3, 1 ], // &shy; not matched, but syllable after is.
+			[ 'bla foo&#8203;bar bar', 'bla foo&#8203;bar&nbsp;bar', 3, 3, 1 ],
+			[ 'bla foo&nbsp;bar bar', 'bla foo&nbsp;bar bar', 3, 3, 1 ], // widow not replaced because the &nbsp; would pull too many letters from previous.
+			[ 'bla foo bar bar', 'bla foo bar&nbsp;bar', 3, 3, 1 ],
+			[ 'bla foo bar bar', 'bla foo bar&nbsp;bar', 3, 3, 2 ],
+			[ 'bla foo bar bar', 'bla foo bar&nbsp;bar', 3, 3, 3 ],
+			[ 'bla foo bar bar', 'bla foo bar&nbsp;bar', 3, 7, 1 ],
+			[ 'bla foo bar bar', 'bla foo&nbsp;bar&nbsp;bar', 3, 7, 2 ],
+			[ 'bla foo bar bar', 'bla foo&nbsp;bar&nbsp;bar', 3, 7, 3 ],
+			[ 'bla bla foo bar bar', 'bla bla foo bar&nbsp;bar', 3, 11, 1 ],
+			[ 'bla bla foo bar bar', 'bla bla foo&nbsp;bar&nbsp;bar', 3, 11, 2 ],
+			[ 'bla bla foo bar bar', 'bla bla&nbsp;foo&nbsp;bar&nbsp;bar', 3, 11, 3 ],
+			[ 'bla bla foo bar bar', 'bla bla foo&nbsp;bar&nbsp;bar', 3, 11, 2 ],
+			[ 'bla bla foo bar&thinsp;bar', 'bla bla foo&nbsp;bar&#8239;bar', 3, 11, 2 ],
+			[ 'bla bla foo bar&#8239;bar', 'bla bla foo&nbsp;bar&#8239;bar', 3, 11, 2 ],
 		];
 	}
 
@@ -109,14 +109,12 @@ class Dewidow_Fix_Test extends Node_Fix_Testcase {
 	 * @param int    $max_pull     Maximum number of pulled characters.
 	 * @param int    $max_length   Maximum word length for dewidowing.
 	 * @param int    $word_number  Maximum number of words in widow.
-	 * @param bool   $narrow_space Whether to use the NARROW NO-BREAK SPACE character.
 	 */
-	public function test_apply( $html, $result, $max_pull, $max_length, $word_number, $narrow_space ) {
+	public function test_apply( $html, $result, $max_pull, $max_length, $word_number ) {
 		$this->s->set_dewidow( true );
 		$this->s->set_max_dewidow_pull( $max_pull );
 		$this->s->set_max_dewidow_length( $max_length );
 		$this->s->set_dewidow_word_number( $word_number );
-		$this->s->set_true_no_break_narrow_space( $narrow_space );
 
 		$this->assertFixResultSame( $html, $result );
 	}
@@ -165,7 +163,7 @@ class Dewidow_Fix_Test extends Node_Fix_Testcase {
 	 * @covers ::make_space_nonbreaking
 	 */
 	public function test_make_space_nonbreaking() {
-		$result = $this->invoke_static_method( Dewidow_Fix::class, 'make_space_nonbreaking', [ 'foo' . U::SOFT_HYPHEN . 'bar ' . U::ZERO_WIDTH_SPACE . ' baz' . U::ZERO_WIDTH_SPACE, U::NO_BREAK_SPACE, 'u' ] );
+		$result = $this->invoke_static_method( Dewidow_Fix::class, 'make_space_nonbreaking', [ 'foo' . U::SOFT_HYPHEN . 'bar ' . U::ZERO_WIDTH_SPACE . ' baz' . U::ZERO_WIDTH_SPACE, 'u' ] );
 
 		$this->assertSame( 'foo' . U::SOFT_HYPHEN . 'bar' . U::NO_BREAK_SPACE . U::ZERO_WIDTH_SPACE . U::NO_BREAK_SPACE . 'baz' . U::ZERO_WIDTH_SPACE, $result );
 	}

--- a/tests/fixes/node-fixes/class-french-punctuation-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-french-punctuation-spacing-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -107,7 +107,6 @@ class French_Punctuation_Spacing_Fix_Test extends Node_Fix_Testcase {
 	 */
 	public function test_apply( $input, $result ) {
 		$this->s->set_french_punctuation_spacing( true );
-		$this->s->set_true_no_break_narrow_space( true );
 
 		$this->assertFixResultSame( $input, $result );
 	}
@@ -126,7 +125,6 @@ class French_Punctuation_Spacing_Fix_Test extends Node_Fix_Testcase {
 	 */
 	public function test_apply_with_siblings( $html, $result ) {
 		$this->s->set_french_punctuation_spacing( true );
-		$this->s->set_true_no_break_narrow_space( true );
 
 		$this->assertFixResultSame( $html, $result, 'foo', 'bar' );
 	}

--- a/tests/fixes/node-fixes/class-process-words-fix-test.php
+++ b/tests/fixes/node-fixes/class-process-words-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -83,19 +83,20 @@ class Process_Words_Fix_Test extends Node_Fix_Testcase {
 	 *
 	 * @covers ::get_text_parser
 	 *
-	 * @uses PHP_Typography\Text_Parser::__construct
+	 * @uses PHP_Typography\Text_Parser
+	 * @uses PHP_Typography\Text_Parser\Token
 	 */
 	public function test_get_text_parser() {
-		$this->assert_attribute_empty( 'text_parser', $this->fix );
+		$some_words = 'A short text of no importance at all.';
 
-		$parser1 = $this->fix->get_text_parser();
+		$parser1 = $this->fix->get_text_parser( $some_words );
 		$this->assertInstanceOf( '\PHP_Typography\Text_Parser', $parser1 );
 
-		$parser2 = $this->fix->get_text_parser();
+		$parser2 = $this->fix->get_text_parser( $some_words );
 		$this->assertInstanceOf( '\PHP_Typography\Text_Parser', $parser2 );
 
-		$this->assertSame( $parser1, $parser2 );
-		$this->assert_attribute_instance_of( '\PHP_Typography\Text_Parser', 'text_parser', $this->fix );
+		// The text parser is not stored as part of the object state anymore.
+		$this->assertNotSame( $parser1, $parser2 );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-smart-fractions-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-fractions-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -234,7 +234,6 @@ class Smart_Fractions_Fix_Test extends Node_Fix_Testcase {
 		$this->fix = new Node_Fixes\Smart_Fractions_Fix( $numerator, $denominator );
 
 		$this->s->set_smart_fractions( true );
-		$this->s->set_true_no_break_narrow_space( true );
 		$this->s->set_fraction_spacing( false );
 
 		$this->assertFixResultSame( $input, $result );
@@ -258,7 +257,6 @@ class Smart_Fractions_Fix_Test extends Node_Fix_Testcase {
 		$this->fix = new Node_Fixes\Smart_Fractions_Fix( $numerator, $denominator );
 
 		$this->s->set_smart_fractions( true );
-		$this->s->set_true_no_break_narrow_space( true );
 		$this->s->set_fraction_spacing( true );
 
 		$this->assertFixResultSame( $input, $result );
@@ -282,7 +280,6 @@ class Smart_Fractions_Fix_Test extends Node_Fix_Testcase {
 		$this->fix = new Node_Fixes\Smart_Fractions_Fix( $numerator, $denominator );
 
 		$this->s->set_smart_fractions( false );
-		$this->s->set_true_no_break_narrow_space( true );
 		$this->s->set_fraction_spacing( true );
 
 		$this->assertFixResultSame( $input, $result );
@@ -307,7 +304,6 @@ class Smart_Fractions_Fix_Test extends Node_Fix_Testcase {
 		$this->fix = new Node_Fixes\Smart_Fractions_Fix( $numerator, $denominator );
 
 		$this->s->set_smart_fractions( false );
-		$this->s->set_true_no_break_narrow_space( true );
 		$this->s->set_fraction_spacing( false );
 
 		$this->assertFixResultSame( $input, $input );

--- a/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -95,7 +95,6 @@ class Unit_Spacing_Fix_Test extends Node_Fix_Testcase {
 	 */
 	public function test_apply( $input, $result ) {
 		$this->s->set_unit_spacing( true );
-		$this->s->set_true_no_break_narrow_space( true );
 
 		$this->assertFixResultSame( $input, $result );
 	}
@@ -115,7 +114,6 @@ class Unit_Spacing_Fix_Test extends Node_Fix_Testcase {
 	 */
 	public function test_apply_off( $input, $result ) {
 		$this->s->set_unit_spacing( false );
-		$this->s->set_true_no_break_narrow_space( true );
 
 		$this->assertFixResultSame( $input, $input );
 	}

--- a/tests/fixes/token-fixes/class-hyphenate-compounds-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-compounds-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2022 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -113,7 +113,7 @@ class Hyphenate_Compounds_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_hyphenate_compounds( $hyphenate_compunds );
 		$this->s->set_hyphenation_exceptions( [ 'KING-desk' ] );
 
-		$this->assertFixResultSame( $input, $result );
+		$this->assertFixResultSame( $input, $result, false, $this->getTextnode( 'foo', $input ) );
 	}
 
 	/**
@@ -147,6 +147,6 @@ class Hyphenate_Compounds_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_hyphenate_compounds( $hyphenate_compunds );
 		$this->s->set_hyphenation_exceptions( [ 'KING-desk' ] );
 
-		$this->assertFixResultSame( $input, $input );
+		$this->assertFixResultSame( $input, $input, false, $this->getTextnode( 'foo', $input ) );
 	}
 }

--- a/tests/fixes/token-fixes/class-hyphenate-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-fix-test.php
@@ -24,6 +24,7 @@
 
 namespace PHP_Typography\Tests\Fixes\Token_Fixes;
 
+use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes;
 use PHP_Typography\Settings;
@@ -97,6 +98,7 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_hyphenate_all_caps( true );
 		$this->s->set_hyphenate_title_case( true );
 
+		$this->expect_exception( Invalid_Encoding_Exception::class );
 		$tokens     = $this->tokenize( mb_convert_encoding( 'Änderungsmeldung', 'ISO-8859-2' ) );
 		$hyphenated = $this->invoke_method( $this->fix, 'do_hyphenate', [ $tokens, $this->s ] );
 		$this->assert_tokens_same( $hyphenated, $tokens );

--- a/tests/fixes/token-fixes/class-hyphenate-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2022 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -263,16 +263,7 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_hyphenate_title_case( $hyphenate_title_case );
 		$this->s->set_hyphenation_exceptions( [ 'KING-desk' ] );
 
-		$parent = new \DOMElement( $parent_tag, $input );
-
-		/**
-		 * Always a \DOMText.
-		 *
-		 * @var \DOMText
-		 */
-		$textnode = $parent->firstChild;
-
-		$this->assertFixResultSame( $input, $result, false, $textnode );
+		$this->assertFixResultSame( $input, $result, false, $this->getTextnode( $parent_tag, $input ) );
 	}
 
 	/**
@@ -306,6 +297,6 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_hyphenate_title_case( $hyphenate_title_case );
 		$this->s->set_hyphenation_exceptions( [ 'KING-desk' ] );
 
-		$this->assertFixResultSame( $input, $input );
+		$this->assertFixResultSame( $input, $input, false, $this->getTextnode( 'foo', $input ) );
 	}
 }

--- a/tests/fixes/token-fixes/class-smart-dashes-hyphen-fix-test.php
+++ b/tests/fixes/token-fixes/class-smart-dashes-hyphen-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -99,7 +99,7 @@ class Smart_Dashes_Hyphen_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_smart_dashes( true );
 
 		// Need to add new test data for the smart dashes/hard hyphens combo.
-		$this->assertFixResultSame( $input, $result );
+		$this->assertFixResultSame( $input, $result, false, $this->getTextnode( 'foo', $input ) );
 	}
 
 	/**
@@ -118,6 +118,6 @@ class Smart_Dashes_Hyphen_Fix_Test extends Token_Fix_Testcase {
 	public function test_apply_off( $input, $result ) {
 		$this->s->set_smart_dashes( false );
 
-		$this->assertFixResultSame( $input, $input );
+		$this->assertFixResultSame( $input, $input,false, $this->getTextnode( 'foo', $input ) );
 	}
 }

--- a/tests/fixes/token-fixes/class-token-fix-testcase.php
+++ b/tests/fixes/token-fixes/class-token-fix-testcase.php
@@ -52,7 +52,7 @@ abstract class Token_Fix_Testcase extends Testcase {
 	 *
 	 * @var \DOMNode[]
 	 */
-	private $nodes = [];
+	private $nodes = []; // @phpstan-ignore-line - prevents GC
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -81,13 +81,13 @@ abstract class Token_Fix_Testcase extends Testcase {
 	/**
 	 * Creates a \DOMText node.
 	 *
-	 * @param  string $parent  The parent tag.
-	 * @param  string $content The node content.
+	 * @param  string $parent_node The parent element.
+	 * @param  string $content     The node content.
 	 *
 	 * @return \DOMText
 	 */
-	protected function getTextnode( $parent, $content ) {
-		$element       = new \DOMElement( $parent, $content );
+	protected function getTextnode( $parent_node, $content ) {
+		$element       = new \DOMElement( $parent_node, $content );
 		$this->nodes[] = $element;
 
 		return $element->firstChild;

--- a/tests/fixes/token-fixes/class-token-fix-testcase.php
+++ b/tests/fixes/token-fixes/class-token-fix-testcase.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2020 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -48,6 +48,13 @@ abstract class Token_Fix_Testcase extends Testcase {
 	protected $fix;
 
 	/**
+	 * A collection of DOM nodes to prevent garbage collection.
+	 *
+	 * @var \DOMNode[]
+	 */
+	private $nodes = [];
+
+	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
@@ -60,14 +67,29 @@ abstract class Token_Fix_Testcase extends Testcase {
 	/**
 	 * Assert that the output of the fix is the same as the expected result.
 	 *
-	 * @param string        $input    Text node value.
-	 * @param string        $result   Expected result.
-	 * @param bool          $is_title Optional. Default false.
-	 * @param \DOMText|null $textnode Optional. Default null.
+	 * @param string   $input    Text node value.
+	 * @param string   $result   Expected result.
+	 * @param bool     $is_title Indicates if the processed tokens occur in a title/heading context.
+	 * @param \DOMText $textnode The context DOM node.
 	 */
-	protected function assertFixResultSame( $input, $result, $is_title = false, $textnode = null ) {
+	protected function assertFixResultSame( $input, $result, $is_title, $textnode ) {
 		$tokens        = $this->tokenize_sentence( $input );
-		$result_tokens = $this->fix->apply( $tokens, $this->s, $is_title, $textnode );
+		$result_tokens = $this->fix->apply( $tokens, $textnode, $this->s, $is_title );
 		$this->assert_tokens_same( $result, $result_tokens );
+	}
+
+	/**
+	 * Creates a \DOMText node.
+	 *
+	 * @param  string $parent  The parent tag.
+	 * @param  string $content The node content.
+	 *
+	 * @return \DOMText
+	 */
+	protected function getTextnode( $parent, $content ) {
+		$element       = new \DOMElement( $parent, $content );
+		$this->nodes[] = $element;
+
+		return $element->firstChild;
 	}
 }

--- a/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -99,7 +99,7 @@ class Wrap_Emails_Fix_Test extends Token_Fix_Testcase {
 	public function test_apply( $input, $result ) {
 		$this->s->set_email_wrap( true );
 
-		$this->assertFixResultSame( $input, $result );
+		$this->assertFixResultSame( $input, $result, false, $this->getTextnode( 'foo', $input ) );
 	}
 
 	/**
@@ -118,6 +118,6 @@ class Wrap_Emails_Fix_Test extends Token_Fix_Testcase {
 	public function test_apply_off( $input, $result ) {
 		$this->s->set_email_wrap( false );
 
-		$this->assertFixResultSame( $input, $input );
+		$this->assertFixResultSame( $input, $input, false, $this->getTextnode( 'foo', $input ) );
 	}
 }

--- a/tests/fixes/token-fixes/class-wrap-hard-hyphens-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-hard-hyphens-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -98,7 +98,28 @@ class Wrap_Hard_Hyphens_Fix_Test extends Token_Fix_Testcase {
 	public function test_apply( $input, $result ) {
 		$this->s->set_wrap_hard_hyphens( true );
 
-		$this->assertFixResultSame( $input, $result );
+		$this->assertFixResultSame( $input, $result, false, $this->getTextnode( 'foo', $input ) );
+	}
+
+	/**
+	 * Test apply.
+	 *
+	 * @covers ::apply
+	 *
+	 * @uses PHP_Typography\Text_Parser
+	 * @uses PHP_Typography\Text_Parser\Token
+	 *
+	 * @dataProvider provide_wrap_hard_hyphens_data
+	 *
+	 * @param string $input  HTML input.
+	 * @param string $result Expected result.
+	 */
+	public function test_apply_with_smart_dashes( $input, $result ) {
+		$this->s->set_wrap_hard_hyphens( true );
+		$this->s->set_smart_dashes( true );
+
+		// Need to add new test data for the smart dashes/hard hyphens combo.
+		$this->assertFixResultSame( $input, $result, false, $this->getTextnode( 'foo', $input ) );
 	}
 
 	/**
@@ -117,6 +138,6 @@ class Wrap_Hard_Hyphens_Fix_Test extends Token_Fix_Testcase {
 	public function test_apply_off( $input, $result ) {
 		$this->s->set_wrap_hard_hyphens( false );
 
-		$this->assertFixResultSame( $input, $input );
+		$this->assertFixResultSame( $input, $input, false, $this->getTextnode( 'foo', $input ) );
 	}
 }

--- a/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2022 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -106,7 +106,7 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_url_wrap( true );
 		$this->s->set_min_after_url_wrap( $min_after );
 
-		$this->assertFixResultSame( $input, $result );
+		$this->assertFixResultSame( $input, $result, false, $this->getTextnode( 'foo', $input ) );
 	}
 
 	/**
@@ -127,6 +127,6 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_url_wrap( false );
 		$this->s->set_min_after_url_wrap( $min_after );
 
-		$this->assertFixResultSame( $input, $input );
+		$this->assertFixResultSame( $input, $input, false, $this->getTextnode( 'foo', $input ) );
 	}
 }

--- a/tests/hyphenator/class-trie-node-test.php
+++ b/tests/hyphenator/class-trie-node-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2020 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -42,7 +42,6 @@ class Trie_Node_Test extends Testcase {
 	 * @covers ::__construct
 	 *
 	 * @uses ::get_node
-	 * @uses PHP_Typography\Strings::mb_str_split
 	 *
 	 * @return Trie_Node
 	 */


### PR DESCRIPTION
- Refactors`Token_Fix::apply` signature.
- Refactors `Node_Fix::apply` signature.
- Removes deprecated methods and properties.
- Fixes various small issues detected by PHPCS and PHPStan.
- Refactors `Strings::functions` to use exceptions instead of return values for invalid encodings.
- Refactors `Text_Parser` to unused methods.