### PR TITLE
Apostrophe for decades

### DIFF
--- a/src/fixes/node-fixes/class-smart-quotes-fix.php
+++ b/src/fixes/node-fixes/class-smart-quotes-fix.php
@@ -52,7 +52,7 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 	const DOUBLE_QUOTED_NUMBERS = '/(?<=\W|\A)"([^"]*\d+)"(?=\W|\Z)/S';
 	const COMMA_QUOTE           = '/(?<=\s|\A),(?=\S)/S';
 	const APOSTROPHE_WORDS      = "/(?<=\w)'(?=\w)/S";
-	const APOSTROPHE_DECADES    = "/'(\d\d\b)/S";
+	const APOSTROPHE_DECADES    = "/'(\d\d(s|er)?\b)/S"; // Allow both English '80s and German '80er.
 	const SINGLE_QUOTE_OPEN     = "/(?: '(?=\w) )  | (?: (?<=\s|\A)'(?=\S) )/Sx"; // Alternative is for expressions like _'¿hola?'_.
 	const SINGLE_QUOTE_CLOSE    = "/(?: (?<=\w)' ) | (?: (?<=\S)'(?=\s|\Z) )/Sx";
 	const DOUBLE_QUOTE_OPEN     = '/(?: "(?=\w) )  | (?: (?<=\s|\A)"(?=\S) )/Sx';

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -497,6 +497,7 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 			[ '3/4 of 10/12/89', '<sup class="numerator"><span class="numbers">3</span></sup>&frasl;<sub class="denominator"><span class="numbers">4</span></sub> of <span class="numbers">10</span>/<span class="numbers">12</span>/<span class="numbers">89</span>', false ],
 			[ 'Certain HTML entities', 'Cer&shy;tain <span class="caps">HTML</span> entities', false ],
 			[ 'during WP-CLI commands', 'dur&shy;ing <span class="caps">WP-CLI</span> commands', false ],
+			[ 'from the early \'60s, American engagement', 'from the ear&shy;ly <span class="push-single"></span>&#8203;<span class="pull-single">&rsquo;</span><span class="numbers">60</span>s, Amer&shy;i&shy;can engagement', 'from the early &rsquo;60s, American engagement' ],
 		];
 	}
 

--- a/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
@@ -79,6 +79,7 @@ class Smart_Quotes_Fix_Test extends Node_Fix_Testcase {
 			[ 'Some "word")',                      'Some &ldquo;word&rdquo;)' ],
 			[ '"So \'this\'", she said',           '&ldquo;So &lsquo;this&rsquo;&nbsp;&rdquo;, she said' ],
 			[ '"\'This\' is it?"',                 '&ldquo;&nbsp;&lsquo;This&rsquo; is it?&rdquo;' ],
+			[ 'from the early \'60s, American',    'from the early ’60s, American' ],
 		];
 	}
 


### PR DESCRIPTION
`'60s` and `'80er` are now rendered with an apostrophe. Fixes #107.