### PR TITLE
Refactor Roman numeral ordinals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change History
 
+## 6.4.3 - January 29, 2019
+*   _Bugfix_: To prevent common false positives for single-letter Roman ordinals (especially in French and Dutch), Roman numeral matching is now only enabled when `Settings::set_smart_ordinal_suffix_match_roman_numerals` is set to `true`. In addition, only `I`, `V`, and `X` are accepted as single-letter Roman numbers.
+
 ## 6.4.2 - January 27, 2019
 *   _Bugfix_: The Unicode hyphen character (`‐`) is recognized as a valid word combiner.
 

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -264,6 +264,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		$this->set_diacritic_custom_replacements();
 		$this->set_smart_marks();
 		$this->set_smart_ordinal_suffix();
+		$this->set_smart_ordinal_suffix_match_roman_numerals();
 		$this->set_smart_math();
 		$this->set_smart_fractions();
 		$this->set_smart_exponents();
@@ -729,6 +730,17 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 */
 	public function set_smart_ordinal_suffix( $on = true ) {
 		$this->data['smartOrdinalSuffix'] = $on;
+	}
+
+	/**
+	 * Enables/disables replacement of XXe with XX<sup>e</sup>.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param bool $on Optional. Default false.
+	 */
+	public function set_smart_ordinal_suffix_match_roman_numerals( $on = false ) {
+		$this->data['smartOrdinalSuffixRomanNumerals'] = $on;
 	}
 
 	/**

--- a/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
+++ b/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
@@ -116,6 +116,14 @@ class Smart_Ordinal_Suffix_Fix extends Abstract_Node_Fix {
 			return;
 		}
 
-		$textnode->data = \preg_replace( [ self::RE_ARABIC_ORDINALS, self::RE_ROMAN_ORDINALS ], $this->replacement, $textnode->data );
+		// Always match Arabic numbers.
+		$patterns = [ self::RE_ARABIC_ORDINALS ];
+
+		// Only match Roman numbers if explicitely enabled.
+		if ( ! empty( $settings['smartOrdinalSuffixRomanNumerals'] ) ) {
+			$patterns[] = self::RE_ROMAN_ORDINALS;
+		}
+
+		$textnode->data = \preg_replace( $patterns, $this->replacement, $textnode->data );
 	}
 }

--- a/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
+++ b/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
@@ -51,7 +51,7 @@ class Smart_Ordinal_Suffix_Fix extends Abstract_Node_Fix {
 	const ROMAN_NUMERALS     = '(?=[MDCLXVI])M*(?:C[MD]|D?C*)(?:X[CL]|L?X*)(?:I[XV]|V?I*)';
 
 	// Zero-width spaces and soft hyphens should not be treated as word boundaries.
-	const WORD_BOUNDARY_START = '\b(?![' . U::SOFT_HYPHEN . U::ZERO_WIDTH_SPACE . '])';
+	const WORD_BOUNDARY_START = '\b(?<![' . U::SOFT_HYPHEN . U::ZERO_WIDTH_SPACE . '])';
 	const WORD_BOUNDARY_END   = '\b(?![' . U::SOFT_HYPHEN . U::ZERO_WIDTH_SPACE . '])';
 
 	/**

--- a/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
+++ b/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
@@ -43,12 +43,42 @@ use PHP_Typography\U;
  */
 class Smart_Ordinal_Suffix_Fix extends Abstract_Node_Fix {
 
-	const RE_ARABIC_ORDINALS = '/' . self::WORD_BOUNDARY_START . '(\d+)(' . self::ENGLISH_SUFFIXES . '|' . self::FRENCH_SUFFIXES . '|' . self::LATIN_SUFFIXES . ')' . self::WORD_BOUNDARY_END . '/Su';
-	const ENGLISH_SUFFIXES   = 'st|nd|rd|th';
-	const FRENCH_SUFFIXES    = 'er|re|e|ère|d|nd|nde|e|de|me|ème|è';
-	const LATIN_SUFFIXES     = 'o';
-	const RE_ROMAN_ORDINALS  = '/' . self::WORD_BOUNDARY_START . '(' . self::ROMAN_NUMERALS . ')(' . self::FRENCH_SUFFIXES . '|' . self::LATIN_SUFFIXES . ')' . self::WORD_BOUNDARY_END . '/Sxu';
-	const ROMAN_NUMERALS     = '(?=[MDCLXVI])M*(?:C[MD]|D?C*)(?:X[CL]|L?X*)(?:I[XV]|V?I*)';
+	// Possible suffixes.
+	const ENGLISH_SUFFIXES = 'st|nd|rd|th';
+	const FRENCH_SUFFIXES  = 'er|re|e|ère|d|nd|nde|de|me|ème|è';
+	const LATIN_SUFFIXES   = 'o';
+
+	// Ordinals with arabic numerals.
+	const RE_ARABIC_ORDINALS = '/' .
+		self::WORD_BOUNDARY_START . '
+		(\d+)
+		(' .
+			self::ENGLISH_SUFFIXES . '|' .
+			self::FRENCH_SUFFIXES . '|' .
+			self::LATIN_SUFFIXES . '
+		)' .
+		self::WORD_BOUNDARY_END . '
+	/Sxu';
+
+	// Ordinals with Roman numerals.
+	const RE_ROMAN_ORDINALS = '/' .
+		self::WORD_BOUNDARY_START . '
+		(
+			# Prevent single letter numbers other than I, V, and X.
+			(?=(?:I|V|X|' . self::ROMAN_NUMERALS . '{2,}))
+
+			# Otherwise, allow all valid Roman numbers.
+			(?=' . self::ROMAN_NUMERALS . ')M*(?:C[MD]|D?C*)(?:X[CL]|L?X*)(?:I[XV]|V?I*)
+		)
+		(' .
+			self::FRENCH_SUFFIXES . '|' .
+			self::LATIN_SUFFIXES . '
+		)' .
+		self::WORD_BOUNDARY_END . '
+	/Sxu';
+
+	// Additional character classes.
+	const ROMAN_NUMERALS = '[MDCLXVI]';
 
 	// Zero-width spaces and soft hyphens should not be treated as word boundaries.
 	const WORD_BOUNDARY_START = '\b(?<![' . U::SOFT_HYPHEN . U::ZERO_WIDTH_SPACE . '])';

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -886,6 +886,19 @@ class Settings_Test extends PHP_Typography_Testcase {
 	}
 
 	/**
+	 * Tests set_smart_ordinal_suffix_match_roman_numerals.
+	 *
+	 * @covers ::set_smart_ordinal_suffix_match_roman_numerals
+	 */
+	public function test_set_smart_ordinal_suffix_match_roman_numerals() {
+		$this->settings->set_smart_ordinal_suffix_match_roman_numerals( true );
+		$this->assertTrue( $this->settings['smartOrdinalSuffixRomanNumerals'] );
+
+		$this->settings->set_smart_ordinal_suffix_match_roman_numerals( false );
+		$this->assertFalse( $this->settings['smartOrdinalSuffixRomanNumerals'] );
+	}
+
+	/**
 	 * Tests set_single_character_word_spacing.
 	 *
 	 * @covers ::set_single_character_word_spacing

--- a/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
@@ -76,12 +76,28 @@ class Smart_Ordinal_Suffix_Fix_Test extends Node_Fix_Testcase {
 	 *
 	 * @return array
 	 */
-	public function provide_smart_ordinal_suffix() {
+	public function provide_smart_ordinal_suffix_data() {
 		return [
 			[ 'in the 1st instance',          'in the 1<sup>st</sup> instance', '' ],
 			[ 'in the 2nd degree',            'in the 2<sup>nd</sup> degree',   '' ],
 			[ 'a 3rd party',                  'a 3<sup>rd</sup> party',         '' ],
 			[ '12th Night',                   '12<sup>th</sup> Night',          '' ],
+			[ 'in the 1st instance, we',      'in the 1<sup class="ordinal">st</sup> instance, we',  'ordinal' ],
+			[ 'murder in the 2nd degree',     'murder in the 2<sup class="ordinal">nd</sup> degree', 'ordinal' ],
+			[ 'a 3rd party',                  'a 3<sup class="ordinal">rd</sup> party',              'ordinal' ],
+			[ 'the 12th Night',               'the 12<sup class="ordinal">th</sup> Night',           'ordinal' ],
+			[ 'la 1ère guerre',               'la 1<sup class="ordinal">&egrave;re</sup> guerre',    'ordinal' ],
+			[ 'la 1re guerre mondiale',       'la 1<sup class="ordinal">re</sup> guerre mondiale',   'ordinal' ],
+		];
+	}
+
+	/**
+	 * Provide data for testing ordinal suffixes.
+	 *
+	 * @return array
+	 */
+	public function provide_smart_ordinal_suffix_roman_numeral_data() {
+		return [
 			[ 'la IIIIre heure',              'la IIII<sup>re</sup> heure',     '' ],
 			[ 'la IVre heure',                'la IV<sup>re</sup> heure',       '' ],
 			[ 'François Ier',                 'Fran&ccedil;ois I<sup>er</sup>', '' ],
@@ -93,12 +109,6 @@ class Smart_Ordinal_Suffix_Fix_Test extends Node_Fix_Testcase {
 			[ 'Ce livre est très bon.',       'Ce livre est très bon.',         '' ], // Negative test.
 			[ 'De geologische structuur',     'De geologische structuur',       '' ], // Negative test.
 			[ 'Me? I like ice cream.',        'Me? I like ice cream.',          '' ], // Negative test.
-			[ 'in the 1st instance, we',      'in the 1<sup class="ordinal">st</sup> instance, we',  'ordinal' ],
-			[ 'murder in the 2nd degree',     'murder in the 2<sup class="ordinal">nd</sup> degree', 'ordinal' ],
-			[ 'a 3rd party',                  'a 3<sup class="ordinal">rd</sup> party',              'ordinal' ],
-			[ 'the 12th Night',               'the 12<sup class="ordinal">th</sup> Night',           'ordinal' ],
-			[ 'la 1ère guerre',               'la 1<sup class="ordinal">&egrave;re</sup> guerre',    'ordinal' ],
-			[ 'la 1re guerre mondiale',       'la 1<sup class="ordinal">re</sup> guerre mondiale',   'ordinal' ],
 			[ 'le XIXe siècle',               'le XIX<sup class="ordinal">e</sup> si&egrave;cle',    'ordinal' ],
 		];
 	}
@@ -110,7 +120,7 @@ class Smart_Ordinal_Suffix_Fix_Test extends Node_Fix_Testcase {
 	 *
 	 * @uses PHP_Typography\RE::escape_tags
 	 *
-	 * @dataProvider provide_smart_ordinal_suffix
+	 * @dataProvider provide_smart_ordinal_suffix_data
 	 *
 	 * @param string $input     HTML input.
 	 * @param string $result    Expected result.
@@ -133,7 +143,55 @@ class Smart_Ordinal_Suffix_Fix_Test extends Node_Fix_Testcase {
 	 *
 	 * @uses PHP_Typography\RE::escape_tags
 	 *
-	 * @dataProvider provide_smart_ordinal_suffix
+	 * @dataProvider provide_smart_ordinal_suffix_roman_numeral_data
+	 *
+	 * @param string $input     HTML input.
+	 * @param string $result    Expected result.
+	 * @param string $css_class Optional.
+	 */
+	public function test_apply_roman_numerals_on( $input, $result, $css_class ) {
+		$this->s->set_smart_ordinal_suffix( true );
+		$this->s->set_smart_ordinal_suffix_match_roman_numerals( true );
+
+		if ( ! empty( $css_class ) ) {
+			$this->fix = new Node_Fixes\Smart_Ordinal_Suffix_Fix( $css_class );
+		}
+
+		$this->assertFixResultSame( $input, $result );
+	}
+
+	/**
+	 * Test apply.
+	 *
+	 * @covers ::apply
+	 *
+	 * @uses PHP_Typography\RE::escape_tags
+	 *
+	 * @dataProvider provide_smart_ordinal_suffix_roman_numeral_data
+	 *
+	 * @param string $input     HTML input.
+	 * @param string $result    Expected result.
+	 * @param string $css_class Optional.
+	 */
+	public function test_apply_roman_numerals_off( $input, $result, $css_class ) {
+		$this->s->set_smart_ordinal_suffix( true );
+
+		if ( ! empty( $css_class ) ) {
+			$this->fix = new Node_Fixes\Smart_Ordinal_Suffix_Fix( $css_class );
+		}
+
+		$this->assertFixResultSame( $input, $input );
+	}
+
+	/**
+	 * Test apply.
+	 *
+	 * @covers ::apply
+	 *
+	 * @uses PHP_Typography\RE::escape_tags
+	 *
+	 * @dataProvider provide_smart_ordinal_suffix_data
+	 * @dataProvider provide_smart_ordinal_suffix_roman_numeral_data
 	 *
 	 * @param string $input  HTML input.
 	 * @param string $result Expected result.
@@ -141,6 +199,7 @@ class Smart_Ordinal_Suffix_Fix_Test extends Node_Fix_Testcase {
 	 */
 	public function test_apply_off( $input, $result, $css_class ) {
 		$this->s->set_smart_ordinal_suffix( false );
+		$this->s->set_smart_ordinal_suffix_match_roman_numerals( true );
 
 		if ( ! empty( $css_class ) ) {
 			$this->fix = new Node_Fixes\Smart_Ordinal_Suffix_Fix( $css_class );

--- a/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
@@ -83,11 +83,16 @@ class Smart_Ordinal_Suffix_Fix_Test extends Node_Fix_Testcase {
 			[ 'a 3rd party',                  'a 3<sup>rd</sup> party',         '' ],
 			[ '12th Night',                   '12<sup>th</sup> Night',          '' ],
 			[ 'la IIIIre heure',              'la IIII<sup>re</sup> heure',     '' ],
+			[ 'la IVre heure',                'la IV<sup>re</sup> heure',       '' ],
 			[ 'François Ier',                 'Fran&ccedil;ois I<sup>er</sup>', '' ],
 			[ 'MDCCLXXVIo',                   'MDCCLXXVI<sup>o</sup>',          '' ],
 			[ 'Certain HTML entities',        'Certain HTML entities',          '' ], // Negative test.
-			[ 'Cer&shy;tain HTML entities',   'Cer&shy;tain HTML entities',          '' ], // Negative test.
-			[ 'Cer&#8203;tain HTML entities', 'Cer&#8203;tain HTML entities',          '' ], // Negative test.
+			[ 'Cer&shy;tain HTML entities',   'Cer&shy;tain HTML entities',     '' ], // Negative test.
+			[ 'Cer&#8203;tain HTML entities', 'Cer&#8203;tain HTML entities',   '' ], // Negative test.
+			[ 'Le Président',                 'Le Président',                   '' ], // Negative test.
+			[ 'Ce livre est très bon.',       'Ce livre est très bon.',         '' ], // Negative test.
+			[ 'De geologische structuur',     'De geologische structuur',       '' ], // Negative test.
+			[ 'Me? I like ice cream.',        'Me? I like ice cream.',          '' ], // Negative test.
 			[ 'in the 1st instance, we',      'in the 1<sup class="ordinal">st</sup> instance, we',  'ordinal' ],
 			[ 'murder in the 2nd degree',     'murder in the 2<sup class="ordinal">nd</sup> degree', 'ordinal' ],
 			[ 'a 3rd party',                  'a 3<sup class="ordinal">rd</sup> party',              'ordinal' ],


### PR DESCRIPTION
- Single-letter Roman numbers are ignored, except for `I`, `V`, and `X` (still problematic for Italian, though, because of `Io` at the start of a sentence).
- Roman numeral matching is disabled unless it's first enabled with the new method `Settings::set_smart_ordinal_suffix_match_roman_numerals()`.

Fixes #103.