### PR TITLE
Add general character remapping framework

### DIFF
--- a/src/class-php-typography.php
+++ b/src/class-php-typography.php
@@ -192,7 +192,7 @@ class PHP_Typography {
 
 			// Replace original node (if anthing was changed).
 			if ( $new !== $original ) {
-				$this->replace_node_with_html( $textnode, $new );
+				$this->replace_node_with_html( $textnode, $settings->apply_character_mapping( $new ) );
 			}
 		}
 

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -126,6 +126,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 
 		// Keep backwards compatibility.
 		if ( isset( $this->unicode_mapping[ U::NO_BREAK_NARROW_SPACE ] ) ) {
+			/* @scrutinizer ignore-deprecated */
 			$this->no_break_narrow_space = $this->unicode_mapping[ U::NO_BREAK_NARROW_SPACE ];
 		}
 	}
@@ -245,6 +246,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 
 		// Compatibility with the old way of setting the no-break narrow space.
 		if ( U::NO_BREAK_NARROW_SPACE === $char ) {
+			/* @scrutinizer ignore-deprecated */
 			$this->no_break_narrow_space = $new_char;
 		}
 	}
@@ -284,7 +286,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 * @return string
 	 */
 	public function no_break_narrow_space() {
-		return $this->no_break_narrow_space;
+		return /* @scrutinizer ignore-deprecated */$this->no_break_narrow_space;
 	}
 
 	/**
@@ -367,6 +369,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		$this->set_email_wrap();
 		$this->set_min_after_url_wrap();
 		$this->set_space_collapse();
+		/* @scrutinizer ignore-deprecated */
 		$this->set_true_no_break_narrow_space();
 
 		// Character styling.

--- a/src/class-u.php
+++ b/src/class-u.php
@@ -55,7 +55,7 @@ interface U {
 	const EM_DASH                    = "\xe2\x80\x94";
 	const SINGLE_QUOTE_OPEN          = "\xe2\x80\x98";
 	const SINGLE_QUOTE_CLOSE         = "\xe2\x80\x99";
-	const APOSTROPHE                 = "\xe2\x80\x99"; // defined seperate from SINGLE_QUOTE_CLOSE to preserve semantics.
+	const APOSTROPHE                 = "\xca\xbc"; // This is the "MODIFIER LETTER APOSTROPHE".
 	const SINGLE_LOW_9_QUOTE         = "\xe2\x80\x9a";
 	const DOUBLE_QUOTE_OPEN          = "\xe2\x80\x9c";
 	const DOUBLE_QUOTE_CLOSE         = "\xe2\x80\x9d";

--- a/src/class-u.php
+++ b/src/class-u.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2018 Peter Putzer.
+ *  Copyright 2017-2019 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -74,4 +74,5 @@ interface U {
 	const RIGHT_CORNER_BRACKET       = "\xe3\x80\x8d";
 	const LEFT_WHITE_CORNER_BRACKET  = "\xe3\x80\x8e";
 	const RIGHT_WHITE_CORNER_BRACKET = "\xe3\x80\x8f";
+
 }

--- a/src/fixes/node-fixes/class-dewidow-fix.php
+++ b/src/fixes/node-fixes/class-dewidow-fix.php
@@ -183,13 +183,11 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 	protected static function make_space_nonbreaking( $string, $deprecated, $u ) {
 		return \preg_replace(
 			[
-				'/\s*' . U::THIN_SPACE . '\s*/u', // FIXME: Can be changed to single regex.
-				'/\s*' . U::NO_BREAK_NARROW_SPACE . '\s*/u',
-				"/\\s+/$u",
-				'/' . self::MASKED_NARROW_SPACE . "/$u",
+				'/\s*(?:' . U::THIN_SPACE . '|' . U::NO_BREAK_NARROW_SPACE . ')\s*/Su',
+				"/\\s+/S$u",
+				'/' . self::MASKED_NARROW_SPACE . "/S$u",
 			],
 			[
-				self::MASKED_NARROW_SPACE,
 				self::MASKED_NARROW_SPACE,
 				U::NO_BREAK_SPACE,
 				U::NO_BREAK_NARROW_SPACE,

--- a/src/fixes/node-fixes/class-dewidow-fix.php
+++ b/src/fixes/node-fixes/class-dewidow-fix.php
@@ -93,23 +93,25 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 
 		if ( '' === DOM::get_next_chr( $textnode ) ) {
 			// We have the last type "text" child of a block level element.
-			$textnode->data = $this->dewidow( $textnode->data, Strings::functions( $textnode->data ), $settings['dewidowMaxPull'], $settings['dewidowMaxLength'], $settings['dewidowWordNumber'], $settings->no_break_narrow_space() );
+			$textnode->data = $this->dewidow( $textnode->data, Strings::functions( $textnode->data ), $settings['dewidowMaxPull'], $settings['dewidowMaxLength'], $settings['dewidowWordNumber'], U::NO_BREAK_NARROW_SPACE );
 		}
 	}
 
 	/**
 	 * Dewidow a given text fragment.
 	 *
+	 * @since 6.5.0 Parameter $narrow_space has been deprecated.
+	 *
 	 * @param  string $text         The text fragment to dewidow.
 	 * @param  array  $func         An array of string functions.
 	 * @param  int    $max_pull     Maximum number of characters pulled from previous line.
 	 * @param  int    $max_length   Maximum widow length.
 	 * @param  int    $word_number  Maximum number of words allowed in widow.
-	 * @param  string $narrow_space The narrow no-break space character.
+	 * @param  string $deprecated   Ignored.
 	 *
 	 * @return string
 	 */
-	protected function dewidow( $text, array $func, $max_pull, $max_length, $word_number, $narrow_space ) {
+	protected function dewidow( $text, array $func, $max_pull, $max_length, $word_number, $deprecated ) {
 		if ( $word_number < 1 ) {
 			return $text; // We are done.
 		}
@@ -117,13 +119,13 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 		// Do what we have to do.
 		return \preg_replace_callback(
 			self::REGEX_START . ( $word_number - 1 ) . self::REGEX_END,
-			function( array $widow ) use ( $func, $max_pull, $max_length, $word_number, $narrow_space ) {
+			function( array $widow ) use ( $func, $max_pull, $max_length, $word_number ) {
 
 				// If we are here, we know that widows are being protected in some fashion
 				// with that, we will assert that widows should never be hyphenated or wrapped
 				// as such, we will strip soft hyphens and zero-width-spaces.
 				$widow['widow']    = self::strip_breaking_characters( $widow['widow'] );
-				$widow['trailing'] = self::strip_breaking_characters( self::make_space_nonbreaking( $widow['trailing'], $narrow_space, $func['u'] ) );
+				$widow['trailing'] = self::strip_breaking_characters( self::make_space_nonbreaking( $widow['trailing'], U::NO_BREAK_NARROW_SPACE, $func['u'] ) );
 
 				if (
 					// Eject if widows neighbor is proceeded by a no break space (the pulled text would be too long).
@@ -133,11 +135,11 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 					// Never replace thin and hair spaces with &nbsp;.
 					self::is_narrow_space( $widow['space_between'] )
 				) {
-					return $widow['space_before'] . $widow['neighbor'] . $this->dewidow( $widow['space_between'] . $widow['widow'] . $widow['trailing'], $func, $max_pull, $max_length, $word_number - 1, $narrow_space );
+					return $widow['space_before'] . $widow['neighbor'] . $this->dewidow( $widow['space_between'] . $widow['widow'] . $widow['trailing'], $func, $max_pull, $max_length, $word_number - 1, U::NO_BREAK_NARROW_SPACE );
 				}
 
 				// Let's protect some widows!
-				return $widow['space_before'] . $widow['neighbor'] . U::NO_BREAK_SPACE . self::make_space_nonbreaking( $widow['widow'], $narrow_space, $func['u'] ) . $widow['trailing'];
+				return $widow['space_before'] . $widow['neighbor'] . U::NO_BREAK_SPACE . self::make_space_nonbreaking( $widow['widow'], U::NO_BREAK_NARROW_SPACE, $func['u'] ) . $widow['trailing'];
 			},
 			$text
 		);
@@ -170,16 +172,18 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 	/**
 	 * Strip zero-width space and soft hyphens from the given string.
 	 *
-	 * @param  string $string       Required.
-	 * @param  string $narrow_space The narrow no-break space character.
-	 * @param  string $u            Either 'u' or the empty string.
+	 * @since 6.5.0 Parameter $narrow_space has been deprecated.
+	 *
+	 * @param  string $string     Required.
+	 * @param  string $deprecated Ignored.
+	 * @param  string $u          Either 'u' or the empty string.
 	 *
 	 * @return string
 	 */
-	protected static function make_space_nonbreaking( $string, $narrow_space, $u ) {
+	protected static function make_space_nonbreaking( $string, $deprecated, $u ) {
 		return \preg_replace(
 			[
-				'/\s*' . U::THIN_SPACE . '\s*/u', // @codeCoverageIgnoreStart
+				'/\s*' . U::THIN_SPACE . '\s*/u', // FIXME: Can be changed to single regex.
 				'/\s*' . U::NO_BREAK_NARROW_SPACE . '\s*/u',
 				"/\\s+/$u",
 				'/' . self::MASKED_NARROW_SPACE . "/$u",
@@ -187,8 +191,8 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 			[
 				self::MASKED_NARROW_SPACE,
 				self::MASKED_NARROW_SPACE,
-				U::NO_BREAK_SPACE, // @codeCoverageIgnoreEnd
-				$narrow_space,
+				U::NO_BREAK_SPACE,
+				U::NO_BREAK_NARROW_SPACE,
 			],
 			$string
 		);

--- a/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
+++ b/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
@@ -70,9 +70,19 @@ class French_Punctuation_Spacing_Fix extends Abstract_Node_Fix {
 		$node_data          = "{$previous_character}{$textnode->data}"; // $next_character is not included on purpose.
 		$f                  = Strings::functions( "{$node_data}{$next_character}" ); // Include $next_character for determining encodiing.
 
-		$node_data = \preg_replace( self::INSERT_SPACE_BEFORE_CLOSING_QUOTE, '$1' . U::NO_BREAK_NARROW_SPACE . '$3$4', $node_data );
-		$node_data = \preg_replace( self::INSERT_NARROW_SPACE,               '$1' . U::NO_BREAK_NARROW_SPACE . '$3$4', $node_data );
-		$node_data = \preg_replace( self::INSERT_FULL_SPACE,                 '$1' . U::NO_BREAK_SPACE . '$3$4',      $node_data );
+		$node_data = \preg_replace(
+			[
+				self::INSERT_SPACE_BEFORE_CLOSING_QUOTE,
+				self::INSERT_NARROW_SPACE,
+				self::INSERT_FULL_SPACE,
+			],
+			[
+				'$1' . U::NO_BREAK_NARROW_SPACE . '$3$4',
+				'$1' . U::NO_BREAK_NARROW_SPACE . '$3$4',
+				'$1' . U::NO_BREAK_SPACE . '$3$4',
+			],
+			$node_data
+		);
 
 		// The next rule depends on the following characters as well.
 		$node_data = \preg_replace( self::INSERT_SPACE_AFTER_OPENING_QUOTE,  '$1$2' . U::NO_BREAK_NARROW_SPACE . '$4', "{$node_data}{$next_character}" );

--- a/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
+++ b/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2016-2018 Peter Putzer.
+ *  Copyright 2016-2019 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify modify
  *  it under the terms of the GNU General Public License as published by
@@ -63,9 +63,6 @@ class French_Punctuation_Spacing_Fix extends Abstract_Node_Fix {
 			return;
 		}
 
-		// Use the proper non-breaking narrow space.
-		$no_break_narrow_space = $settings->no_break_narrow_space();
-
 		// Need to get context of adjacent characters outside adjacent inline tags or HTML comment
 		// if we have adjacent characters add them to the text.
 		$previous_character = DOM::get_prev_chr( $textnode );
@@ -73,12 +70,12 @@ class French_Punctuation_Spacing_Fix extends Abstract_Node_Fix {
 		$node_data          = "{$previous_character}{$textnode->data}"; // $next_character is not included on purpose.
 		$f                  = Strings::functions( "{$node_data}{$next_character}" ); // Include $next_character for determining encodiing.
 
-		$node_data = \preg_replace( self::INSERT_SPACE_BEFORE_CLOSING_QUOTE, '$1' . $no_break_narrow_space . '$3$4', $node_data );
-		$node_data = \preg_replace( self::INSERT_NARROW_SPACE,               '$1' . $no_break_narrow_space . '$3$4', $node_data );
+		$node_data = \preg_replace( self::INSERT_SPACE_BEFORE_CLOSING_QUOTE, '$1' . U::NO_BREAK_NARROW_SPACE . '$3$4', $node_data );
+		$node_data = \preg_replace( self::INSERT_NARROW_SPACE,               '$1' . U::NO_BREAK_NARROW_SPACE . '$3$4', $node_data );
 		$node_data = \preg_replace( self::INSERT_FULL_SPACE,                 '$1' . U::NO_BREAK_SPACE . '$3$4',      $node_data );
 
 		// The next rule depends on the following characters as well.
-		$node_data = \preg_replace( self::INSERT_SPACE_AFTER_OPENING_QUOTE,  '$1$2' . $no_break_narrow_space . '$4', "{$node_data}{$next_character}" );
+		$node_data = \preg_replace( self::INSERT_SPACE_AFTER_OPENING_QUOTE,  '$1$2' . U::NO_BREAK_NARROW_SPACE . '$4', "{$node_data}{$next_character}" );
 
 		// If we have adjacent characters remove them from the text.
 		$textnode->data = self::remove_adjacent_characters( $node_data, $f['strlen'], $f['substr'], $f['strlen']( $previous_character ), $f['strlen']( $next_character ) );

--- a/src/fixes/node-fixes/class-smart-dashes-fix.php
+++ b/src/fixes/node-fixes/class-smart-dashes-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2014-2017 Peter Putzer.
+ *  Copyright 2014-2019 Peter Putzer.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or modify modify
@@ -133,20 +133,40 @@ class Smart_Dashes_Fix extends Abstract_Node_Fix {
 		$node_data = \str_replace( '---', U::EM_DASH, $node_data );
 		$node_data = \preg_replace( self::PARENTHETICAL_DOUBLE_DASH, "\$1{$s->parenthetical_dash()}\$2", $node_data );
 		$node_data = \str_replace( '--', U::EN_DASH, $node_data );
-		$node_data = \preg_replace( self::PARENTHETICAL_SINGLE_DASH, "\$1{$s->parenthetical_dash()}\$2", $node_data );
 
-		$node_data = \preg_replace( self::EN_DASH_WORDS ,        '$1' . U::EN_DASH . '$2',         $node_data );
-		$node_data = \preg_replace( self::EN_DASH_NUMBERS,       "\$1{$s->interval_dash()}\$3",    $node_data );
-		$node_data = \preg_replace( self::EN_DASH_PHONE_NUMBERS, '$1' . U::NO_BREAK_HYPHEN . '$2', $node_data ); // phone numbers.
-		$node_data = \str_replace( 'xn' . U::EN_DASH,            'xn--',                           $node_data ); // revert messed-up punycode.
+		$node_data = \preg_replace(
+			[
+				self::PARENTHETICAL_SINGLE_DASH,
+				self::EN_DASH_WORDS,
+				self::EN_DASH_NUMBERS,
+				self::EN_DASH_PHONE_NUMBERS,
+			],
+			[
+				"\$1{$s->parenthetical_dash()}\$2",
+				'$1' . U::EN_DASH . '$2',
+				"\$1{$s->interval_dash()}\$3",
+				'$1' . U::NO_BREAK_HYPHEN . '$2',
+			],
+			$node_data
+		);
 
-		// Revert dates back to original formats
-		// YYYY-MM-DD.
-		$node_data = \preg_replace( self::DATE_YYYY_MM_DD, '$1-$2-$3',     $node_data );
-		// MM-DD-YYYY or DD-MM-YYYY.
-		$node_data = \preg_replace( self::DATE_MM_DD_YYYY, '$1$3-$2$4-$5', $node_data );
-		// YYYY-MM or YYYY-DDDD next.
-		$node_data = \preg_replace( self::DATE_YYYY_MM,    '$1-$2',        $node_data );
+		// Revert messed-up punycode.
+		$node_data = \str_replace( 'xn' . U::EN_DASH, 'xn--', $node_data );
+
+		// Revert dates back to original formats.
+		$node_data = \preg_replace(
+			[
+				self::DATE_YYYY_MM_DD, // YYYY-MM-DD.
+				self::DATE_MM_DD_YYYY, // MM-DD-YYYY or DD-MM-YYYY.
+				self::DATE_YYYY_MM, // YYYY-MM or YYYY-DDDD.
+			],
+			[
+				'$1-$2-$3',
+				'$1$3-$2$4-$5',
+				'$1-$2',
+			],
+			$node_data
+		);
 
 		// Restore textnode content.
 		$textnode->data = $node_data;

--- a/src/fixes/node-fixes/class-smart-fractions-fix.php
+++ b/src/fixes/node-fixes/class-smart-fractions-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2018 Peter Putzer.
+ *  Copyright 2017-2019 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify modify
  *  it under the terms of the GNU General Public License as published by
@@ -144,7 +144,7 @@ class Smart_Fractions_Fix extends Abstract_Node_Fix {
 		$node_data = $textnode->data;
 
 		if ( ! empty( $settings['fractionSpacing'] ) && ! empty( $settings['smartFractions'] ) ) {
-			$node_data = \preg_replace( self::SPACING, '$1' . $settings->no_break_narrow_space() . '$2', $node_data );
+			$node_data = \preg_replace( self::SPACING, '$1' . U::NO_BREAK_NARROW_SPACE . '$2', $node_data );
 		} elseif ( ! empty( $settings['fractionSpacing'] ) && empty( $settings['smartFractions'] ) ) {
 			$node_data = \preg_replace( self::SPACING, '$1' . U::NO_BREAK_SPACE . '$2', $node_data );
 		}

--- a/src/fixes/node-fixes/class-smart-fractions-fix.php
+++ b/src/fixes/node-fixes/class-smart-fractions-fix.php
@@ -150,11 +150,23 @@ class Smart_Fractions_Fix extends Abstract_Node_Fix {
 		}
 
 		if ( ! empty( $settings['smartFractions'] ) ) {
-			// Escape sequences we don't want fractionified.
-			$node_data = \preg_replace( [ $this->escape_consecutive_years, self::ESCAPE_DATE_MM_YYYY ], '$1' . RE::ESCAPE_MARKER . '$2$3', $node_data );
+			$node_data = \preg_replace(
+				[
+					// Escape sequences we don't want fractionified.
+					$this->escape_consecutive_years,
+					self::ESCAPE_DATE_MM_YYYY,
 
-			// Replace fractions.
-			$node_data = \preg_replace( self::FRACTION_MATCHING, $this->replacement, $node_data );
+					// Replace fractions.
+					self::FRACTION_MATCHING,
+				],
+				[
+					'$1' . RE::ESCAPE_MARKER . '$2$3',
+					'$1' . RE::ESCAPE_MARKER . '$2$3',
+
+					$this->replacement,
+				],
+				$node_data
+			);
 
 			// Unescape escaped sequences.
 			$node_data = \str_replace( RE::ESCAPE_MARKER, '', $node_data );

--- a/src/fixes/node-fixes/class-smart-quotes-fix.php
+++ b/src/fixes/node-fixes/class-smart-quotes-fix.php
@@ -192,10 +192,9 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 		$node_data = \str_replace( [ "'", '"' ], [ $single_close, $double_close ], $node_data );
 
 		// Add a thin non-breaking space between secondary and primary quotes.
-		$no_break  = $settings->no_break_narrow_space();
 		$node_data = \str_replace(
 			[ "{$double_open}{$single_open}", "{$single_close}{$double_close}" ],
-			[ "{$double_open}{$no_break}{$single_open}", "{$single_close}{$no_break}{$double_close}" ],
+			[ $double_open . U::NO_BREAK_NARROW_SPACE . $single_open, $single_close . U::NO_BREAK_NARROW_SPACE . $double_close ],
 			$node_data
 		);
 

--- a/src/fixes/node-fixes/class-unit-spacing-fix.php
+++ b/src/fixes/node-fixes/class-unit-spacing-fix.php
@@ -92,9 +92,6 @@ class Unit_Spacing_Fix extends Simple_Regex_Replacement_Fix {
 	 * @param bool     $is_title Optional. Default false.
 	 */
 	public function apply( \DOMText $textnode, Settings $settings, $is_title = false ) {
-		// Update replacement with current non-breaking narrow space.
-		$this->replacement = "\$1{$settings->no_break_narrow_space()}\$2";
-
 		// Update regex with custom units.
 		$this->regex = "/(\d\.?)\s({$settings->custom_units()}" . self::_STANDARD_UNITS . ')' . self::WORD_BOUNDARY . '/Sxu';
 

--- a/src/settings/class-dash-style.php
+++ b/src/settings/class-dash-style.php
@@ -118,6 +118,8 @@ abstract class Dash_Style {
 	/**
 	 * Creates a new Dashes object in the given style.
 	 *
+	 * @since 6.5.0 The $settings parameter has been deprecated.
+	 *
 	 * @param string   $style    The dash style.
 	 * @param Settings $settings The current settings.
 	 *

--- a/src/settings/class-quote-style.php
+++ b/src/settings/class-quote-style.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2019 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -101,6 +101,10 @@ abstract class Quote_Style {
 			self::_OPEN  => U::GUILLEMET_CLOSE,
 			self::_CLOSE => U::GUILLEMET_OPEN,
 		],
+		self::DOUBLE_GUILLEMETS_FRENCH   => [
+			self::_OPEN  => U::GUILLEMET_OPEN . U::NO_BREAK_NARROW_SPACE,
+			self::_CLOSE => U::NO_BREAK_NARROW_SPACE . U::GUILLEMET_CLOSE,
+		],
 		self::SINGLE_GUILLEMETS          => [
 			self::_OPEN  => U::SINGLE_ANGLE_QUOTE_OPEN,
 			self::_CLOSE => U::SINGLE_ANGLE_QUOTE_CLOSE,
@@ -148,12 +152,6 @@ abstract class Quote_Style {
 	public static function get_styled_quotes( $style, Settings $settings ) {
 		if ( isset( self::$styles[ $style ] ) ) {
 			return new Simple_Quotes( self::$styles[ $style ][ self::_OPEN ], self::$styles[ $style ][ self::_CLOSE ] );
-		}
-
-		if ( self::DOUBLE_GUILLEMETS_FRENCH === $style ) {
-			$space = $settings->no_break_narrow_space();
-
-			return new Simple_Quotes( U::GUILLEMET_OPEN . $space, $space . U::GUILLEMET_CLOSE );
 		}
 
 		return null;

--- a/src/settings/class-quote-style.php
+++ b/src/settings/class-quote-style.php
@@ -144,12 +144,14 @@ abstract class Quote_Style {
 	/**
 	 * Creates a new Quotes object in the given style.
 	 *
+	 * @since 6.5.0 The $settings parameter has been deprecated.
+	 * 
 	 * @param string   $style    The quote style.
 	 * @param Settings $settings The current settings.
 	 *
 	 * @return Quotes|null Returns null in case of an invalid $style parameter.
 	 */
-	public static function get_styled_quotes( $style, Settings $settings ) {
+	public static function get_styled_quotes( $style, /** Currently unused. @scrutinizer ignore-unused */ Settings $settings ) {
 		if ( isset( self::$styles[ $style ] ) ) {
 			return new Simple_Quotes( self::$styles[ $style ][ self::_OPEN ], self::$styles[ $style ][ self::_CLOSE ] );
 		}

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -592,6 +592,35 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 	}
 
 	/**
+	 * Test process_textnodes.
+	 *
+	 * @covers ::process_textnodes
+	 *
+	 * @uses PHP_Typography\Hyphenator
+	 * @uses PHP_Typography\Hyphenator\Trie_Node
+	 * @uses PHP_Typography\Text_Parser
+	 * @uses PHP_Typography\Text_Parser\Token
+	 * @uses PHP_Typography\Settings\Dash_Style::get_styled_dashes
+	 * @uses PHP_Typography\Settings\Quote_Style::get_styled_quotes
+	 */
+	public function test_process_textnodes_with_result() {
+		$s = $this->s;
+		$s->set_defaults();
+
+		// We don't really care about the result, so we make sotmhing up.
+		$this->assertSame(
+			'fake result',
+			$this->typo->process_textnodes(
+				'some input',
+				function ( $node ) {
+					$node->data = 'fake result';
+				},
+				$s
+			)
+		);
+	}
+
+	/**
 	 * Provide invalid data for testing process_textnodes.
 	 *
 	 * @return array

--- a/tests/class-php-typography-testcase.php
+++ b/tests/class-php-typography-testcase.php
@@ -357,8 +357,8 @@ abstract class PHP_Typography_Testcase extends \PHPUnit\Framework\TestCase {
 				break;
 
 			case 'doubleGuillemetsFrench':
-				$this->assertSame( Strings::uchr( 171, 160 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 160, 187 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( Strings::uchr( 171, 8239 ), $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( Strings::uchr( 8239, 187 ), $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'doubleGuillemets':

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -1593,6 +1593,65 @@ class Settings_Test extends PHP_Typography_Testcase {
 	}
 
 	/**
+	 * Tests apply_character_mapping.
+	 *
+	 * @covers ::remap_character
+	 */
+	public function test_remap_character() {
+		$mapping = [
+			'a' => 'A',
+			'r' => 'z',
+		];
+
+		$s = new Settings( false, $mapping );
+		$this->assertAttributeSame( $mapping, 'unicode_mapping', $s );
+
+		$s->remap_character( 'a', 'a' );
+		$this->assertAttributeSame( [ 'r' => 'z' ], 'unicode_mapping', $s );
+
+		$s->remap_character( U::NO_BREAK_NARROW_SPACE, 'x' );
+		$this->assertAttributeCount( 2, 'unicode_mapping', $s );
+		$this->assertAttributeContains( 'x', 'unicode_mapping', $s );
+		$this->assertAttributeSame( 'x', 'no_break_narrow_space', $s );
+	}
+
+
+	/**
+	 * Provides data for testing apply_character_mapping.
+	 *
+	 * @return array
+	 */
+	public function provide_apply_character_mapping_data() {
+		return [
+			[ 'foobar', 'foobAz' ],
+			[ [ 'foobar' ], [ 'foobAz' ] ],
+			[ [ 'foobar', 'fugazi' ], [ 'foobAz', 'fugAzi' ] ],
+			[ '', '' ],
+		];
+	}
+
+	/**
+	 * Tests apply_character_mapping.
+	 *
+	 * @covers ::apply_character_mapping
+	 *
+	 * @dataProvider provide_apply_character_mapping_data
+	 *
+	 * @param  string|string[] $input  The input.
+	 * @param  string|string[] $result The expected result.
+	 */
+	public function test_apply_character_mapping( $input, $result ) {
+		$mapping = [
+			'a' => 'A',
+			'r' => 'z',
+		];
+
+		$s = new Settings( false, $mapping );
+
+		$this->assertSame( $result, $s->apply_character_mapping( $input ) );
+	}
+
+	/**
 	 * Provide data for testing array_map_assoc.
 	 *
 	 * @return array

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -791,6 +791,11 @@ class Settings_Test extends PHP_Typography_Testcase {
 				[],
 				[],
 			],
+			[
+				'foobar',
+				[],
+				[],
+			],
 		];
 	}
 

--- a/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
@@ -77,9 +77,9 @@ class Smart_Quotes_Fix_Test extends Node_Fix_Testcase {
 			[ '3/44"',                             '3/44&Prime;' ],
 			[ '("Some" word',                      '(&ldquo;Some&rdquo; word' ],
 			[ 'Some "word")',                      'Some &ldquo;word&rdquo;)' ],
-			[ '"So \'this\'", she said',           '&ldquo;So &lsquo;this&rsquo;&nbsp;&rdquo;, she said' ],
-			[ '"\'This\' is it?"',                 '&ldquo;&nbsp;&lsquo;This&rsquo; is it?&rdquo;' ],
-			[ 'from the early \'60s, American',    'from the early ’60s, American' ],
+			[ '"So \'this\'", she said',           '&ldquo;So &lsquo;this&rsquo;&#8239;&rdquo;, she said' ],
+			[ '"\'This\' is it?"',                 '&ldquo;&#8239;&lsquo;This&rsquo; is it?&rdquo;' ],
+			[ 'from the early \'60s, American',    'from the early &#700;60s, American' ],
 		];
 	}
 
@@ -98,7 +98,7 @@ class Smart_Quotes_Fix_Test extends Node_Fix_Testcase {
 			],
 			[
 				'(sans franchir la case "carte de crédit")',
-				'(sans franchir la case &laquo;&nbsp;carte de cr&eacute;dit&nbsp;&raquo;)',
+				'(sans franchir la case &laquo;&#8239;carte de cr&eacute;dit&#8239;&raquo;)',
 				Quote_Style::DOUBLE_GUILLEMETS_FRENCH,
 				Quote_Style::SINGLE_GUILLEMETS_REVERSED,
 			],


### PR DESCRIPTION
- Adds general character remapping framework
- Deprecates `Settings:: set_true_no_break_narrow_space()` and `Settings::no_break_narrow_space()`
- Updates the fixes to use the new framework consistently.

Fixes #99.