### PR TITLE
Release 6.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change History
 
+## 6.4.2 - January 27, 2019
+*   _Bugfix_: The Unicode hyphen character (`‐`) is recognized as a valid word combiner.
+
 ## 6.4.1 - January 27, 2019
-*   _Bugfix_: Parts of hyphenated words should not be detected as Roman numerals anymore. 
+*   _Bugfix_: Parts of hyphenated words should not be detected as Roman numerals anymore.
 
 ## 6.4.0 - January 24, 2019
 *   _Feature_: French (1<sup>ère</sup>) and "Latin" (1<sup>o</sup>) ordinal numbers are now supported by the smart ordinals feature (also with Roman numerals, e.g. XIX<sup>ème</sup>).

--- a/src/fixes/node-fixes/class-dewidow-fix.php
+++ b/src/fixes/node-fixes/class-dewidow-fix.php
@@ -42,7 +42,7 @@ use PHP_Typography\U;
  */
 class Dewidow_Fix extends Abstract_Node_Fix {
 	const SPACE_BETWEEN = '[\s]+'; // \s includes all special spaces (but not ZWSP) with the u flag.
-	const WIDOW         = '[\w\p{M}\-' . U::ZERO_WIDTH_SPACE . U::SOFT_HYPHEN . ']+?'; // \w includes all alphanumeric Unicode characters but not composed characters.
+	const WIDOW         = '[\w\p{M}\-' . U::HYPHEN . U::ZERO_WIDTH_SPACE . U::SOFT_HYPHEN . ']+?'; // \w includes all alphanumeric Unicode characters but not composed characters.
 
 	// Mandatory UTF-8 modifer.
 	const REGEX_START = '/

--- a/src/fixes/node-fixes/class-style-caps-fix.php
+++ b/src/fixes/node-fixes/class-style-caps-fix.php
@@ -71,26 +71,28 @@ class Style_Caps_Fix extends Simple_Style_Fix {
 	// Servers with PCRE compiled without "--enable-unicode-properties" fail at \p{Lu} by returning an empty string (this leaving the screen void of text
 	// thus are testing this alternative.
 	const REGEX = '/
-		(?<![\w\-_' . U::ZERO_WIDTH_SPACE . U::SOFT_HYPHEN . ']) # negative lookbehind assertion
+		(?<![\w' . self::COMBINING_MARKS . ']) # negative lookbehind assertion
 		(
 			(?:							# CASE 1: " 9A "
 				[0-9]+					# starts with at least one number
-				(?:\-|_|' . U::ZERO_WIDTH_SPACE . '|' . U::SOFT_HYPHEN . ')*
+				(?:[' . self::COMBINING_MARKS . '])*
 						                # may contain hyphens, underscores, zero width spaces, or soft hyphens,
 				[A-ZÀ-ÖØ-Ý]				# but must contain at least one capital letter
-				(?:[A-ZÀ-ÖØ-Ý]|[0-9]|\-|_|' . U::ZERO_WIDTH_SPACE . '|' . U::SOFT_HYPHEN . ')*
+				(?:[A-ZÀ-ÖØ-Ý]|[0-9]|[' . self::COMBINING_MARKS . '])*
 										# may be followed by any number of numbers capital letters, hyphens, underscores, zero width spaces, or soft hyphens
 			)
 			|
 			(?:							# CASE 2: " A9 "
 				[A-ZÀ-ÖØ-Ý]				# starts with capital letter
 				(?:[A-ZÀ-ÖØ-Ý]|[0-9])	# must be followed a number or capital letter
-				(?:[A-ZÀ-ÖØ-Ý]|[0-9]|\-|_|' . U::ZERO_WIDTH_SPACE . '|' . U::SOFT_HYPHEN . ')*
+				(?:[A-ZÀ-ÖØ-Ý]|[0-9]|[' . self::COMBINING_MARKS . '])*
 										# may be followed by any number of numbers capital letters, hyphens, underscores, zero width spaces, or soft hyphens
 			)
 		)
-		(?![\w\-_' . U::ZERO_WIDTH_SPACE . U::SOFT_HYPHEN . ']) # negative lookahead assertion
+		(?![\w' . self::COMBINING_MARKS . ']) # negative lookahead assertion
 	/Sxu';
+
+	const COMBINING_MARKS = '\-_' . U::HYPHEN . U::SOFT_HYPHEN . U::ZERO_WIDTH_SPACE; // Needs to be part of character class.
 
 	/**
 	 * Creates a new node fix with a class.

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -496,6 +496,7 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 			[ '<p>Line One <br>Line Two,<br><span>Line Three.</span></p>', '<p>Line One <br>Line Two,<br><span>Line Three.</span></p>', false ],
 			[ '3/4 of 10/12/89', '<sup class="numerator"><span class="numbers">3</span></sup>&frasl;<sub class="denominator"><span class="numbers">4</span></sub> of <span class="numbers">10</span>/<span class="numbers">12</span>/<span class="numbers">89</span>', false ],
 			[ 'Certain HTML entities', 'Cer&shy;tain <span class="caps">HTML</span> entities', false ],
+			[ 'during WP-CLI commands', 'dur&shy;ing <span class="caps">WP-CLI</span> commands', false ],
 		];
 	}
 

--- a/tests/fixes/node-fixes/class-style-caps-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-caps-fix-test.php
@@ -59,6 +59,8 @@ class Style_Caps_Fix_Test extends Node_Fix_Testcase {
 			[ 'foo BARbaz', 'foo BARbaz' ],
 			[ 'foo BAR123 baz', 'foo <span class="caps">BAR123</span> baz' ],
 			[ 'foo 123BAR baz', 'foo <span class="caps">123BAR</span> baz' ],
+			[ 'during WP-CLI commands', 'during <span class="caps">WP-CLI</span> commands' ],
+			[ 'during WP‐CLI commands', 'during <span class="caps">WP‐CLI</span> commands' ], // HYPHEN instead of HYPHEN-MINUS.
 		];
 	}
 


### PR DESCRIPTION
_Bugfix_: The Unicode hyphen character (`‐`) is recognized as a valid word combiner.