### PR TITLE
Add support for French and "Latin" ordinal suffixes

### DIFF
--- a/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
+++ b/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
@@ -42,6 +42,14 @@ use PHP_Typography\Settings;
  */
 class Smart_Ordinal_Suffix_Fix extends Abstract_Node_Fix {
 
+	const RE_ARABIC_ORDINALS = '/\b(\d+)(' . self::ENGLISH_SUFFIXES . '|' . self::FRENCH_SUFFIXES . '|' . self::LATIN_SUFFIXES . ')\b/Su';
+	const ENGLISH_SUFFIXES   = 'st|nd|rd|th';
+	const FRENCH_SUFFIXES    = 'er|re|e|ère|d|nd|nde|e|de|me|ème|è';
+	const LATIN_SUFFIXES     = 'o';
+	const RE_ROMAN_ORDINALS  = '/\b(' . self::ROMAN_NUMERALS . ')(' . self::FRENCH_SUFFIXES . '|' . self::LATIN_SUFFIXES . ')\b/Sxu';
+	const ROMAN_NUMERALS     = '(?=[MDCLXVI])M*(?:C[MD]|D?C*)(?:X[CL]|L?X*)(?:I[XV]|V?I*)';
+
+
 	/**
 	 * The replacement expression (depends on CSS class).
 	 *
@@ -74,6 +82,6 @@ class Smart_Ordinal_Suffix_Fix extends Abstract_Node_Fix {
 			return;
 		}
 
-		$textnode->data = \preg_replace( '/\b(\d+)(st|nd|rd|th)\b/S', $this->replacement, $textnode->data );
+		$textnode->data = \preg_replace( [ self::RE_ARABIC_ORDINALS, self::RE_ROMAN_ORDINALS ], $this->replacement, $textnode->data );
 	}
 }

--- a/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
@@ -82,10 +82,16 @@ class Smart_Ordinal_Suffix_Fix_Test extends Node_Fix_Testcase {
 			[ 'in the 2nd degree',        'in the 2<sup>nd</sup> degree',   '' ],
 			[ 'a 3rd party',              'a 3<sup>rd</sup> party',         '' ],
 			[ '12th Night',               '12<sup>th</sup> Night',          '' ],
+			[ 'la IIIIre heure',          'la IIII<sup>re</sup> heure',     '' ],
+			[ 'François Ier',             'Fran&ccedil;ois I<sup>er</sup>', '' ],
+			[ 'MDCCLXXVIo',               'MDCCLXXVI<sup>o</sup>',          '' ],
 			[ 'in the 1st instance, we',  'in the 1<sup class="ordinal">st</sup> instance, we',  'ordinal' ],
 			[ 'murder in the 2nd degree', 'murder in the 2<sup class="ordinal">nd</sup> degree', 'ordinal' ],
 			[ 'a 3rd party',              'a 3<sup class="ordinal">rd</sup> party',              'ordinal' ],
 			[ 'the 12th Night',           'the 12<sup class="ordinal">th</sup> Night',           'ordinal' ],
+			[ 'la 1ère guerre',           'la 1<sup class="ordinal">&egrave;re</sup> guerre',    'ordinal' ],
+			[ 'la 1re guerre mondiale',   'la 1<sup class="ordinal">re</sup> guerre mondiale',   'ordinal' ],
+			[ 'le XIXe siècle',           'le XIX<sup class="ordinal">e</sup> si&egrave;cle',    'ordinal' ],
 		];
 	}
 


### PR DESCRIPTION
This PR adds supports
- French (1<sup>ère</sup>) and "Latin" (1<sup>o</sup>) ordinal numbers to the Smart Ordinals feature.
- Roman numerals (with French or Latin suffixes, e.g. XIX<sup>ème</sup>).

The matching rules are permissive and besides Roman numeral matching, no validation is performed to see if the numbers actually agree with the found suffix. This fixes #91.