### PR TITLE
Release 6.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change History
 
+## 6.5.1 - July 8, 2019
+*   _Bugfix_: The smart area and volume units fix now handles missing whitespace
+    as well (e.g. `5m2` is transformed into `5 m²`).
+
 ## 6.5.0 - July 6, 2019
 *   _Feature_: Use non-breaking hyphen for connecting one-letter-words and when
     an elision is followed by a comma.

--- a/src/fixes/node-fixes/class-smart-area-units-fix.php
+++ b/src/fixes/node-fixes/class-smart-area-units-fix.php
@@ -39,7 +39,7 @@ use PHP_Typography\U;
  */
 class Smart_Area_Units_Fix extends Abstract_Node_Fix {
 
-	const LENGTH_UNITS = 'mm|cm|m';
+	const LENGTH_UNITS = '(?:p|µ|[mcdhkMGT])?m'; // Just metric for now.
 	const NUMBER       = '[0-9]+(?:\.,)?[0-9]*';
 	const WHITESPACE   = '\s*';
 

--- a/src/fixes/node-fixes/class-smart-area-units-fix.php
+++ b/src/fixes/node-fixes/class-smart-area-units-fix.php
@@ -60,7 +60,7 @@ class Smart_Area_Units_Fix extends Abstract_Node_Fix {
 
 		$textnode->data = \preg_replace(
 			[ self::AREA_UNITS, self::VOLUME_UNITS ],
-			[ '$1$2$3²', '$1$2$3³' ],
+			[ '$1 $3²', '$1 $3³' ],
 			$textnode->data
 		);
 	}

--- a/tests/fixes/node-fixes/class-smart-area-units-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-area-units-fix-test.php
@@ -67,6 +67,7 @@ class Smart_Area_Units_Fix_Test extends Node_Fix_Testcase {
 			[ '10 cm2', '10 cm²' ],
 			[ '10,20 mm2', '10,20 mm²' ],
 			[ '5 m2, das ergibt 5000000mm2', '5 m², das ergibt 5000000mm²' ],
+			[ '3 µm2', '3 µm²' ],
 		];
 	}
 

--- a/tests/fixes/node-fixes/class-smart-area-units-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-area-units-fix-test.php
@@ -66,8 +66,9 @@ class Smart_Area_Units_Fix_Test extends Node_Fix_Testcase {
 			[ '5.3 m3', '5.3 m³' ],
 			[ '10 cm2', '10 cm²' ],
 			[ '10,20 mm2', '10,20 mm²' ],
-			[ '5 m2, das ergibt 5000000mm2', '5 m², das ergibt 5000000mm²' ],
+			[ '5 m2, das ergibt 5000000mm2', '5 m², das ergibt 5000000 mm²' ],
 			[ '3 µm2', '3 µm²' ],
+			[ '2m2', '2 m²' ],
 		];
 	}
 

--- a/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
@@ -74,6 +74,9 @@ class Unit_Spacing_Fix_Test extends Node_Fix_Testcase {
 			[ '5 nanoamperes', '5&#8239;nanoamperes' ],
 			[ '1 Ω', '1&#8239;&Omega;' ],
 			[ '1 &Omega;', '1&#8239;&Omega;' ],
+			[ '10 m2', '10&#8239;m2' ],
+			[ '10 m²', '10&#8239;m²' ],
+			[ '5 m³', '5&#8239;m³' ],
 		];
 	}
 


### PR DESCRIPTION
The smart area and volume units fix now handles missing whitespace as well (e.g. `5m2` is transformed into `5 m²`).
