### PR TITLE
Update PHPUnit infrastructure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "5.*||6.*||7.*",
+        "phpunit/phpunit": "5.*||6.*||7.*|8.*|9.*",
         "brain/monkey": "^2.2.0",
         "squizlabs/php_codesniffer": "^3",
         "wp-coding-standards/wpcs": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "phpcompatibility/php-compatibility": "^9.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
         "phpstan/phpstan": "^0.12",
-        "phpbench/phpbench": "^0.17||^1.0@dev"
+        "phpbench/phpbench": "^0.17||^1.0@dev",
+        "mundschenk-at/phpunit-cross-version": "dev-master"
     },
 
     "autoload": {

--- a/tests/class-dom-test.php
+++ b/tests/class-dom-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@ use PHP_Typography\DOM;
  * @coversDefaultClass \PHP_Typography\DOM
  * @usesDefaultClass \PHP_Typography\DOM
  */
-class DOM_Test extends PHP_Typography_Testcase {
+class DOM_Test extends Testcase {
 
 	/**
 	 * HTML parser.

--- a/tests/class-dom-test.php
+++ b/tests/class-dom-test.php
@@ -45,8 +45,8 @@ class DOM_Test extends PHP_Typography_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->parser = new \Masterminds\HTML5( [ 'disable_html_ns' => true ] );
 	}

--- a/tests/class-dom-test.php
+++ b/tests/class-dom-test.php
@@ -69,7 +69,7 @@ class DOM_Test extends Testcase {
 	 */
 	public function test_block_tags() {
 		$block_tags = DOM::block_tags( true );
-		$this->assertInternalType( 'array', $block_tags );
+		$this->assert_is_array( $block_tags );
 
 		$tag_names = array_keys( $block_tags );
 		$this->assertContainsOnly( 'string', $tag_names );
@@ -94,7 +94,7 @@ class DOM_Test extends Testcase {
 	 */
 	public function test_inappropriate_tags() {
 		$inappropriate_tags = DOM::inappropriate_tags( true );
-		$this->assertInternalType( 'array', $inappropriate_tags );
+		$this->assert_is_array( $inappropriate_tags );
 
 		$tag_names = array_keys( $inappropriate_tags );
 		$this->assertContainsOnly( 'string', $tag_names );

--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -529,14 +529,14 @@ class Hyphenator_Test extends Testcase {
 		$this->assertAttributeNotCount( 0, 'merged_exception_patterns', $h );
 		$this->assertAttributeNotCount( 1, 'merged_exception_patterns', $h );
 		$this->assertAttributeNotCount( 2, 'merged_exception_patterns', $h );
-		$this->assert_attribute_array_has_kay( 'hugo', 'merged_exception_patterns', $h );
-		$this->assert_attribute_array_has_kay( 'fäviken', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_key( 'hugo', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_key( 'fäviken', 'merged_exception_patterns', $h );
 
 		$h->set_language( 'de' ); // w/o pattern exceptions.
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
 		$this->assertAttributeCount( 2, 'merged_exception_patterns', $h );
-		$this->assert_attribute_array_has_kay( 'hugo', 'merged_exception_patterns', $h );
-		$this->assert_attribute_array_has_kay( 'fäviken', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_key( 'hugo', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_key( 'fäviken', 'merged_exception_patterns', $h );
 
 		$h->set_language( 'en-US' ); // w/ pattern exceptions.
 		$h->set_custom_exceptions( [] );

--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2016-2019 Peter Putzer.
+ *  Copyright 2016-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -44,8 +44,8 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->h = new \PHP_Typography\Hyphenator();
 	}
@@ -125,7 +125,7 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 			]
 		);
 		$h->set_language( 'en-US' );
-		$this->invokeMethod( $h, 'merge_hyphenation_exceptions', [] );
+		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
 		$this->assertAttributeNotEmpty( 'pattern_trie', $h, 'Empty pattern array' );
 		$this->assertAttributeNotEmpty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
 
@@ -223,7 +223,7 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 		$exceptions = [ 'Hu-go', 'Fö-ba-ß' ];
 		$h->set_custom_exceptions( $exceptions );
 		$h->set_language( 'de' ); // German has no pattern exceptions.
-		$this->invokeMethod( $h, 'merge_hyphenation_exceptions', [] );
+		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
 		$this->assertAttributeNotEmpty( 'merged_exception_patterns', $h );
 
 		$exceptions = [ 'Hu-go' ];
@@ -297,7 +297,7 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 		$h->set_language( $lang );
 		$h->set_custom_exceptions( [ 'KING-desk' ] );
 
-		$this->assertTokensSame( $result, $h->hyphenate( $this->tokenize_sentence( $html ), '|', $hyphenate_title_case, 2, 2, 2 ) );
+		$this->assert_tokens_same( $result, $h->hyphenate( $this->tokenize_sentence( $html ), '|', $hyphenate_title_case, 2, 2, 2 ) );
 	}
 
 	/**
@@ -341,7 +341,7 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 		$h->set_language( $lang );
 		$h->set_custom_exceptions( $exceptions );
 
-		$this->assertTokensSame( $result, $h->hyphenate( $this->tokenize_sentence( $html ), '|', $hyphenate_title_case, 2, 2, 2 ) );
+		$this->assert_tokens_same( $result, $h->hyphenate( $this->tokenize_sentence( $html ), '|', $hyphenate_title_case, 2, 2, 2 ) );
 	}
 
 	/**
@@ -362,11 +362,11 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 
 		$tokens     = $this->tokenize( mb_convert_encoding( 'Änderungsmeldung', 'ISO-8859-2' ) );
 		$hyphenated = $this->h->hyphenate( $tokens, '|', true, 2, 2, 2 );
-		$this->assertTokensSame( $hyphenated, $tokens, 'Wrong encoding, value should be unchanged.' );
+		$this->assert_tokens_same( $hyphenated, $tokens, 'Wrong encoding, value should be unchanged.' );
 
 		$tokens     = $this->tokenize( 'Änderungsmeldung' );
 		$hyphenated = $this->h->hyphenate( $tokens, '|', true, 2, 2, 2 );
-		$this->assertTokensNotSame( $hyphenated, $tokens, 'Correct encoding, string should have been hyphenated.' );
+		$this->assert_tokens_not_same( $hyphenated, $tokens, 'Correct encoding, string should have been hyphenated.' );
 	}
 
 	/**
@@ -423,9 +423,9 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 		$string = 'unknown';
 
 		// Make pattern trie invalid.
-		$this->setValue( $this->h, 'pattern_trie', null );
+		$this->set_value( $this->h, 'pattern_trie', null );
 
-		$this->assertSame( [], $this->invokeMethod( $this->h, 'lookup_word_pattern', [ $string, 'strlen', 'str_split' ] ) );
+		$this->assertSame( [], $this->invoke_method( $this->h, 'lookup_word_pattern', [ $string, 'strlen', 'str_split' ] ) );
 	}
 
 	/**
@@ -444,7 +444,7 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 		$this->h->set_language( 'en-US' );
 
 		// Again, no punctuation due to the fake tokenization.
-		$this->assertTokensSame(
+		$this->assert_tokens_same(
 			'A few words to hy|phen|ate like KINGdesk Re|al|ly there should be more hy|phen|ation here',
 			$this->h->hyphenate( $this->tokenize_sentence( 'A few words to hyphenate like KINGdesk Really there should be more hyphenation here' ), '|', true, 2, 2, 2 )
 		);
@@ -477,7 +477,7 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 		$prop->setValue( $this->h, null );
 
 		// Again, no punctuation due to the fake tokenization.
-		$this->assertTokensSame(
+		$this->assert_tokens_same(
 			'A few words to hy|phen|ate like KINGdesk Re|al|ly there should be more hy|phen|ation here',
 			$this->h->hyphenate( $this->tokenize_sentence( 'A few words to hyphenate like KINGdesk Really there should be more hyphenation here' ), '|', true, 2, 2, 2 )
 		);
@@ -492,8 +492,8 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 	 */
 	public function test_convert_hyphenation_exception_to_pattern() {
 		$h = $this->h;
-		$this->assertSame( [ 4 => 9 ], $this->invokeMethod( $h, 'convert_hyphenation_exception_to_pattern', [ 'KING-desk' ] ) );
-		$this->assertSame( [ 2 => 9 ], $this->invokeMethod( $h, 'convert_hyphenation_exception_to_pattern', [ 'ta-ble' ] ) );
+		$this->assertSame( [ 4 => 9 ], $this->invoke_method( $h, 'convert_hyphenation_exception_to_pattern', [ 'KING-desk' ] ) );
+		$this->assertSame( [ 2 => 9 ], $this->invoke_method( $h, 'convert_hyphenation_exception_to_pattern', [ 'ta-ble' ] ) );
 	}
 
 	/**
@@ -508,7 +508,7 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 		$h         = $this->h;
 		$exception = mb_convert_encoding( 'Fö-ba-ß' , 'ISO-8859-2' );
 
-		$this->assertNull( $this->invokeMethod( $h, 'convert_hyphenation_exception_to_pattern', [ $exception ] ) );
+		$this->assertNull( $this->invoke_method( $h, 'convert_hyphenation_exception_to_pattern', [ $exception ] ) );
 	}
 
 	/**
@@ -525,31 +525,31 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 		$h->set_custom_exceptions( [ 'Hu-go', 'Fä-vi-ken' ] );
 
 		$h->set_language( 'en-US' ); // w/ pattern exceptions.
-		$this->invokeMethod( $h, 'merge_hyphenation_exceptions', [] );
+		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
 		$this->assertAttributeNotCount( 0, 'merged_exception_patterns', $h );
 		$this->assertAttributeNotCount( 1, 'merged_exception_patterns', $h );
 		$this->assertAttributeNotCount( 2, 'merged_exception_patterns', $h );
-		$this->assertAttributeArrayHasKey( 'hugo', 'merged_exception_patterns', $h );
-		$this->assertAttributeArrayHasKey( 'fäviken', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_kay( 'hugo', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_kay( 'fäviken', 'merged_exception_patterns', $h );
 
 		$h->set_language( 'de' ); // w/o pattern exceptions.
-		$this->invokeMethod( $h, 'merge_hyphenation_exceptions', [] );
+		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
 		$this->assertAttributeCount( 2, 'merged_exception_patterns', $h );
-		$this->assertAttributeArrayHasKey( 'hugo', 'merged_exception_patterns', $h );
-		$this->assertAttributeArrayHasKey( 'fäviken', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_kay( 'hugo', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_kay( 'fäviken', 'merged_exception_patterns', $h );
 
 		$h->set_language( 'en-US' ); // w/ pattern exceptions.
 		$h->set_custom_exceptions( [] );
-		$this->invokeMethod( $h, 'merge_hyphenation_exceptions', [] );
+		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
 		$this->assertAttributeNotCount( 0, 'merged_exception_patterns', $h );
-		$this->assertAttributeArrayNotHasKey( 'hugo', 'merged_exception_patterns', $h );
-		$this->assertAttributeArrayNotHasKey( 'fäviken', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_not_has_key( 'hugo', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_not_has_key( 'fäviken', 'merged_exception_patterns', $h );
 
 		$h->set_language( 'de' ); // w/o pattern exceptions.
-		$this->invokeMethod( $h, 'merge_hyphenation_exceptions', [] );
+		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
 		$this->assertAttributeCount( 0, 'merged_exception_patterns', $h );
-		$this->assertAttributeArrayNotHasKey( 'hugo', 'merged_exception_patterns', $h );
-		$this->assertAttributeArrayNotHasKey( 'fäviken', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_not_has_key( 'hugo', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_not_has_key( 'fäviken', 'merged_exception_patterns', $h );
 	}
 
 	/**
@@ -579,9 +579,9 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 	 */
 	public function test_is_odd( $number, $result ) {
 		if ( $result ) {
-			$this->assertTrue( $this->invokeStaticMethod( \PHP_Typography\Hyphenator::class, 'is_odd', [ $number ] ) );
+			$this->assertTrue( $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'is_odd', [ $number ] ) );
 		} else {
-			$this->assertFalse( $this->invokeStaticMethod( \PHP_Typography\Hyphenator::class, 'is_odd', [ $number ] ) );
+			$this->assertFalse( $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'is_odd', [ $number ] ) );
 		}
 	}
 
@@ -591,11 +591,11 @@ class Hyphenator_Test extends PHP_Typography_Testcase {
 	 * @covers ::get_object_hash
 	 */
 	public function test_get_object_hash() {
-		$hash1 = $this->invokeStaticMethod( \PHP_Typography\Hyphenator::class, 'get_object_hash', [ 666 ] );
+		$hash1 = $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'get_object_hash', [ 666 ] );
 		$this->assertInternalType( 'string', $hash1 );
 		$this->assertGreaterThan( 0, strlen( $hash1 ) );
 
-		$hash2 = $this->invokeStaticMethod( \PHP_Typography\Hyphenator::class, 'get_object_hash', [ new \stdClass() ] );
+		$hash2 = $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'get_object_hash', [ new \stdClass() ] );
 		$this->assertInternalType( 'string', $hash2 );
 		$this->assertGreaterThan( 0, strlen( $hash2 ) );
 

--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -32,7 +32,7 @@ namespace PHP_Typography\Tests;
  *
  * @uses PHP_Typography\Hyphenator
  */
-class Hyphenator_Test extends PHP_Typography_Testcase {
+class Hyphenator_Test extends Testcase {
 	/**
 	 * Hyphenator fixture.
 	 *

--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -355,7 +355,6 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 * @uses PHP_Typography\Strings::mb_str_split
-	 * @uses \mb_convert_encoding
 	 */
 	public function test_hyphenate_wrong_encoding() {
 		$this->h->set_language( 'de' );
@@ -457,8 +456,6 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
-	 * @uses ReflectionClass
-	 * @uses ReflectionProperty
 	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
@@ -502,7 +499,6 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::convert_hyphenation_exception_to_pattern
 	 *
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses \mb_convert_encoding
 	 */
 	public function test_convert_hyphenation_exception_to_pattern_unknown_encoding() {
 		$h         = $this->h;

--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -70,8 +70,8 @@ class Hyphenator_Test extends Testcase {
 		$h2 = new \PHP_Typography\Hyphenator( 'en-US', [ 'foo-bar' ] );
 		$this->assertNotNull( $h2 );
 		$this->assertInstanceOf( '\PHP_Typography\Hyphenator', $h2 );
-		$this->assertAttributeSame( 'en-US', 'language', $h2 );
-		$this->assertAttributeCount( 1, 'custom_exceptions', $h2 );
+		$this->assert_attribute_same( 'en-US', 'language', $h2 );
+		$this->assert_attribute_count( 1, 'custom_exceptions', $h2 );
 	}
 
 	/**
@@ -87,20 +87,20 @@ class Hyphenator_Test extends Testcase {
 	public function test_set_language() {
 		$h = $this->h;
 		$h->set_language( 'en-US' );
-		$this->assertAttributeNotEmpty( 'pattern_trie', $h, 'Empty English-US pattern array' );
-		$this->assertAttributeNotEmpty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty English-US pattern array' );
+		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
 
 		$h->set_language( 'foobar' );
-		$this->assertAttributeEmpty( 'pattern_trie', $h );
-		$this->assertAttributeEmpty( 'pattern_exceptions', $h );
+		$this->assert_attribute_empty( 'pattern_trie', $h );
+		$this->assert_attribute_empty( 'pattern_exceptions', $h );
 
 		$h->set_language( 'no' );
-		$this->assertAttributeNotEmpty( 'pattern_trie', $h, 'Empty Norwegian pattern array' );
-		$this->assertAttributeNotEmpty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' ); // Norwegian has exceptions.
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty Norwegian pattern array' );
+		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' ); // Norwegian has exceptions.
 
 		$h->set_language( 'de' );
-		$this->assertAttributeNotEmpty( 'pattern_trie', $h, 'Empty German pattern array' );
-		$this->assertAttributeEmpty( 'pattern_exceptions', $h, 'Unexpected pattern exceptions found' ); // no exceptions in the German pattern file.
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty German pattern array' );
+		$this->assert_attribute_empty( 'pattern_exceptions', $h, 'Unexpected pattern exceptions found' ); // no exceptions in the German pattern file.
 	}
 
 	/**
@@ -126,12 +126,12 @@ class Hyphenator_Test extends Testcase {
 		);
 		$h->set_language( 'en-US' );
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
-		$this->assertAttributeNotEmpty( 'pattern_trie', $h, 'Empty pattern array' );
-		$this->assertAttributeNotEmpty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
+		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
 
 		$h->set_language( 'de' );
-		$this->assertAttributeNotEmpty( 'pattern_trie', $h, 'Empty pattern array' );
-		$this->assertAttributeEmpty( 'pattern_exceptions', $h, 'Unexpected pattern exceptions found' ); // no exceptions in the German pattern file.
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
+		$this->assert_attribute_empty( 'pattern_exceptions', $h, 'Unexpected pattern exceptions found' ); // no exceptions in the German pattern file.
 	}
 
 	/**
@@ -148,12 +148,12 @@ class Hyphenator_Test extends Testcase {
 		$h = $this->h;
 
 		$h->set_language( 'en-US' );
-		$this->assertAttributeNotEmpty( 'pattern_trie', $h, 'Empty pattern array' );
-		$this->assertAttributeNotEmpty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
+		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
 
 		$h->set_language( 'en-US' );
-		$this->assertAttributeNotEmpty( 'pattern_trie', $h, 'Empty pattern array' );
-		$this->assertAttributeNotEmpty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
+		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
 	}
 
 	/**
@@ -190,18 +190,18 @@ class Hyphenator_Test extends Testcase {
 			if ( ! empty( $exceptions ) ) {
 
 				// Exceptions have to be strings.
-				$this->assertAttributeContainsOnly( 'string', 'custom_exceptions', $h );
+				$this->assert_attribute_contains_only( 'string', 'custom_exceptions', $h );
 
 				// Assert count.
-				$this->assertAttributeCount( $count, 'custom_exceptions', $h );
+				$this->assert_attribute_count( $count, 'custom_exceptions', $h );
 			} else {
-				$this->assertAttributeEmpty( 'custom_exceptions', $h );
+				$this->assert_attribute_empty( 'custom_exceptions', $h );
 			}
 
 			// Assert existence of individual exceptions.
 			foreach ( $exceptions as $exception ) {
 				$exception = mb_strtolower( $exception ); // Exceptions are stored all lowercase.
-				$this->assertAttributeContains( $exception, 'custom_exceptions', $h, "Exception $exception not found in round $i" );
+				$this->assert_attribute_contains( $exception, 'custom_exceptions', $h, "Exception $exception not found in round $i" );
 			}
 		}
 	}
@@ -224,15 +224,15 @@ class Hyphenator_Test extends Testcase {
 		$h->set_custom_exceptions( $exceptions );
 		$h->set_language( 'de' ); // German has no pattern exceptions.
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
-		$this->assertAttributeNotEmpty( 'merged_exception_patterns', $h );
+		$this->assert_attribute_not_empty( 'merged_exception_patterns', $h );
 
 		$exceptions = [ 'Hu-go' ];
 		$h->set_custom_exceptions( $exceptions );
-		$this->assertAttributeEmpty( 'merged_exception_patterns', $h );
+		$this->assert_attribute_empty( 'merged_exception_patterns', $h );
 
-		$this->assertAttributeContainsOnly( 'string', 'custom_exceptions', $h );
-		$this->assertAttributeContains( 'hu-go', 'custom_exceptions', $h );
-		$this->assertAttributeCount( 1, 'custom_exceptions', $h );
+		$this->assert_attribute_contains_only( 'string', 'custom_exceptions', $h );
+		$this->assert_attribute_contains( 'hu-go', 'custom_exceptions', $h );
+		$this->assert_attribute_count( 1, 'custom_exceptions', $h );
 	}
 
 	/**
@@ -247,10 +247,10 @@ class Hyphenator_Test extends Testcase {
 		$exceptions = [ 'Hu-go', mb_convert_encoding( 'Fö-ba-ß', 'ISO-8859-2' ) ];
 		$h->set_custom_exceptions( $exceptions );
 
-		$this->assertAttributeContainsOnly( 'string', 'custom_exceptions', $h );
-		$this->assertAttributeContains( 'hu-go', 'custom_exceptions', $h );
-		$this->assertAttributeNotContains( 'fö-ba-ß', 'custom_exceptions', $h );
-		$this->assertAttributeCount( 1, 'custom_exceptions', $h );
+		$this->assert_attribute_contains_only( 'string', 'custom_exceptions', $h );
+		$this->assert_attribute_contains( 'hu-go', 'custom_exceptions', $h );
+		$this->assert_attribute_not_contains( 'fö-ba-ß', 'custom_exceptions', $h );
+		$this->assert_attribute_count( 1, 'custom_exceptions', $h );
 	}
 
 	/**
@@ -526,28 +526,28 @@ class Hyphenator_Test extends Testcase {
 
 		$h->set_language( 'en-US' ); // w/ pattern exceptions.
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
-		$this->assertAttributeNotCount( 0, 'merged_exception_patterns', $h );
-		$this->assertAttributeNotCount( 1, 'merged_exception_patterns', $h );
-		$this->assertAttributeNotCount( 2, 'merged_exception_patterns', $h );
+		$this->assert_attribute_not_count( 0, 'merged_exception_patterns', $h );
+		$this->assert_attribute_not_count( 1, 'merged_exception_patterns', $h );
+		$this->assert_attribute_not_count( 2, 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_has_key( 'hugo', 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_has_key( 'fäviken', 'merged_exception_patterns', $h );
 
 		$h->set_language( 'de' ); // w/o pattern exceptions.
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
-		$this->assertAttributeCount( 2, 'merged_exception_patterns', $h );
+		$this->assert_attribute_count( 2, 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_has_key( 'hugo', 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_has_key( 'fäviken', 'merged_exception_patterns', $h );
 
 		$h->set_language( 'en-US' ); // w/ pattern exceptions.
 		$h->set_custom_exceptions( [] );
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
-		$this->assertAttributeNotCount( 0, 'merged_exception_patterns', $h );
+		$this->assert_attribute_not_count( 0, 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_not_has_key( 'hugo', 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_not_has_key( 'fäviken', 'merged_exception_patterns', $h );
 
 		$h->set_language( 'de' ); // w/o pattern exceptions.
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
-		$this->assertAttributeCount( 0, 'merged_exception_patterns', $h );
+		$this->assert_attribute_count( 0, 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_not_has_key( 'hugo', 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_not_has_key( 'fäviken', 'merged_exception_patterns', $h );
 	}
@@ -592,11 +592,11 @@ class Hyphenator_Test extends Testcase {
 	 */
 	public function test_get_object_hash() {
 		$hash1 = $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'get_object_hash', [ 666 ] );
-		$this->assertInternalType( 'string', $hash1 );
+		$this->assert_is_string( $hash1 );
 		$this->assertGreaterThan( 0, strlen( $hash1 ) );
 
 		$hash2 = $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'get_object_hash', [ new \stdClass() ] );
-		$this->assertInternalType( 'string', $hash2 );
+		$this->assert_is_string( $hash2 );
 		$this->assertGreaterThan( 0, strlen( $hash2 ) );
 
 		$this->assertNotEquals( $hash1, $hash2 );

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -2960,7 +2960,7 @@ class PHP_Typography_Test extends Testcase {
 	 */
 	public function test_get_html5_parser() {
 
-		$this->assertAttributeEmpty( 'html5_parser', $this->typo );
+		$this->assert_attribute_empty( 'html5_parser', $this->typo );
 
 		$parser1 = $this->typo->get_html5_parser();
 		$this->assertInstanceOf( '\Masterminds\HTML5', $parser1 );
@@ -2969,7 +2969,7 @@ class PHP_Typography_Test extends Testcase {
 		$this->assertInstanceOf( '\Masterminds\HTML5', $parser2 );
 
 		$this->assertSame( $parser1, $parser2 );
-		$this->assertAttributeInstanceOf( '\Masterminds\HTML5', 'html5_parser', $this->typo );
+		$this->assert_attribute_instance_of( '\Masterminds\HTML5', 'html5_parser', $this->typo );
 	}
 
 	/**

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -39,8 +39,6 @@ use PHP_Typography\Fixes\Registry;
 
 use PHP_Typography\Hyphenator\Cache as Hyphenator_Cache;
 
-use Brain\Monkey;
-
 use \Mockery as m;
 
 /**
@@ -96,7 +94,7 @@ use \Mockery as m;
  * @uses PHP_Typography\Fixes\Node_Fixes\Style_Numbers_Fix
  * @uses PHP_Typography\Fixes\Node_Fixes\Unit_Spacing_Fix
  */
-class PHP_Typography_Test extends PHP_Typography_Testcase {
+class PHP_Typography_Test extends Testcase {
 
 	/**
 	 * The PHP_Typography instance.

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -116,8 +116,8 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->typo = new PHP_Typography();
 		$this->s    = new Settings( false );
@@ -130,12 +130,12 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 	 */
 	public function test_constructor() {
 		$typo = new PHP_Typography();
-		$this->assertNull( $this->getValue( $typo, 'registry' ) );
-		$this->assertFalse( $this->getValue( $typo, 'update_registry_cache' ) );
+		$this->assertNull( $this->get_value( $typo, 'registry' ) );
+		$this->assertFalse( $this->get_value( $typo, 'update_registry_cache' ) );
 
 		$typo = new PHP_Typography( m::mock( Registry::class ) );
-		$this->assertNotNull( $this->getValue( $typo, 'registry' ) );
-		$this->assertTrue( $this->getValue( $typo, 'update_registry_cache' ) );
+		$this->assertNotNull( $this->get_value( $typo, 'registry' ) );
+		$this->assertTrue( $this->get_value( $typo, 'update_registry_cache' ) );
 	}
 
 	/**
@@ -444,9 +444,9 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 			$this->expectException( \PHPUnit\Framework\Error\Warning::class );
 		}
 
-		$this->invokeStaticMethod( PHP_Typography::class, 'get_language_plugin_list', [ '/does/not/exist' ] );
+		$this->invoke_static_method( PHP_Typography::class, 'get_language_plugin_list', [ '/does/not/exist' ] );
 
-		$this->assertEmpty( @$this->invokeStaticMethod( PHP_Typography::class, 'get_language_plugin_list', [ '/does/not/exist' ] ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		$this->assertEmpty( @$this->invoke_static_method( PHP_Typography::class, 'get_language_plugin_list', [ '/does/not/exist' ] ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 	}
 
 	/**
@@ -3132,7 +3132,7 @@ class PHP_Typography_Test extends PHP_Typography_Testcase {
 			}
 		}
 
-		$this->assertSame( $result, $this->invokeStaticMethod( PHP_Typography::class, 'arrays_intersect', [ $array1, $array2 ] ) );
+		$this->assertSame( $result, $this->invoke_static_method( PHP_Typography::class, 'arrays_intersect', [ $array1, $array2 ] ) );
 	}
 
 	/**

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -442,9 +442,9 @@ class PHP_Typography_Test extends Testcase {
 	public function test_get_language_plugin_list_incorrect_path() {
 		// PHP < 7.0 raises an error instead of throwing an "exception".
 		if ( version_compare( phpversion(), '7.0.0', '<' ) ) {
-			$this->expectException( \PHPUnit_Framework_Error_Warning::class );
+			$this->expect_warning( \PHPUnit_Framework_Error_Warning::class );
 		} else {
-			$this->expectException( \PHPUnit\Framework\Error\Warning::class );
+			$this->expect_warning( \PHPUnit\Framework\Error\Warning::class );
 		}
 
 		$this->invoke_static_method( PHP_Typography::class, 'get_language_plugin_list', [ '/does/not/exist' ] );
@@ -701,9 +701,9 @@ class PHP_Typography_Test extends Testcase {
 
 		// PHP < 7.0 raises an error instead of throwing an "exception".
 		if ( version_compare( phpversion(), '7.0.0', '<' ) ) {
-			$this->expectException( \PHPUnit_Framework_Error::class );
+			$this->expect_exception( \PHPUnit_Framework_Error::class );
 		} else {
-			$this->expectException( \TypeError::class );
+			$this->expect_exception( \TypeError::class );
 		}
 
 		$this->typo->process_textnodes( $html, 'bar', $s );

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -39,7 +39,7 @@ use PHP_Typography\Fixes\Registry;
 
 use PHP_Typography\Hyphenator\Cache as Hyphenator_Cache;
 
-use \Mockery as m;
+use Mockery as m;
 
 /**
  * PHP_Typography unit test.

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -145,8 +145,10 @@ class PHP_Typography_Test extends Testcase {
 	 * @uses PHP_Typography\Text_Parser\Token
 	 */
 	public function test_set_tags_to_ignore() {
+		// Syntax shortening.
 		$s = $this->s;
 
+		// Constants.
 		$always_ignore = [
 			'iframe',
 			'textarea',
@@ -166,30 +168,33 @@ class PHP_Typography_Test extends Testcase {
 			'math',
 		];
 
+		// Input.
+		$tags_to_ignore = [
+			'code',
+			'head',
+			'kbd',
+			'object',
+			'option',
+			'pre',
+			'samp',
+			'script',
+			'noscript',
+			'noembed',
+			'select',
+			'style',
+			'textarea',
+			'title',
+			'var',
+			'math',
+		];
+
 		// Default tags.
-		$s->set_tags_to_ignore(
-			[
-				'code',
-				'head',
-				'kbd',
-				'object',
-				'option',
-				'pre',
-				'samp',
-				'script',
-				'noscript',
-				'noembed',
-				'select',
-				'style',
-				'textarea',
-				'title',
-				'var',
-				'math',
-			]
-		);
+		$s->set_tags_to_ignore( $tags_to_ignore );
 
 		// Inspect settings.
-		$this->assertArraySubset( [ 'code', 'head', 'kbd', 'object', 'option', 'pre', 'samp', 'script', 'noscript', 'noembed', 'select', 'style', 'textarea', 'title', 'var', 'math' ], $s['ignoreTags'] );
+		foreach ( $tags_to_ignore as $tag ) {
+			$this->assertContains( $tag, $s['ignoreTags'] );
+		}
 		foreach ( $always_ignore as $tag ) {
 			$this->assertContains( $tag, $s['ignoreTags'] );
 		}

--- a/tests/class-php-typography-testcase.php
+++ b/tests/class-php-typography-testcase.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -29,144 +29,7 @@ use PHP_Typography\Strings;
 /**
  * Abstract base class for \PHP_Typography\* unit tests.
  */
-abstract class PHP_Typography_Testcase extends \PHPUnit\Framework\TestCase {
-
-	/**
-	 * Tears down the fixture, for example, closes a network connection.
-	 * This method is called after a test is executed.
-	 */
-	protected function tearDown() {
-		\Brain\Monkey\tearDown();
-		parent::tearDown();
-	}
-
-	/**
-	 * Return encoded HTML string (everything except <>"').
-	 *
-	 * @param string $html A HTML fragment.
-	 */
-	protected function clean_html( $html ) {
-		// Convert everything except Latin and Cyrillic and Thai.
-		static $convmap = [ // phpcs:disable WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-			// Simple Latin characters.
-			0x80,   0x03ff,   0, 0xffffff,
-			// Cyrillic characters.
-			0x0514, 0x0dff,   0, 0xffffff,
-			// Thai characters.
-			0x0e7f, 0x10ffff, 0, 0xffffff,
-		]; // phpcs:enable WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-
-		return str_replace( [ '&lt;', '&gt;' ], [ '<', '>' ], mb_encode_numericentity( htmlentities( $html, ENT_NOQUOTES, 'UTF-8', false ), $convmap, 'UTF-8' ) );
-	}
-
-	/**
-	 * Call protected/private method of a class.
-	 *
-	 * @param object $object      Instantiated object that we will run method on.
-	 * @param string $method_name Method name to call.
-	 * @param array  $parameters  Array of parameters to pass into method.
-	 * @param string $classname   Optional. The class to use for accessing private properties.
-	 *
-	 * @return mixed Method return.
-	 */
-	protected function invokeMethod( $object, $method_name, array $parameters = [], $classname = '' ) {
-		if ( empty( $classname ) ) {
-			$classname = get_class( $object );
-		}
-
-		$reflection = new \ReflectionClass( $classname );
-		$method     = $reflection->getMethod( $method_name );
-		$method->setAccessible( true );
-
-		return $method->invokeArgs( $object, $parameters );
-	}
-
-	/**
-	 * Call protected/private method of a class.
-	 *
-	 * @param string $classname   A class that we will run the method on.
-	 * @param string $method_name Method name to call.
-	 * @param array  $parameters  Array of parameters to pass into method.
-	 *
-	 * @return mixed Method return.
-	 */
-	protected function invokeStaticMethod( $classname, $method_name, array $parameters = [] ) {
-		$reflection = new \ReflectionClass( $classname );
-		$method     = $reflection->getMethod( $method_name );
-		$method->setAccessible( true );
-
-		return $method->invokeArgs( null, $parameters );
-	}
-
-	/**
-	 * Sets the value of a private/protected property of a class.
-	 *
-	 * @param string     $classname     A class whose property we will access.
-	 * @param string     $property_name Property to set.
-	 * @param mixed|null $value         The new value.
-	 */
-	protected function setStaticValue( $classname, $property_name, $value ) {
-		$reflection = new \ReflectionClass( $classname );
-		$property   = $reflection->getProperty( $property_name );
-		$property->setAccessible( true );
-		$property->setValue( $value );
-	}
-
-	/**
-	 * Sets the value of a private/protected property of a class.
-	 *
-	 * @param object     $object        Instantiated object that we will run method on.
-	 * @param string     $property_name Property to set.
-	 * @param mixed|null $value         The new value.
-	 * @param string     $classname     Optional. The class to use for accessing private properties.
-	 */
-	protected function setValue( $object, $property_name, $value, $classname = '' ) {
-		if ( empty( $classname ) ) {
-			$classname = get_class( $object );
-		}
-
-		$reflection = new \ReflectionClass( $classname );
-		$property   = $reflection->getProperty( $property_name );
-		$property->setAccessible( true );
-		$property->setValue( $object, $value );
-	}
-
-	/**
-	 * Retrieves the value of a private/protected property of a class.
-	 *
-	 * @param string $classname     A class whose property we will access.
-	 * @param string $property_name Property to set.
-	 *
-	 * @return mixed
-	 */
-	protected function getStaticValue( $classname, $property_name ) {
-		$reflection = new \ReflectionClass( $classname );
-		$property   = $reflection->getProperty( $property_name );
-		$property->setAccessible( true );
-
-		return $property->getValue();
-	}
-
-	/**
-	 * Retrieves the value of a private/protected property of a class.
-	 *
-	 * @param object $object        Instantiated object that we will run method on.
-	 * @param string $property_name Property to set.
-	 * @param string $classname     Optional. The class to use for accessing private properties.
-	 *
-	 * @return mixed
-	 */
-	protected function getValue( $object, $property_name, $classname = '' ) {
-		if ( empty( $classname ) ) {
-			$classname = get_class( $object );
-		}
-
-		$reflection = new \ReflectionClass( $classname );
-		$property   = $reflection->getProperty( $property_name );
-		$property->setAccessible( true );
-
-		return $property->getValue( $object );
-	}
+abstract class PHP_Typography_Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 
 	/**
 	 * Helper function to generate a valid token list from strings.
@@ -207,7 +70,7 @@ abstract class PHP_Typography_Testcase extends \PHPUnit\Framework\TestCase {
 	 * @param array        $actual_tokens  A token array.
 	 * @param string       $message        Optional. Default ''.
 	 */
-	protected function assertTokensSame( $expected_value, array $actual_tokens, $message = '' ) {
+	protected function assert_tokens_same( $expected_value, array $actual_tokens, $message = '' ) {
 		$this->assertContainsOnlyInstancesOf( \PHP_Typography\Text_Parser\Token::class, $actual_tokens, '$actual_tokens has to be an array of tokens.' );
 		foreach ( $actual_tokens as $index => $token ) {
 			$actual_tokens[ $index ] = $token->with_value( $this->clean_html( $token->value ) );
@@ -246,7 +109,7 @@ abstract class PHP_Typography_Testcase extends \PHPUnit\Framework\TestCase {
 	 * @param array        $actual_tokens  A token array.
 	 * @param string       $message        Optional. Default ''.
 	 */
-	protected function assertTokensNotSame( $expected_value, array $actual_tokens, $message = '' ) {
+	protected function assert_tokens_not_same( $expected_value, array $actual_tokens, $message = '' ) {
 		$this->assertContainsOnlyInstancesOf( \PHP_Typography\Text_Parser\Token::class, $actual_tokens, '$actual_tokens has to be an array of tokens.' );
 		foreach ( $actual_tokens as $index => $token ) {
 			$actual_tokens[ $index ] = $token->with_value( $this->clean_html( $token->value ) );
@@ -276,45 +139,13 @@ abstract class PHP_Typography_Testcase extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * Reports an error identified by $message if $attribute in $object does not have the $key.
-	 *
-	 * @param string $key       The array key.
-	 * @param string $attribute The attribute name.
-	 * @param object $object    The object.
-	 * @param string $message   Optional. Default ''.
-	 */
-	protected function assertAttributeArrayHasKey( $key, $attribute, $object, $message = '' ) {
-		$ref  = new \ReflectionClass( get_class( $object ) );
-		$prop = $ref->getProperty( $attribute );
-		$prop->setAccessible( true );
-
-		return $this->assertArrayHasKey( $key, $prop->getValue( $object ), $message );
-	}
-
-	/**
-	 * Reports an error identified by $message if $attribute in $object does have the $key.
-	 *
-	 * @param string $key       The array key.
-	 * @param string $attribute The attribute name.
-	 * @param object $object    The object.
-	 * @param string $message   Optional. Default ''.
-	 */
-	protected function assertAttributeArrayNotHasKey( $key, $attribute, $object, $message = '' ) {
-		$ref  = new \ReflectionClass( get_class( $object ) );
-		$prop = $ref->getProperty( $attribute );
-		$prop->setAccessible( true );
-
-		return $this->assertArrayNotHasKey( $key, $prop->getValue( $object ), $message );
-	}
-
-	/**
 	 * Assert that the given quote styles match.
 	 *
 	 * @param string $style Style name.
 	 * @param string $open  Opening quote character.
 	 * @param string $close Closing quote character.
 	 */
-	protected function assertSmartQuotesStyle( $style, $open, $close ) {
+	protected function assert_smart_quotes_style( $style, $open, $close ) {
 		switch ( $style ) {
 			case 'doubleCurled':
 				$this->assertSame( Strings::uchr( 8220 ), $open, "Opening quote $open did not match quote style $style." );

--- a/tests/class-re-test.php
+++ b/tests/class-re-test.php
@@ -32,7 +32,7 @@ use PHP_Typography\RE;
  * @coversDefaultClass \PHP_Typography\RE
  * @usesDefaultClass \PHP_Typography\RE
  */
-class RE_Test extends PHP_Typography_Testcase {
+class RE_Test extends Testcase {
 
 	/**
 	 * Tests top_level_domains.

--- a/tests/class-re-test.php
+++ b/tests/class-re-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@ class RE_Test extends PHP_Typography_Testcase {
 	 * @uses ::get_top_level_domains_from_file
 	 */
 	public function test_top_level_domains() {
-		$result = $this->invokeStaticMethod( RE::class, 'top_level_domains', [] );
+		$result = $this->invoke_static_method( RE::class, 'top_level_domains', [] );
 
 		$this->assertInternalType( 'string', $result, 'RE::top_level_domains() should return a string.' );
 		$this->assertGreaterThan( 0, strlen( $result ) );
@@ -57,9 +57,9 @@ class RE_Test extends PHP_Typography_Testcase {
 	 */
 	public function test_top_level_domains_clean() {
 		// Unset RE::$top_level_domains_pattern.
-		$this->setStaticValue( RE::class, 'top_level_domains_pattern', null );
+		$this->set_static_value( RE::class, 'top_level_domains_pattern', null );
 
-		$result = $this->invokeStaticMethod( RE::class, 'top_level_domains', [] );
+		$result = $this->invoke_static_method( RE::class, 'top_level_domains', [] );
 
 		$this->assertInternalType( 'string', $result, 'RE::top_level_domains() should return a string.' );
 		$this->assertGreaterThan( 0, strlen( $result ) );
@@ -73,8 +73,8 @@ class RE_Test extends PHP_Typography_Testcase {
 	public function test_get_top_level_domains_from_file() {
 		$default = 'ac|ad|aero|ae|af|ag|ai|al|am|an|ao|aq|arpa|ar|asia|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|biz|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|cat|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|com|coop|co|cr|cu|cv|cx|cy|cz|de|dj|dk|dm|do|dz|ec|edu|ee|eg|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gov|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|info|int|in|io|iq|ir|is|it|je|jm|jobs|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mil|mk|ml|mm|mn|mobi|mo|mp|mq|mr|ms|mt|museum|mu|mv|mw|mx|my|mz|name|na|nc|net|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|org|pa|pe|pf|pg|ph|pk|pl|pm|pn|pro|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|so|sr|st|su|sv|sy|sz|tc|td|tel|tf|tg|th|tj|tk|tl|tm|tn|to|tp|travel|tr|tt|tv|tw|tz|ua|ug|uk|um|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|yu|za|zm|zw';
 
-		$invalid_result = $this->invokeStaticMethod( RE::class, 'get_top_level_domains_from_file', [ '/some/invalid/path/to_a_non_existent_file.txt' ] );
-		$valid_result   = $this->invokeStaticMethod( RE::class, 'get_top_level_domains_from_file', [ dirname( __DIR__ ) . '/src/IANA/tlds-alpha-by-domain.txt' ] );
+		$invalid_result = $this->invoke_static_method( RE::class, 'get_top_level_domains_from_file', [ '/some/invalid/path/to_a_non_existent_file.txt' ] );
+		$valid_result   = $this->invoke_static_method( RE::class, 'get_top_level_domains_from_file', [ dirname( __DIR__ ) . '/src/IANA/tlds-alpha-by-domain.txt' ] );
 
 		$this->assertSame( $default, $invalid_result );
 		$this->assertNotSame( $valid_result, $invalid_result );

--- a/tests/class-re-test.php
+++ b/tests/class-re-test.php
@@ -44,7 +44,7 @@ class RE_Test extends Testcase {
 	public function test_top_level_domains() {
 		$result = $this->invoke_static_method( RE::class, 'top_level_domains', [] );
 
-		$this->assertInternalType( 'string', $result, 'RE::top_level_domains() should return a string.' );
+		$this->assert_is_string( $result, 'RE::top_level_domains() should return a string.' );
 		$this->assertGreaterThan( 0, strlen( $result ) );
 	}
 
@@ -61,7 +61,7 @@ class RE_Test extends Testcase {
 
 		$result = $this->invoke_static_method( RE::class, 'top_level_domains', [] );
 
-		$this->assertInternalType( 'string', $result, 'RE::top_level_domains() should return a string.' );
+		$this->assert_is_string( $result, 'RE::top_level_domains() should return a string.' );
 		$this->assertGreaterThan( 0, strlen( $result ) );
 	}
 

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -351,9 +351,9 @@ class Settings_Test extends Testcase {
 
 		// PHP < 7.0 raises an error instead of throwing an "exception".
 		if ( version_compare( phpversion(), '7.0.0', '<' ) ) {
-			$this->expectException( \PHPUnit_Framework_Error::class );
+			$this->expect_exception( \PHPUnit_Framework_Error::class );
 		} else {
-			$this->expectException( \TypeError::class );
+			$this->expect_exception( \TypeError::class );
 		}
 
 		// Invalid handler, previous handler not changed.
@@ -484,12 +484,12 @@ class Settings_Test extends Testcase {
 	 * @covers ::get_style
 	 *
 	 * @uses PHP_Typography\Settings\Quote_Style::get_styled_quotes
-	 *
-	 * @expectedException \DomainException
-	 * @expectedExceptionMessageRegExp /^Invalid quote style \w+\.$/
 	 */
 	public function test_set_smart_quotes_primary_invalid() {
 		$s = $this->settings;
+
+		$this->expect_exception( \DomainException::class );
+		$this->expect_exception_message_matches( '/^Invalid quote style \w+\.$/' );
 
 		$s->set_smart_quotes_primary( 'invalidStyleName' );
 	}
@@ -562,12 +562,12 @@ class Settings_Test extends Testcase {
 	 * @covers ::get_style
 	 *
 	 * @uses PHP_Typography\Settings\Quote_Style::get_styled_quotes
-	 *
-	 * @expectedException \DomainException
-	 * @expectedExceptionMessageRegExp /^Invalid quote style \w+\.$/
 	 */
 	public function test_set_smart_quotes_secondary_invalid() {
 		$s = $this->settings;
+
+		$this->expect_exception( \DomainException::class );
+		$this->expect_exception_message_matches( '/^Invalid quote style \w+\.$/' );
 
 		$s->set_smart_quotes_secondary( 'invalidStyleName' );
 	}
@@ -694,12 +694,12 @@ class Settings_Test extends Testcase {
 	 * @covers ::get_style
 	 *
 	 * @uses PHP_Typography\Settings\Dash_Style::get_styled_dashes
-	 *
-	 * @expectedException \DomainException
-	 * @expectedExceptionMessageRegExp /^Invalid dash style \w+.$/
 	 */
 	public function test_set_smart_dashes_style_invalid() {
 		$s = $this->settings;
+
+		$this->expect_exception( \DomainException::class );
+		$this->expect_exception_message_matches( '/^Invalid dash style \w+\.$/' );
 
 		$s->set_smart_dashes_style( 'invalidStyleName' );
 	}

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -78,9 +78,9 @@ class Settings_Test extends Testcase {
 	 */
 	public function test_set_defaults() {
 		$second_settings = new \PHP_Typography\Settings( false );
-		$this->assertAttributeEmpty( 'data', $second_settings );
+		$this->assert_attribute_empty( 'data', $second_settings );
 		$second_settings->set_defaults();
-		$this->assertAttributeNotEmpty( 'data', $second_settings );
+		$this->assert_attribute_not_empty( 'data', $second_settings );
 	}
 
 	/**
@@ -99,14 +99,14 @@ class Settings_Test extends Testcase {
 		$s = $this->settings;
 
 		// No defaults.
-		$this->assertAttributeEmpty( 'data', $s );
+		$this->assert_attribute_empty( 'data', $s );
 
 		// After set_defaults().
 		$s->set_defaults();
-		$this->assertAttributeNotEmpty( 'data', $s );
+		$this->assert_attribute_not_empty( 'data', $s );
 
 		$second_settings = new \PHP_Typography\Settings( true );
-		$this->assertAttributeNotEmpty( 'data', $second_settings );
+		$this->assert_attribute_not_empty( 'data', $second_settings );
 	}
 
 
@@ -289,7 +289,7 @@ class Settings_Test extends Testcase {
 	public function test_custom_units() {
 		$s = $this->settings;
 
-		$this->assertInternalType( 'string', $s->custom_units(), 'The result of custom_units() is not a string.' );
+		$this->assert_is_string( $s->custom_units(), 'The result of custom_units() is not a string.' );
 	}
 
 
@@ -325,7 +325,7 @@ class Settings_Test extends Testcase {
 				return [];
 			}
 		);
-		$this->assertInternalType( 'callable', $s[ Settings::PARSER_ERRORS_HANDLER ] );
+		$this->assert_is_callable( $s[ Settings::PARSER_ERRORS_HANDLER ] );
 		$old_handler = $s[ Settings::PARSER_ERRORS_HANDLER ];
 	}
 
@@ -346,7 +346,7 @@ class Settings_Test extends Testcase {
 				return [];
 			}
 		);
-		$this->assertInternalType( 'callable', $s[ Settings::PARSER_ERRORS_HANDLER ] );
+		$this->assert_is_callable( $s[ Settings::PARSER_ERRORS_HANDLER ] );
 		$old_handler = $s[ Settings::PARSER_ERRORS_HANDLER ];
 
 		// PHP < 7.0 raises an error instead of throwing an "exception".
@@ -358,7 +358,7 @@ class Settings_Test extends Testcase {
 
 		// Invalid handler, previous handler not changed.
 		$s->set_parser_errors_handler( 'foobar' );
-		$this->assertInternalType( 'callable', $s[ Settings::PARSER_ERRORS_HANDLER ] );
+		$this->assert_is_callable( $s[ Settings::PARSER_ERRORS_HANDLER ] );
 		$this->assertSame( $old_handler, $s[ Settings::PARSER_ERRORS_HANDLER ] );
 	}
 
@@ -1602,15 +1602,15 @@ class Settings_Test extends Testcase {
 		];
 
 		$s = new Settings( false, $mapping );
-		$this->assertAttributeSame( $mapping, 'unicode_mapping', $s );
+		$this->assert_attribute_same( $mapping, 'unicode_mapping', $s );
 
 		$s->remap_character( 'a', 'a' );
-		$this->assertAttributeSame( [ 'r' => 'z' ], 'unicode_mapping', $s );
+		$this->assert_attribute_same( [ 'r' => 'z' ], 'unicode_mapping', $s );
 
 		$s->remap_character( U::NO_BREAK_NARROW_SPACE, 'x' );
-		$this->assertAttributeCount( 2, 'unicode_mapping', $s );
-		$this->assertAttributeContains( 'x', 'unicode_mapping', $s );
-		$this->assertAttributeSame( 'x', 'no_break_narrow_space', $s );
+		$this->assert_attribute_count( 2, 'unicode_mapping', $s );
+		$this->assert_attribute_contains( 'x', 'unicode_mapping', $s );
+		$this->assert_attribute_same( 'x', 'no_break_narrow_space', $s );
 	}
 
 

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2016-2019 Peter Putzer.
+ *  Copyright 2016-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -61,8 +61,8 @@ class Settings_Test extends PHP_Typography_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->settings = new \PHP_Typography\Settings( false );
 	}
@@ -471,7 +471,7 @@ class Settings_Test extends PHP_Typography_Testcase {
 		foreach ( $quote_styles as $style ) {
 			$s->set_smart_quotes_primary( $style );
 
-			$this->assertSmartQuotesStyle( $style, $s->primary_quote_style()->open(), $s->primary_quote_style()->close() );
+			$this->assert_smart_quotes_style( $style, $s->primary_quote_style()->open(), $s->primary_quote_style()->close() );
 		}
 	}
 
@@ -549,7 +549,7 @@ class Settings_Test extends PHP_Typography_Testcase {
 		foreach ( $quote_styles as $style ) {
 			$s->set_smart_quotes_secondary( $style );
 
-			$this->assertSmartQuotesStyle( $style, $s->secondary_quote_style()->open(), $s->secondary_quote_style()->close() );
+			$this->assert_smart_quotes_style( $style, $s->secondary_quote_style()->open(), $s->secondary_quote_style()->close() );
 		}
 	}
 
@@ -1045,7 +1045,7 @@ class Settings_Test extends PHP_Typography_Testcase {
 	 * @param  string   $regex The resulting regular expression.
 	 */
 	public function test_update_unit_pattern( array $units, $regex ) {
-		$result = $this->invokeMethod( $this->settings, 'update_unit_pattern', [ $units ] );
+		$result = $this->invoke_method( $this->settings, 'update_unit_pattern', [ $units ] );
 
 		$this->assertSame( $regex, $result );
 	}
@@ -1690,6 +1690,6 @@ class Settings_Test extends PHP_Typography_Testcase {
 	 * @param  array    $result   Expected output array.
 	 */
 	public function test_array_map_assoc( callable $callable, array $array, array $result ) {
-		$this->assertSame( $result, $this->invokeStaticMethod( Settings::class, 'array_map_assoc', [ $callable, $array ] ) );
+		$this->assertSame( $result, $this->invoke_static_method( Settings::class, 'array_map_assoc', [ $callable, $array ] ) );
 	}
 }

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -370,12 +370,15 @@ class Settings_Test extends Testcase {
 	 * @uses PHP_Typography\Strings::maybe_split_parameters
 	 */
 	public function test_set_tags_to_ignore() {
-		$s             = $this->settings;
-		$always_ignore = [ 'iframe', 'textarea', 'button', 'select', 'optgroup', 'option', 'map', 'style', 'head', 'title', 'script', 'applet', 'object', 'param', 'svg', 'math' ];
+		$s              = $this->settings;
+		$always_ignore  = [ 'iframe', 'textarea', 'button', 'select', 'optgroup', 'option', 'map', 'style', 'head', 'title', 'script', 'applet', 'object', 'param', 'svg', 'math' ];
+		$tags_to_ignore = [ 'code', 'head', 'kbd', 'object', 'option', 'pre', 'samp', 'script', 'noscript', 'noembed', 'select', 'style', 'textarea', 'title', 'var', 'math' ];
 
 		// Default tags.
-		$s->set_tags_to_ignore( [ 'code', 'head', 'kbd', 'object', 'option', 'pre', 'samp', 'script', 'noscript', 'noembed', 'select', 'style', 'textarea', 'title', 'var', 'math' ] );
-		$this->assertArraySubset( [ 'code', 'head', 'kbd', 'object', 'option', 'pre', 'samp', 'script', 'noscript', 'noembed', 'select', 'style', 'textarea', 'title', 'var', 'math' ], $s['ignoreTags'] );
+		$s->set_tags_to_ignore( $tags_to_ignore );
+		foreach ( $tags_to_ignore as $tag ) {
+			$this->assertContains( $tag, $s['ignoreTags'] );
+		}
 		foreach ( $always_ignore as $tag ) {
 			$this->assertContains( $tag, $s['ignoreTags'] );
 		}

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -31,8 +31,6 @@ use PHP_Typography\U;
 use PHP_Typography\Settings\Dashes;
 use PHP_Typography\Settings\Quotes;
 
-use Brain\Monkey;
-
 use Mockery as m;
 
 /**
@@ -49,7 +47,7 @@ use Mockery as m;
  * @uses PHP_Typography\Strings::uchr
  * @uses PHP_Typography\DOM::inappropriate_tags
  */
-class Settings_Test extends PHP_Typography_Testcase {
+class Settings_Test extends Testcase {
 	/**
 	 * Settings fixture.
 	 *

--- a/tests/class-strings-test.php
+++ b/tests/class-strings-test.php
@@ -32,7 +32,7 @@ use PHP_Typography\Strings;
  * @coversDefaultClass \PHP_Typography\Strings
  * @usesDefaultClass \PHP_Typography\Strings
  */
-class Strings_Test extends \PHPUnit\Framework\TestCase {
+class Strings_Test extends Testcase {
 
 	/**
 	 * Reports an error identified by $message if the given function array contains a non-callable.
@@ -40,7 +40,7 @@ class Strings_Test extends \PHPUnit\Framework\TestCase {
 	 * @param array  $func    An array of string functions.
 	 * @param string $message Optional. Default ''.
 	 */
-	protected function assertStringFunctions( array $func, $message = '' ) {
+	protected function assert_string_functions( array $func, $message = '' ) {
 		// Each function is a callable (except for the 'u' modifier string).
 		foreach ( $func as $name => $function ) {
 			if ( 'u' !== $name ) {
@@ -70,8 +70,8 @@ class Strings_Test extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( array_keys( $func_ascii ), array_keys( $func_utf8 ) );
 
 		// Each function is a callable (except for the 'u' modifier string).
-		$this->assertStringFunctions( $func_ascii );
-		$this->assertStringFunctions( $func_utf8 );
+		$this->assert_string_functions( $func_ascii );
+		$this->assert_string_functions( $func_utf8 );
 	}
 
 	/**

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -28,8 +28,10 @@ use PHP_Typography\Strings;
 
 /**
  * Abstract base class for \PHP_Typography\* unit tests.
+ *
+ * @since 6.6.0 Renamed to Testcase
  */
-abstract class PHP_Typography_Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
+abstract class Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 
 	/**
 	 * Helper function to generate a valid token list from strings.

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -25,6 +25,7 @@
 namespace PHP_Typography\Tests;
 
 use PHP_Typography\Strings;
+use PHP_Typography\Text_Parser\Token;
 
 /**
  * Abstract base class for \PHP_Typography\* unit tests.
@@ -41,9 +42,9 @@ abstract class Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 	 *
 	 * @return array
 	 */
-	protected function tokenize( $value, $type = \PHP_Typography\Text_Parser\Token::WORD ) {
+	protected function tokenize( $value, $type = Token::WORD ) {
 		return [
-			new \PHP_Typography\Text_Parser\Token( $value, $type ),
+			new Token( $value, $type ),
 		];
 	}
 
@@ -59,10 +60,26 @@ abstract class Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 		$tokens = [];
 
 		foreach ( $words as $word ) {
-			$tokens[] = new \PHP_Typography\Text_Parser\Token( $word, \PHP_Typography\Text_Parser\Token::WORD );
+			$tokens[] = new Token( $word, Token::WORD );
 		}
 
 		return $tokens;
+	}
+
+	/**
+	 * Reports an error identified by $message if the token at $index does not have the $value or $type given.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @param  int     $index         A token position.
+	 * @param  string  $value         A token value.
+	 * @param  int     $type          A Token type constant.
+	 * @param  Token[] $actual_tokens An array of tokens.
+	 * @param  string  $message       Optional. Default ''.
+	 */
+	protected function assert_token( $index, $value, $type, array $actual_tokens, $message = '' ) {
+		$this->assertArrayHasKey( $index, $actual_tokens, 'Token index not found' );
+		$this->assertEquals( new Token( $value, $type ), $actual_tokens[ $index ], $message );
 	}
 
 	/**
@@ -73,7 +90,7 @@ abstract class Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 	 * @param string       $message        Optional. Default ''.
 	 */
 	protected function assert_tokens_same( $expected_value, array $actual_tokens, $message = '' ) {
-		$this->assertContainsOnlyInstancesOf( \PHP_Typography\Text_Parser\Token::class, $actual_tokens, '$actual_tokens has to be an array of tokens.' );
+		$this->assertContainsOnlyInstancesOf( Token::class, $actual_tokens, '$actual_tokens has to be an array of tokens.' );
 		foreach ( $actual_tokens as $index => $token ) {
 			$actual_tokens[ $index ] = $token->with_value( $this->clean_html( $token->value ) );
 		}
@@ -87,7 +104,7 @@ abstract class Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 		}
 
 		// Ensure clean HTML even when a scalar was passed.
-		$this->assertContainsOnlyInstancesOf( \PHP_Typography\Text_Parser\Token::class, $expected_value, '$expected_value has to be a string or an array of tokens.' );
+		$this->assertContainsOnlyInstancesOf( Token::class, $expected_value, '$expected_value has to be a string or an array of tokens.' );
 		$expected = [];
 		foreach ( $expected_value as $index => $token ) {
 			$expected[ $index ] = $token->with_value( $this->clean_html( $token->value ) );
@@ -112,7 +129,7 @@ abstract class Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 	 * @param string       $message        Optional. Default ''.
 	 */
 	protected function assert_tokens_not_same( $expected_value, array $actual_tokens, $message = '' ) {
-		$this->assertContainsOnlyInstancesOf( \PHP_Typography\Text_Parser\Token::class, $actual_tokens, '$actual_tokens has to be an array of tokens.' );
+		$this->assertContainsOnlyInstancesOf( Token::class, $actual_tokens, '$actual_tokens has to be an array of tokens.' );
 		foreach ( $actual_tokens as $index => $token ) {
 			$actual_tokens[ $index ] = $token->with_value( $this->clean_html( $token->value ) );
 		}
@@ -124,7 +141,7 @@ abstract class Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 				$expected = $this->tokenize( $expected_value );
 			}
 		} else {
-			$this->assertContainsOnlyInstancesOf( \PHP_Typography\Text_Parser\Token::class, (array) $expected_value, '$expected_value has to be a string or an array of tokens.' );
+			$this->assertContainsOnlyInstancesOf( Token::class, (array) $expected_value, '$expected_value has to be a string or an array of tokens.' );
 			$expected = $expected_value;
 		}
 

--- a/tests/class-text-parser-test.php
+++ b/tests/class-text-parser-test.php
@@ -63,8 +63,8 @@ class Text_Parser_Test extends Testcase {
 	public function test_constructor() {
 		$parser = new Text_Parser();
 
-		$this->assertAttributeCount( 0, 'text', $parser );
-		$this->assertAttributeSame( 'strtoupper', 'current_strtoupper', $parser );
+		$this->assert_attribute_count( 0, 'text', $parser );
+		$this->assert_attribute_same( 'strtoupper', 'current_strtoupper', $parser );
 	}
 
 	/**
@@ -405,46 +405,46 @@ class Text_Parser_Test extends Testcase {
 		$parser->load( 'A few m1xed W0RDS.' );
 		$tokens = $parser->get_words( Text_Parser::REQUIRE_ALL_LETTERS, Text_Parser::NO_ALL_CAPS );
 		$this->assertCount( 1, $tokens );
-		$this->assertContains( new Token( 'few', Token::WORD ), $tokens, '', false, false, true );
+		$this->assert_contains_equals( new Token( 'few', Token::WORD ), $tokens, '' );
 
 		$tokens = $parser->get_words( Text_Parser::ALLOW_ALL_LETTERS, Text_Parser::NO_ALL_CAPS );
 		$this->assertCount( 2, $tokens );
-		$this->assertContains( new Token( 'few', Token::WORD ), $tokens, '', false, false, true );
-		$this->assertContains( new Token( 'm1xed', Token::WORD ), $tokens, '', false, false, true );
+		$this->assert_contains_equals( new Token( 'few', Token::WORD ), $tokens, '' );
+		$this->assert_contains_equals( new Token( 'm1xed', Token::WORD ), $tokens, '' );
 
 		$tokens = $parser->get_words( Text_Parser::NO_ALL_LETTERS, Text_Parser::NO_ALL_CAPS );
 		$this->assertCount( 1, $tokens );
-		$this->assertContains( new Token( 'm1xed', Token::WORD ), $tokens, '', false, false, true );
+		$this->assert_contains_equals( new Token( 'm1xed', Token::WORD ), $tokens, '' );
 
 		$tokens = $parser->get_words( Text_Parser::REQUIRE_ALL_LETTERS, Text_Parser::ALLOW_ALL_CAPS );
 		$this->assertCount( 2, $tokens );
-		$this->assertContains( new Token( 'A', Token::WORD ), $tokens, '', false, false, true );
-		$this->assertContains( new Token( 'few', Token::WORD ), $tokens, '', false, false, true );
+		$this->assert_contains_equals( new Token( 'A', Token::WORD ), $tokens, '' );
+		$this->assert_contains_equals( new Token( 'few', Token::WORD ), $tokens, '' );
 
 		$tokens = $parser->get_words( Text_Parser::ALLOW_ALL_LETTERS, Text_Parser::ALLOW_ALL_CAPS );
 		$this->assertCount( 4, $tokens );
-		$this->assertContains( new Token( 'A', Token::WORD ), $tokens, '', false, false, true );
-		$this->assertContains( new Token( 'few', Token::WORD ), $tokens, '', false, false, true );
-		$this->assertContains( new Token( 'm1xed', Token::WORD ), $tokens, '', false, false, true );
-		$this->assertContains( new Token( 'W0RDS', Token::WORD ), $tokens, '', false, false, true );
+		$this->assert_contains_equals( new Token( 'A', Token::WORD ), $tokens, '' );
+		$this->assert_contains_equals( new Token( 'few', Token::WORD ), $tokens, '' );
+		$this->assert_contains_equals( new Token( 'm1xed', Token::WORD ), $tokens, '' );
+		$this->assert_contains_equals( new Token( 'W0RDS', Token::WORD ), $tokens, '' );
 
 		$tokens = $parser->get_words( Text_Parser::NO_ALL_LETTERS, Text_Parser::ALLOW_ALL_CAPS );
 		$this->assertCount( 2, $tokens );
-		$this->assertContains( new Token( 'm1xed', Token::WORD ), $tokens, '', false, false, true );
-		$this->assertContains( new Token( 'W0RDS', Token::WORD ), $tokens, '', false, false, true );
+		$this->assert_contains_equals( new Token( 'm1xed', Token::WORD ), $tokens, '' );
+		$this->assert_contains_equals( new Token( 'W0RDS', Token::WORD ), $tokens, '' );
 
 		$tokens = $parser->get_words( Text_Parser::REQUIRE_ALL_LETTERS, Text_Parser::REQUIRE_ALL_CAPS );
 		$this->assertCount( 1, $tokens );
-		$this->assertContains( new Token( 'A', Token::WORD ), $tokens, '', false, false, true );
+		$this->assert_contains_equals( new Token( 'A', Token::WORD ), $tokens, '' );
 
 		$tokens = $parser->get_words( Text_Parser::ALLOW_ALL_LETTERS, Text_Parser::REQUIRE_ALL_CAPS );
 		$this->assertCount( 2, $tokens );
-		$this->assertContains( new Token( 'A', Token::WORD ), $tokens, '', false, false, true );
-		$this->assertContains( new Token( 'W0RDS', Token::WORD ), $tokens, '', false, false, true );
+		$this->assert_contains_equals( new Token( 'A', Token::WORD ), $tokens, '' );
+		$this->assert_contains_equals( new Token( 'W0RDS', Token::WORD ), $tokens, '' );
 
 		$tokens = $parser->get_words( Text_Parser::NO_ALL_LETTERS, Text_Parser::REQUIRE_ALL_CAPS );
 		$this->assertCount( 1, $tokens );
-		$this->assertContains( new Token( 'W0RDS', Token::WORD ), $tokens, '', false, false, true );
+		$this->assert_contains_equals( new Token( 'W0RDS', Token::WORD ), $tokens, '' );
 	}
 
 	/**

--- a/tests/class-text-parser-test.php
+++ b/tests/class-text-parser-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -49,8 +49,8 @@ class Text_Parser_Test extends PHP_Typography_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->parser = new \PHP_Typography\Text_Parser();
 	}
@@ -491,7 +491,7 @@ class Text_Parser_Test extends PHP_Typography_Testcase {
 		$parser = $this->parser;
 		$token  = new Token( $value, $type );
 
-		$this->assertSame( $result, $this->invokeMethod( $parser, 'conforms_to_letters_policy', [ $token, $policy ] ) );
+		$this->assertSame( $result, $this->invoke_method( $parser, 'conforms_to_letters_policy', [ $token, $policy ] ) );
 	}
 
 	/**
@@ -540,7 +540,7 @@ class Text_Parser_Test extends PHP_Typography_Testcase {
 
 		$token = new Token( $value, $type );
 
-		$this->assertSame( $result, $this->invokeMethod( $parser, 'conforms_to_caps_policy', [ $token, $policy ] ) );
+		$this->assertSame( $result, $this->invoke_method( $parser, 'conforms_to_caps_policy', [ $token, $policy ] ) );
 	}
 
 	/**
@@ -589,7 +589,7 @@ class Text_Parser_Test extends PHP_Typography_Testcase {
 
 		$token = new Token( $value, $type );
 
-		$this->assertSame( $result, $this->invokeMethod( $parser, 'conforms_to_compounds_policy', [ $token, $policy ] ) );
+		$this->assertSame( $result, $this->invoke_method( $parser, 'conforms_to_compounds_policy', [ $token, $policy ] ) );
 	}
 
 	/**

--- a/tests/class-text-parser-test.php
+++ b/tests/class-text-parser-test.php
@@ -98,9 +98,9 @@ class Text_Parser_Test extends Testcase {
 		$tokens = $parser->get_all();
 
 		$this->assertCount( 13, $tokens );
-		$this->assertArraySubset( [ 0 => new Token( 'Quoth', Token::WORD ) ], $tokens );
-		$this->assertArraySubset( [ 5 => new Token( ',', Token::PUNCTUATION ) ], $tokens );
-		$this->assertArraySubset( [ 11 => new Token( 'Äöüß', Token::WORD ) ], $tokens );
+		$this->assert_token( 0, 'Quoth', Token::WORD, $tokens );
+		$this->assert_token( 5, ',', Token::PUNCTUATION, $tokens );
+		$this->assert_token( 11, 'Äöüß', Token::WORD, $tokens );
 
 		return $parser;
 	}
@@ -125,9 +125,9 @@ class Text_Parser_Test extends Testcase {
 		$tokens = $parser->get_all();
 		$this->assertCount( 19, $tokens );
 
-		$this->assertArraySubset( [ 0 => new Token( 'Quoth', Token::WORD ) ], $tokens );
-		$this->assertArraySubset( [ 5 => new Token( ',', Token::PUNCTUATION ) ], $tokens );
-		$this->assertArraySubset( [ 17 => new Token( 'someone@example.org', Token::OTHER ) ], $tokens );
+		$this->assert_token( 0, 'Quoth', Token::WORD, $tokens );
+		$this->assert_token( 5, ',', Token::PUNCTUATION, $tokens );
+		$this->assert_token( 17, 'someone@example.org', Token::OTHER , $tokens );
 
 		return $parser;
 	}
@@ -152,13 +152,13 @@ class Text_Parser_Test extends Testcase {
 		$tokens = $parser->get_all();
 		$this->assertCount( 33, $tokens );
 
-		$this->assertArraySubset( [ 0 => new Token( 'Quoth', Token::WORD ) ], $tokens );
-		$this->assertArraySubset( [ 5 => new Token( ',', Token::PUNCTUATION ) ], $tokens );
-		$this->assertArraySubset( [ 15 => new Token( 'http://example.org', Token::OTHER ) ], $tokens );
-		$this->assertArraySubset( [ 19 => new Token( 'foo:WordPress', Token::OTHER ) ], $tokens );
-		$this->assertArraySubset( [ 23 => new Token( 'foo:W@rdPress', Token::OTHER ) ], $tokens );
-		$this->assertArraySubset( [ 27 => new Token( '@example', Token::OTHER ) ], $tokens );
-		$this->assertArraySubset( [ 31 => new Token( '@:@:@:risk', Token::OTHER ) ], $tokens );
+		$this->assert_token( 0, 'Quoth', Token::WORD, $tokens );
+		$this->assert_token( 5, ',', Token::PUNCTUATION, $tokens );
+		$this->assert_token( 15, 'http://example.org', Token::OTHER, $tokens );
+		$this->assert_token( 19, 'foo:WordPress', Token::OTHER, $tokens );
+		$this->assert_token( 23, 'foo:W@rdPress', Token::OTHER, $tokens );
+		$this->assert_token( 27, '@example', Token::OTHER, $tokens );
+		$this->assert_token( 31, '@:@:@:risk', Token::OTHER, $tokens );
 
 		return $parser;
 	}
@@ -183,9 +183,9 @@ class Text_Parser_Test extends Testcase {
 		$tokens = $parser->get_all();
 		$this->assertCount( 10, $tokens );
 
-		$this->assertArraySubset( [ 0 => new Token( 'Some', Token::WORD ) ], $tokens );
-		$this->assertArraySubset( [ 2 => new Token( "don't", Token::OTHER ) ], $tokens );
-		$this->assertArraySubset( [ 8 => new Token( 'captain-owner', Token::WORD ) ], $tokens );
+		$this->assert_token( 0, 'Some', Token::WORD, $tokens );
+		$this->assert_token( 2, "don't", Token::OTHER, $tokens );
+		$this->assert_token( 8, 'captain-owner', Token::WORD, $tokens );
 
 		return $parser;
 	}
@@ -660,6 +660,6 @@ class Text_Parser_Test extends Testcase {
 			}
 		}
 
-		$this->assertArraySubset( $words, $parser->get_type( Token::WORD ) );
+		$this->assertSame( $words, $parser->get_type( Token::WORD ) );
 	}
 }

--- a/tests/class-text-parser-test.php
+++ b/tests/class-text-parser-test.php
@@ -37,7 +37,7 @@ use PHP_Typography\Text_Parser;
  * @uses PHP_Typography\Text_Parser\Token
  * @uses PHP_Typography\Strings::functions
  */
-class Text_Parser_Test extends PHP_Typography_Testcase {
+class Text_Parser_Test extends Testcase {
 	/**
 	 * The Text_Parser fixture.
 	 *

--- a/tests/fixes/class-default-registry-test.php
+++ b/tests/fixes/class-default-registry-test.php
@@ -31,7 +31,7 @@ use PHP_Typography\Fixes\Token_Fix;
 
 use PHP_Typography\Tests\Testcase;
 
-use \Mockery as m;
+use Mockery as m;
 
 /**
  * PHP_Typography unit test.

--- a/tests/fixes/class-default-registry-test.php
+++ b/tests/fixes/class-default-registry-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ use PHP_Typography\Fixes\Default_Registry;
 use PHP_Typography\Fixes\Node_Fix;
 use PHP_Typography\Fixes\Token_Fix;
 
-use Brain\Monkey;
+use PHP_Typography\Tests\Testcase;
 
 use \Mockery as m;
 
@@ -42,7 +42,7 @@ use \Mockery as m;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-class Default_Registry_Test extends \PHP_Typography\Tests\PHP_Typography_Testcase {
+class Default_Registry_Test extends \PHP_Typography\Tests\Testcase {
 
 	/**
 	 * Tests constructor.

--- a/tests/fixes/class-registry-test.php
+++ b/tests/fixes/class-registry-test.php
@@ -33,7 +33,7 @@ use PHP_Typography\Fixes\Node_Fixes\Process_Words_Fix;
 use PHP_Typography\Strings;
 use PHP_Typography\U;
 
-use Brain\Monkey;
+use PHP_Typography\Tests\Testcase;
 
 use \Mockery as m;
 
@@ -46,7 +46,7 @@ use \Mockery as m;
  * @uses ::register_node_fix
  * @uses PHP_Typography\Fixes\Node_Fixes\Abstract_Node_Fix::__construct
  */
-class Registry_Test extends \PHP_Typography\Tests\PHP_Typography_Testcase {
+class Registry_Test extends Testcase {
 
 	/**
 	 * The Registry instance.

--- a/tests/fixes/class-registry-test.php
+++ b/tests/fixes/class-registry-test.php
@@ -100,7 +100,7 @@ class Registry_Test extends Testcase {
 	public function test_get_node_fixes() {
 		$fixes = $this->r->get_node_fixes();
 
-		$this->assertInternalType( 'array', $fixes );
+		$this->assert_is_array( $fixes );
 		$this->assertCount( count( Registry::GROUPS ), $fixes );
 	}
 
@@ -115,7 +115,7 @@ class Registry_Test extends Testcase {
 			$fake_node_fixer = m::mock( Node_Fix::class );
 
 			$this->r->register_node_fix( $fake_node_fixer, $group );
-			$this->assertContains( $fake_node_fixer, $this->readAttribute( $this->r, 'node_fixes' )[ $group ] );
+			$this->assertContains( $fake_node_fixer, $this->get_value( $this->r, 'node_fixes' )[ $group ] );
 		}
 	}
 

--- a/tests/fixes/class-registry-test.php
+++ b/tests/fixes/class-registry-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -66,16 +66,16 @@ class Registry_Test extends \PHP_Typography\Tests\PHP_Typography_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->r      = m::mock( Registry::class )->makePartial();
 		$this->pw_fix = m::mock( Process_Words_Fix::class );
-		$this->setValue( $this->r, 'process_words_fix', $this->pw_fix, Registry::class );
+		$this->set_value( $this->r, 'process_words_fix', $this->pw_fix, Registry::class );
 
-		$fixes                              = $this->getValue( $this->r, 'node_fixes', Registry::class );
+		$fixes                              = $this->get_value( $this->r, 'node_fixes', Registry::class );
 		$fixes[ Registry::PROCESS_WORDS ][] = $this->pw_fix;
-		$this->setValue( $this->r, 'node_fixes', $fixes, Registry::class );
+		$this->set_value( $this->r, 'node_fixes', $fixes, Registry::class );
 	}
 
 	/**

--- a/tests/fixes/class-registry-test.php
+++ b/tests/fixes/class-registry-test.php
@@ -35,7 +35,7 @@ use PHP_Typography\U;
 
 use PHP_Typography\Tests\Testcase;
 
-use \Mockery as m;
+use Mockery as m;
 
 /**
  * PHP_Typography unit test.

--- a/tests/fixes/class-registry-test.php
+++ b/tests/fixes/class-registry-test.php
@@ -123,14 +123,14 @@ class Registry_Test extends Testcase {
 	 * Tests register_node_fix.
 	 *
 	 * @covers ::register_node_fix
-	 *
-	 * @expectedException \InvalidArgumentException
-	 * @expectedExceptionMessageRegExp /^Invalid fixer group .+\.$/
 	 */
 	public function test_register_node_fix_invalid_group() {
 
 		// Create a stub for the Node_Fix interface.
 		$fake_node_fixer = m::mock( Node_Fix::class );
+
+		$this->expect_exception( \InvalidArgumentException::class );
+		$this->expect_exception_message_matches( '/^Invalid fixer group .+\.$/' );
 
 		$this->r->register_node_fix( $fake_node_fixer, 'invalid group parameter' );
 	}

--- a/tests/fixes/node-fixes/class-abstract-node-fix-test.php
+++ b/tests/fixes/node-fixes/class-abstract-node-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -48,8 +48,8 @@ class Abstract_Node_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = $this->getMockForAbstractClass( Node_Fixes\Abstract_Node_Fix::class );
 	}
@@ -108,6 +108,6 @@ class Abstract_Node_Fix_Test extends Node_Fix_Testcase {
 	 * @param string $result The trimmed string.
 	 */
 	public function test_remove_adjacent_characters( $string, $prev, $next, $result ) {
-		$this->assertSame( $result, $this->invokeStaticMethod( Node_Fixes\Abstract_Node_Fix::class, 'remove_adjacent_characters', [ $string, 'mb_strlen', 'mb_substr', mb_strlen( $prev ), mb_strlen( $next ) ] ) );
+		$this->assertSame( $result, $this->invoke_static_method( Node_Fixes\Abstract_Node_Fix::class, 'remove_adjacent_characters', [ $string, 'mb_strlen', 'mb_substr', mb_strlen( $prev ), mb_strlen( $next ) ] ) );
 	}
 }

--- a/tests/fixes/node-fixes/class-abstract-node-fix-test.php
+++ b/tests/fixes/node-fixes/class-abstract-node-fix-test.php
@@ -63,8 +63,8 @@ class Abstract_Node_Fix_Test extends Node_Fix_Testcase {
 		$feed_fix     = $this->getMockForAbstractClass( Node_Fixes\Abstract_Node_Fix::class, [ true ] );
 		$non_feed_fix = $this->getMockForAbstractClass( Node_Fixes\Abstract_Node_Fix::class, [ false ] );
 
-		$this->assertAttributeEquals( true,  'feed_compatible', $feed_fix,     'The fixer should be feed_compatible.' );
-		$this->assertAttributeEquals( false, 'feed_compatible', $non_feed_fix, 'The fixer should not be feed_compatible.' );
+		$this->assert_attribute_same( true,  'feed_compatible', $feed_fix,     'The fixer should be feed_compatible.' );
+		$this->assert_attribute_same( false, 'feed_compatible', $non_feed_fix, 'The fixer should not be feed_compatible.' );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-classes-dependent-fix-test.php
+++ b/tests/fixes/node-fixes/class-classes-dependent-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -54,9 +54,9 @@ class Classes_Dependent_Fix_Test extends Node_Fix_Testcase {
 	public function test_array_constructor() {
 		$fix = $this->getMockForAbstractClass( Node_Fixes\Classes_Dependent_Fix::class, [ [ 'foo', 'bar' ], false ] );
 
-		$this->assertAttributeContains( 'foo',        'classes_to_avoid', $fix, 'The fixer should avoid class "foo".' );
-		$this->assertAttributeContains( 'bar',        'classes_to_avoid', $fix, 'The fixer should avoid class "bar".' );
-		$this->assertAttributeNotContains( 'foobar',  'classes_to_avoid', $fix, 'The fixer should not care about class "foobar".' );
+		$this->assert_attribute_contains( 'foo',        'classes_to_avoid', $fix, 'The fixer should avoid class "foo".' );
+		$this->assert_attribute_contains( 'bar',        'classes_to_avoid', $fix, 'The fixer should avoid class "bar".' );
+		$this->assert_attribute_not_contains( 'foobar',  'classes_to_avoid', $fix, 'The fixer should not care about class "foobar".' );
 	}
 
 	/**
@@ -69,7 +69,7 @@ class Classes_Dependent_Fix_Test extends Node_Fix_Testcase {
 	public function test_string_constructor() {
 		$fix = $this->getMockForAbstractClass( Node_Fixes\Classes_Dependent_Fix::class, [ 'bar', false ] );
 
-		$this->assertAttributeContains( 'bar',    'classes_to_avoid', $fix, 'The fixer should avoid class "bar".' );
-		$this->assertAttributeNotContains( 'foo', 'classes_to_avoid', $fix, 'The fixer should not care about class "foobar".' );
+		$this->assert_attribute_contains( 'bar',    'classes_to_avoid', $fix, 'The fixer should avoid class "bar".' );
+		$this->assert_attribute_not_contains( 'foo', 'classes_to_avoid', $fix, 'The fixer should not care about class "foobar".' );
 	}
 }

--- a/tests/fixes/node-fixes/class-dash-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-dash-spacing-fix-test.php
@@ -47,8 +47,8 @@ class Dash_Spacing_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Dash_Spacing_Fix();
 	}

--- a/tests/fixes/node-fixes/class-dewidow-fix-test.php
+++ b/tests/fixes/node-fixes/class-dewidow-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -48,8 +48,8 @@ class Dewidow_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Dewidow_Fix();
 	}
@@ -154,7 +154,7 @@ class Dewidow_Fix_Test extends Node_Fix_Testcase {
 	 * @covers ::strip_breaking_characters
 	 */
 	public function test_strip_breaking_characters() {
-		$result = $this->invokeStaticMethod( Dewidow_Fix::class, 'strip_breaking_characters', [ 'foo' . U::SOFT_HYPHEN . 'bar' . U::ZERO_WIDTH_SPACE . 'baz' . U::ZERO_WIDTH_SPACE ] );
+		$result = $this->invoke_static_method( Dewidow_Fix::class, 'strip_breaking_characters', [ 'foo' . U::SOFT_HYPHEN . 'bar' . U::ZERO_WIDTH_SPACE . 'baz' . U::ZERO_WIDTH_SPACE ] );
 
 		$this->assertSame( 'foobarbaz', $result );
 	}
@@ -165,7 +165,7 @@ class Dewidow_Fix_Test extends Node_Fix_Testcase {
 	 * @covers ::make_space_nonbreaking
 	 */
 	public function test_make_space_nonbreaking() {
-		$result = $this->invokeStaticMethod( Dewidow_Fix::class, 'make_space_nonbreaking', [ 'foo' . U::SOFT_HYPHEN . 'bar ' . U::ZERO_WIDTH_SPACE . ' baz' . U::ZERO_WIDTH_SPACE, U::NO_BREAK_SPACE, 'u' ] );
+		$result = $this->invoke_static_method( Dewidow_Fix::class, 'make_space_nonbreaking', [ 'foo' . U::SOFT_HYPHEN . 'bar ' . U::ZERO_WIDTH_SPACE . ' baz' . U::ZERO_WIDTH_SPACE, U::NO_BREAK_SPACE, 'u' ] );
 
 		$this->assertSame( 'foo' . U::SOFT_HYPHEN . 'bar' . U::NO_BREAK_SPACE . U::ZERO_WIDTH_SPACE . U::NO_BREAK_SPACE . 'baz' . U::ZERO_WIDTH_SPACE, $result );
 	}
@@ -176,10 +176,10 @@ class Dewidow_Fix_Test extends Node_Fix_Testcase {
 	 * @covers ::is_narrow_space
 	 */
 	public function test_is_narrow_space() {
-		$this->assertTrue( $this->invokeStaticMethod( Dewidow_Fix::class, 'is_narrow_space', [ U::THIN_SPACE ] ) );
-		$this->assertTrue( $this->invokeStaticMethod( Dewidow_Fix::class, 'is_narrow_space', [ U::HAIR_SPACE ] ) );
-		$this->assertTrue( $this->invokeStaticMethod( Dewidow_Fix::class, 'is_narrow_space', [ U::NO_BREAK_NARROW_SPACE ] ) );
-		$this->assertFalse( $this->invokeStaticMethod( Dewidow_Fix::class, 'is_narrow_space', [ ' ' ] ) );
-		$this->assertFalse( $this->invokeStaticMethod( Dewidow_Fix::class, 'is_narrow_space', [ 'xxx' ] ) );
+		$this->assertTrue( $this->invoke_static_method( Dewidow_Fix::class, 'is_narrow_space', [ U::THIN_SPACE ] ) );
+		$this->assertTrue( $this->invoke_static_method( Dewidow_Fix::class, 'is_narrow_space', [ U::HAIR_SPACE ] ) );
+		$this->assertTrue( $this->invoke_static_method( Dewidow_Fix::class, 'is_narrow_space', [ U::NO_BREAK_NARROW_SPACE ] ) );
+		$this->assertFalse( $this->invoke_static_method( Dewidow_Fix::class, 'is_narrow_space', [ ' ' ] ) );
+		$this->assertFalse( $this->invoke_static_method( Dewidow_Fix::class, 'is_narrow_space', [ 'xxx' ] ) );
 	}
 }

--- a/tests/fixes/node-fixes/class-french-punctuation-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-french-punctuation-spacing-fix-test.php
@@ -48,8 +48,8 @@ class French_Punctuation_Spacing_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new French_Punctuation_Spacing_Fix();
 	}

--- a/tests/fixes/node-fixes/class-node-fix-testcase.php
+++ b/tests/fixes/node-fixes/class-node-fix-testcase.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
-use PHP_Typography\Tests\PHP_Typography_Testcase;
+use PHP_Typography\Tests\Testcase;
 
 use PHP_Typography\Fixes\Node_Fix;
 use PHP_Typography\RE;
@@ -33,7 +33,7 @@ use PHP_Typography\Settings;
 /**
  * Abstract base class for \PHP_Typography\* unit tests.
  */
-abstract class Node_Fix_Testcase extends PHP_Typography_Testcase {
+abstract class Node_Fix_Testcase extends Testcase {
 
 	/**
 	 * Settings object.

--- a/tests/fixes/node-fixes/class-node-fix-testcase.php
+++ b/tests/fixes/node-fixes/class-node-fix-testcase.php
@@ -53,7 +53,7 @@ abstract class Node_Fix_Testcase extends PHP_Typography_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
+	protected function set_up() {
 		$this->s = new Settings( true );
 	}
 

--- a/tests/fixes/node-fixes/class-numbered-abbreviation-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-numbered-abbreviation-spacing-fix-test.php
@@ -50,8 +50,8 @@ class Numbered_Abbreviation_Spacing_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Numbered_Abbreviation_Spacing_Fix();
 	}

--- a/tests/fixes/node-fixes/class-process-words-fix-test.php
+++ b/tests/fixes/node-fixes/class-process-words-fix-test.php
@@ -58,8 +58,8 @@ class Process_Words_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Process_Words_Fix();
 	}

--- a/tests/fixes/node-fixes/class-process-words-fix-test.php
+++ b/tests/fixes/node-fixes/class-process-words-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -86,7 +86,7 @@ class Process_Words_Fix_Test extends Node_Fix_Testcase {
 	 * @uses PHP_Typography\Text_Parser::__construct
 	 */
 	public function test_get_text_parser() {
-		$this->assertAttributeEmpty( 'text_parser', $this->fix );
+		$this->assert_attribute_empty( 'text_parser', $this->fix );
 
 		$parser1 = $this->fix->get_text_parser();
 		$this->assertInstanceOf( '\PHP_Typography\Text_Parser', $parser1 );
@@ -95,7 +95,7 @@ class Process_Words_Fix_Test extends Node_Fix_Testcase {
 		$this->assertInstanceOf( '\PHP_Typography\Text_Parser', $parser2 );
 
 		$this->assertSame( $parser1, $parser2 );
-		$this->assertAttributeInstanceOf( '\PHP_Typography\Text_Parser', 'text_parser', $this->fix );
+		$this->assert_attribute_instance_of( '\PHP_Typography\Text_Parser', 'text_parser', $this->fix );
 	}
 
 	/**
@@ -138,7 +138,7 @@ class Process_Words_Fix_Test extends Node_Fix_Testcase {
 		$fake_token_fixer->method( 'target' )->willReturn( Token_Fix::MIXED_WORDS );
 
 		$this->fix->register_token_fix( $fake_token_fixer );
-		$this->assertAttributeContains( $fake_token_fixer, 'token_fixes', $this->fix, 'The registered fixer is not present in the $token_fixes array.' );
+		$this->assert_attribute_contains( $fake_token_fixer, 'token_fixes', $this->fix, 'The registered fixer is not present in the $token_fixes array.' );
 	}
 
 	/**
@@ -160,6 +160,6 @@ class Process_Words_Fix_Test extends Node_Fix_Testcase {
 		$this->fix->register_token_fix( $token_fixer );
 		$this->fix->update_hyphenator_cache( $fake_cache );
 
-		$this->assertAttributeSame( $fake_cache, 'cache', $token_fixer, 'The hyphenator cache was not update correctly.' );
+		$this->assert_attribute_same( $fake_cache, 'cache', $token_fixer, 'The hyphenator cache was not update correctly.' );
 	}
 }

--- a/tests/fixes/node-fixes/class-simple-regex-replacement-fix-test.php
+++ b/tests/fixes/node-fixes/class-simple-regex-replacement-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -55,9 +55,9 @@ class Simple_Regex_Replacement_Fix_Test extends Node_Fix_Testcase {
 	public function test_constructor() {
 		$this->fix = $this->getMockForAbstractClass( Node_Fixes\Simple_Regex_Replacement_Fix::class, [ '/(.*)/', '*$1*', 'fooBar' ] );
 
-		$this->assertAttributeEquals( '/(.*)/S', 'regex',           $this->fix );
-		$this->assertAttributeEquals( 'fooBar', 'settings_switch', $this->fix );
-		$this->assertAttributeEquals( '*$1*',   'replacement',     $this->fix );
+		$this->assert_attribute_same( '/(.*)/S', 'regex',           $this->fix );
+		$this->assert_attribute_same( 'fooBar', 'settings_switch', $this->fix );
+		$this->assert_attribute_same( '*$1*',   'replacement',     $this->fix );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-simple-style-fix-test.php
+++ b/tests/fixes/node-fixes/class-simple-style-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -56,9 +56,9 @@ class Simple_Style_Fix_Test extends Node_Fix_Testcase {
 	public function test_constructor() {
 		$this->fix = $this->getMockForAbstractClass( Node_Fixes\Simple_Style_Fix::class, [ '/(.*)/', 'fooBar', 'some-class' ] );
 
-		$this->assertAttributeEquals( '/(.*)/',     'regex',           $this->fix );
-		$this->assertAttributeEquals( 'fooBar',     'settings_switch', $this->fix );
-		$this->assertAttributeEquals( 'some-class', 'css_class',       $this->fix );
+		$this->assert_attribute_same( '/(.*)/',     'regex',           $this->fix );
+		$this->assert_attribute_same( 'fooBar',     'settings_switch', $this->fix );
+		$this->assert_attribute_same( 'some-class', 'css_class',       $this->fix );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-single-character-word-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-single-character-word-spacing-fix-test.php
@@ -48,8 +48,8 @@ class Single_Character_Word_Spacing_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Single_Character_Word_Spacing_Fix();
 	}

--- a/tests/fixes/node-fixes/class-smart-area-units-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-area-units-fix-test.php
@@ -49,8 +49,8 @@ class Smart_Area_Units_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Smart_Area_Units_Fix();
 	}

--- a/tests/fixes/node-fixes/class-smart-dashes-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-dashes-fix-test.php
@@ -48,8 +48,8 @@ class Smart_Dashes_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Smart_Dashes_Fix();
 	}

--- a/tests/fixes/node-fixes/class-smart-diacritics-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-diacritics-fix-test.php
@@ -48,8 +48,8 @@ class Smart_Diacritics_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Smart_Diacritics_Fix();
 	}

--- a/tests/fixes/node-fixes/class-smart-ellipses-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-ellipses-fix-test.php
@@ -48,8 +48,8 @@ class Smart_Ellipses_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Smart_Ellipses_Fix();
 	}

--- a/tests/fixes/node-fixes/class-smart-exponents-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-exponents-fix-test.php
@@ -50,8 +50,8 @@ class Smart_Exponents_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Smart_Exponents_Fix();
 	}

--- a/tests/fixes/node-fixes/class-smart-fractions-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-fractions-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -57,7 +57,7 @@ class Smart_Fractions_Fix_Test extends Node_Fix_Testcase {
 	 */
 	public function test_array_constructor() {
 		$this->fix = new Node_Fixes\Smart_Fractions_Fix( 'foo', 'bar' );
-		$this->assertAttributeEquals( RE::escape_tags( '<sup class="foo">$1</sup>' . U::FRACTION_SLASH . '<sub class="bar">$2</sub>$3' ), 'replacement',   $this->fix, 'The replacement should contain the classes "foo" and "bar".' );
+		$this->assert_attribute_same( RE::escape_tags( '<sup class="foo">$1</sup>' . U::FRACTION_SLASH . '<sub class="bar">$2</sub>$3' ), 'replacement',   $this->fix, 'The replacement should contain the classes "foo" and "bar".' );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-smart-marks-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-marks-fix-test.php
@@ -49,8 +49,8 @@ class Smart_Marks_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Smart_Marks_Fix();
 	}

--- a/tests/fixes/node-fixes/class-smart-marks-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-marks-fix-test.php
@@ -63,8 +63,8 @@ class Smart_Marks_Fix_Test extends Node_Fix_Testcase {
 	public function test_constructor() {
 		$this->fix = $this->getMockForAbstractClass( Node_Fixes\Smart_Marks_Fix::class, [ false ] );
 
-		$this->assertAttributeInternalType( 'array', 'marks', $this->fix );
-		$this->assertAttributeInternalType( 'array', 'replacements', $this->fix );
+		$this->assert_is_array( $this->get_value( $this->fix, 'marks' ) );
+		$this->assert_is_array( $this->get_value( $this->fix, 'replacements' ) );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-smart-maths-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-maths-fix-test.php
@@ -49,8 +49,8 @@ class Smart_Maths_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Smart_Maths_Fix();
 	}

--- a/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -68,7 +68,7 @@ class Smart_Ordinal_Suffix_Fix_Test extends Node_Fix_Testcase {
 	public function test_array_constructor() {
 		$this->fix = new Node_Fixes\Smart_Ordinal_Suffix_Fix( 'foo' );
 
-		$this->assertAttributeEquals( RE::escape_tags( '$1<sup class="foo">$2</sup>' ), 'replacement', $this->fix, 'The replacement CSS class should be "foo".' );
+		$this->assert_attribute_same( RE::escape_tags( '$1<sup class="foo">$2</sup>' ), 'replacement', $this->fix, 'The replacement CSS class should be "foo".' );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
@@ -50,8 +50,8 @@ class Smart_Ordinal_Suffix_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Smart_Ordinal_Suffix_Fix();
 	}

--- a/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
@@ -51,8 +51,8 @@ class Smart_Quotes_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Smart_Quotes_Fix();
 	}

--- a/tests/fixes/node-fixes/class-space-collapse-fix-test.php
+++ b/tests/fixes/node-fixes/class-space-collapse-fix-test.php
@@ -49,8 +49,8 @@ class Space_Collapse_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Space_Collapse_Fix();
 	}

--- a/tests/fixes/node-fixes/class-style-hanging-punctuation-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-hanging-punctuation-fix-test.php
@@ -67,10 +67,10 @@ class Style_Hanging_Punctuation_Fix_Test extends Node_Fix_Testcase {
 	public function test_constructor() {
 		$this->fix = new Node_Fixes\Style_Hanging_Punctuation_Fix( 'alpha', 'beta', 'gamma', 'delta' );
 
-		$this->assertAttributeEquals( 'alpha', 'push_single_class', $this->fix );
-		$this->assertAttributeEquals( 'beta',  'push_double_class', $this->fix );
-		$this->assertAttributeEquals( 'gamma', 'pull_single_class', $this->fix );
-		$this->assertAttributeEquals( 'delta', 'pull_double_class', $this->fix );
+		$this->assert_attribute_same( 'alpha', 'push_single_class', $this->fix );
+		$this->assert_attribute_same( 'beta',  'push_double_class', $this->fix );
+		$this->assert_attribute_same( 'gamma', 'pull_single_class', $this->fix );
+		$this->assert_attribute_same( 'delta', 'pull_double_class', $this->fix );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-style-hanging-punctuation-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-hanging-punctuation-fix-test.php
@@ -51,8 +51,8 @@ class Style_Hanging_Punctuation_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Style_Hanging_Punctuation_Fix( 'push-single', 'push-double', 'pull-single', 'pull-double' );
 	}

--- a/tests/fixes/node-fixes/class-style-initial-quotes-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-initial-quotes-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -52,8 +52,8 @@ class Style_Initial_Quotes_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Style_Initial_Quotes_Fix( 'single', 'double' );
 	}
@@ -171,7 +171,7 @@ class Style_Initial_Quotes_Fix_Test extends Node_Fix_Testcase {
 	 * @param bool   $ignored Ignored.
 	 */
 	public function test_is_single_quote( $quote, $result, $ignored ) {
-		$this->assertSame( $result, $this->invokeStaticMethod( Node_Fixes\Style_Initial_Quotes_Fix::class, 'is_single_quote', [ $quote ] ) );
+		$this->assertSame( $result, $this->invoke_static_method( Node_Fixes\Style_Initial_Quotes_Fix::class, 'is_single_quote', [ $quote ] ) );
 	}
 
 	/**
@@ -186,6 +186,6 @@ class Style_Initial_Quotes_Fix_Test extends Node_Fix_Testcase {
 	 * @param bool   $result  Expected result.
 	 */
 	public function test_is_double_quote( $quote, $ignored, $result ) {
-		$this->assertSame( $result, $this->invokeStaticMethod( Node_Fixes\Style_Initial_Quotes_Fix::class, 'is_double_quote', [ $quote ] ) );
+		$this->assertSame( $result, $this->invoke_static_method( Node_Fixes\Style_Initial_Quotes_Fix::class, 'is_double_quote', [ $quote ] ) );
 	}
 }

--- a/tests/fixes/node-fixes/class-style-initial-quotes-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-initial-quotes-fix-test.php
@@ -66,8 +66,8 @@ class Style_Initial_Quotes_Fix_Test extends Node_Fix_Testcase {
 	public function test_constructor() {
 		$this->fix = new Node_Fixes\Style_Initial_Quotes_Fix( 'single', 'double' );
 
-		$this->assertAttributeEquals( 'single', 'single_quote_class', $this->fix );
-		$this->assertAttributeEquals( 'double', 'double_quote_class', $this->fix );
+		$this->assert_attribute_same( 'single', 'single_quote_class', $this->fix );
+		$this->assert_attribute_same( 'double', 'double_quote_class', $this->fix );
 	}
 
 	/**

--- a/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
@@ -50,8 +50,8 @@ class Unit_Spacing_Fix_Test extends Node_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Node_Fixes\Unit_Spacing_Fix();
 	}

--- a/tests/fixes/token-fixes/class-abstract-token-fix-test.php
+++ b/tests/fixes/token-fixes/class-abstract-token-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -83,8 +83,8 @@ class Abstract_Token_Fix_Test extends Token_Fix_Testcase {
 		$bound        = $this->construct_caller->bindTo( $non_feed_fix, $non_feed_fix );
 		$bound( Token_Fix::WORDS, false );
 
-		$this->assertAttributeEquals( true,  'feed_compatible', $feed_fix,     'The fixer should be feed_compatible.' );
-		$this->assertAttributeEquals( false, 'feed_compatible', $non_feed_fix, 'The fixer should not be feed_compatible.' );
+		$this->assert_attribute_same( true,  'feed_compatible', $feed_fix,     'The fixer should be feed_compatible.' );
+		$this->assert_attribute_same( false, 'feed_compatible', $non_feed_fix, 'The fixer should not be feed_compatible.' );
 	}
 
 	/**

--- a/tests/fixes/token-fixes/class-abstract-token-fix-test.php
+++ b/tests/fixes/token-fixes/class-abstract-token-fix-test.php
@@ -56,8 +56,8 @@ class Abstract_Token_Fix_Test extends Token_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->construct_caller = function( $target, $feed_compatible ) {
 			$this->__construct( $target, $feed_compatible );

--- a/tests/fixes/token-fixes/class-hyphenate-compounds-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-compounds-fix-test.php
@@ -52,8 +52,8 @@ class Hyphenate_Compounds_Fix_Test extends Token_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Token_Fixes\Hyphenate_Compounds_Fix();
 	}

--- a/tests/fixes/token-fixes/class-hyphenate-compounds-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-compounds-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -66,8 +66,8 @@ class Hyphenate_Compounds_Fix_Test extends Token_Fix_Testcase {
 	public function test_constructor() {
 		$fix = new Token_Fixes\Hyphenate_Compounds_Fix( null, true );
 
-		$this->assertAttributeEquals( Token_Fix::COMPOUND_WORDS, 'target', $fix, 'The fixer should be targetting COMPOUND_WORDS tokens.' );
-		$this->assertAttributeEquals( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
+		$this->assert_attribute_same( Token_Fix::COMPOUND_WORDS, 'target', $fix, 'The fixer should be targetting COMPOUND_WORDS tokens.' );
+		$this->assert_attribute_same( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
 	}
 
 	/**

--- a/tests/fixes/token-fixes/class-hyphenate-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-fix-test.php
@@ -72,8 +72,8 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 	public function test_constructor() {
 		$fix = new Token_Fixes\Hyphenate_Fix( null, Token_Fix::COMPOUND_WORDS, true );
 
-		$this->assertAttributeEquals( Token_Fix::COMPOUND_WORDS, 'target', $fix, 'The fixer should be targetting COMPOUND_WORDS tokens.' );
-		$this->assertAttributeEquals( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
+		$this->assert_attribute_same( Token_Fix::COMPOUND_WORDS, 'target', $fix, 'The fixer should be targetting COMPOUND_WORDS tokens.' );
+		$this->assert_attribute_same( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
 	}
 
 	/**

--- a/tests/fixes/token-fixes/class-hyphenate-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -58,8 +58,8 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Token_Fixes\Hyphenate_Fix();
 	}
@@ -98,12 +98,12 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_hyphenate_title_case( true );
 
 		$tokens     = $this->tokenize( mb_convert_encoding( 'Änderungsmeldung', 'ISO-8859-2' ) );
-		$hyphenated = $this->invokeMethod( $this->fix, 'do_hyphenate', [ $tokens, $this->s ] );
-		$this->assertTokensSame( $hyphenated, $tokens );
+		$hyphenated = $this->invoke_method( $this->fix, 'do_hyphenate', [ $tokens, $this->s ] );
+		$this->assert_tokens_same( $hyphenated, $tokens );
 
 		$tokens     = $this->tokenize( 'Änderungsmeldung' );
-		$hyphenated = $this->invokeMethod( $this->fix, 'do_hyphenate', [ $tokens, $this->s ] );
-		$this->assertTokensNotSame( $hyphenated, $tokens, 'Different encodings should not be equal.' );
+		$hyphenated = $this->invoke_method( $this->fix, 'do_hyphenate', [ $tokens, $this->s ] );
+		$this->assert_tokens_not_same( $hyphenated, $tokens, 'Different encodings should not be equal.' );
 	}
 
 
@@ -129,7 +129,7 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_hyphenate_title_case( false );
 
 		$tokens     = $this->tokenize( 'Änderungsmeldung' );
-		$hyphenated = $this->invokeMethod( $this->fix, 'do_hyphenate', [ $tokens, $this->s ] );
+		$hyphenated = $this->invoke_method( $this->fix, 'do_hyphenate', [ $tokens, $this->s ] );
 		$this->assertEquals( $tokens, $hyphenated );
 	}
 
@@ -157,7 +157,7 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 		$this->s[ Settings::HYPHENATION_MIN_BEFORE ] = 0; // invalid value.
 
 		$tokens     = $this->tokenize( 'Änderungsmeldung' );
-		$hyphenated = $this->invokeMethod( $this->fix, 'do_hyphenate', [ $tokens, $this->s ] );
+		$hyphenated = $this->invoke_method( $this->fix, 'do_hyphenate', [ $tokens, $this->s ] );
 		$this->assertEquals( $tokens, $hyphenated );
 	}
 
@@ -201,14 +201,14 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 	public function test_set_hyphenator_cache() {
 
 		// Initial set-up.
-		$internal_cache = $this->getValue( $this->fix, 'cache' );
+		$internal_cache = $this->get_value( $this->fix, 'cache' );
 		$cache          = new \PHP_Typography\Hyphenator\Cache();
 
 		$this->fix->set_hyphenator_cache( $cache );
 
 		// Retrieve cache and assert results.
 		$this->assertNotSame( $cache, $internal_cache );
-		$this->assertSame( $cache, $this->getValue( $this->fix, 'cache' ) );
+		$this->assertSame( $cache, $this->get_value( $this->fix, 'cache' ) );
 	}
 
 

--- a/tests/fixes/token-fixes/class-smart-dashes-hyphen-fix-test.php
+++ b/tests/fixes/token-fixes/class-smart-dashes-hyphen-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -65,8 +65,8 @@ class Smart_Dashes_Hyphen_Fix_Test extends Token_Fix_Testcase {
 	public function test_constructor() {
 		$fix = new Token_Fixes\Smart_Dashes_Hyphen_Fix( true );
 
-		$this->assertAttributeEquals( Token_Fix::MIXED_WORDS, 'target', $fix, 'The fixer should be targetting MIXED_WORDS tokens.' );
-		$this->assertAttributeEquals( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
+		$this->assert_attribute_same( Token_Fix::MIXED_WORDS, 'target', $fix, 'The fixer should be targetting MIXED_WORDS tokens.' );
+		$this->assert_attribute_same( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
 	}
 
 	/**

--- a/tests/fixes/token-fixes/class-smart-dashes-hyphen-fix-test.php
+++ b/tests/fixes/token-fixes/class-smart-dashes-hyphen-fix-test.php
@@ -51,8 +51,8 @@ class Smart_Dashes_Hyphen_Fix_Test extends Token_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Token_Fixes\Smart_Dashes_Hyphen_Fix();
 	}

--- a/tests/fixes/token-fixes/class-token-fix-testcase.php
+++ b/tests/fixes/token-fixes/class-token-fix-testcase.php
@@ -51,8 +51,8 @@ abstract class Token_Fix_Testcase extends PHP_Typography_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->s = new Settings( false );
 	}
@@ -68,6 +68,6 @@ abstract class Token_Fix_Testcase extends PHP_Typography_Testcase {
 	protected function assertFixResultSame( $input, $result, $is_title = false, $textnode = null ) {
 		$tokens        = $this->tokenize_sentence( $input );
 		$result_tokens = $this->fix->apply( $tokens, $this->s, $is_title, $textnode );
-		$this->assertTokensSame( $result, $result_tokens );
+		$this->assert_tokens_same( $result, $result_tokens );
 	}
 }

--- a/tests/fixes/token-fixes/class-token-fix-testcase.php
+++ b/tests/fixes/token-fixes/class-token-fix-testcase.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,14 +24,14 @@
 
 namespace PHP_Typography\Tests\Fixes\Token_Fixes;
 
-use PHP_Typography\Tests\PHP_Typography_Testcase;
+use PHP_Typography\Tests\Testcase;
 use PHP_Typography\Settings;
 use PHP_Typography\Fixes\Token_Fix;
 
 /**
  * Abstract base class for \PHP_Typography\* unit tests.
  */
-abstract class Token_Fix_Testcase extends PHP_Typography_Testcase {
+abstract class Token_Fix_Testcase extends Testcase {
 
 	/**
 	 * Settings object.

--- a/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -65,8 +65,8 @@ class Wrap_Emails_Fix_Test extends Token_Fix_Testcase {
 	public function test_constructor() {
 		$fix = new Token_Fixes\Wrap_Emails_Fix( true );
 
-		$this->assertAttributeEquals( Token_Fix::OTHER, 'target', $fix, 'The fixer should be targetting OTHER tokens.' );
-		$this->assertAttributeEquals( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
+		$this->assert_attribute_same( Token_Fix::OTHER, 'target', $fix, 'The fixer should be targetting OTHER tokens.' );
+		$this->assert_attribute_same( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
 	}
 
 

--- a/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
@@ -51,8 +51,8 @@ class Wrap_Emails_Fix_Test extends Token_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Token_Fixes\Wrap_Emails_Fix();
 	}

--- a/tests/fixes/token-fixes/class-wrap-hard-hyphens-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-hard-hyphens-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -65,8 +65,8 @@ class Wrap_Hard_Hyphens_Fix_Test extends Token_Fix_Testcase {
 	public function test_constructor() {
 		$fix = new Token_Fixes\Wrap_Hard_Hyphens_Fix( true );
 
-		$this->assertAttributeEquals( Token_Fix::MIXED_WORDS, 'target', $fix, 'The fixer should be targetting MIXED_WORDS tokens.' );
-		$this->assertAttributeEquals( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
+		$this->assert_attribute_same( Token_Fix::MIXED_WORDS, 'target', $fix, 'The fixer should be targetting MIXED_WORDS tokens.' );
+		$this->assert_attribute_same( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
 	}
 
 	/**

--- a/tests/fixes/token-fixes/class-wrap-hard-hyphens-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-hard-hyphens-fix-test.php
@@ -51,8 +51,8 @@ class Wrap_Hard_Hyphens_Fix_Test extends Token_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Token_Fixes\Wrap_Hard_Hyphens_Fix();
 	}

--- a/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
@@ -53,8 +53,8 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->fix = new Token_Fixes\Wrap_URLs_Fix();
 	}

--- a/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -67,8 +67,8 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 	public function test_constructor() {
 		$fix = new Token_Fixes\Wrap_URLs_Fix( null, true );
 
-		$this->assertAttributeEquals( Token_Fix::OTHER, 'target', $fix, 'The fixer should be targetting OTHER tokens.' );
-		$this->assertAttributeEquals( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
+		$this->assert_attribute_same( Token_Fix::OTHER, 'target', $fix, 'The fixer should be targetting OTHER tokens.' );
+		$this->assert_attribute_same( true, 'feed_compatible', $fix, 'The fixer should not be feed_compatible.' );
 	}
 
 	/**

--- a/tests/hyphenator/class-cache-test.php
+++ b/tests/hyphenator/class-cache-test.php
@@ -46,8 +46,8 @@ class Cache_Test extends PHP_Typography_Testcase {
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 */
-	protected function setUp() {
-		parent::setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		$this->c = new \PHP_Typography\Hyphenator\Cache();
 	}

--- a/tests/hyphenator/class-cache-test.php
+++ b/tests/hyphenator/class-cache-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2016-2019 Peter Putzer.
+ *  Copyright 2016-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 
 namespace PHP_Typography\Tests\Hyphenator;
 
-use PHP_Typography\Tests\PHP_Typography_Testcase;
+use PHP_Typography\Tests\Testcase;
 
 /**
  * Test Hyphenator\Cache class.
@@ -34,7 +34,7 @@ use PHP_Typography\Tests\PHP_Typography_Testcase;
  *
  * @uses PHP_Typography\Hyphenator
  */
-class Cache_Test extends PHP_Typography_Testcase {
+class Cache_Test extends Testcase {
 	/**
 	 * Hyphenator\Cache fixture.
 	 *

--- a/tests/hyphenator/class-trie-node-test.php
+++ b/tests/hyphenator/class-trie-node-test.php
@@ -139,7 +139,7 @@ class Trie_Node_Test extends Testcase {
 		$node = $node->get_node( 'a' );
 
 		$this->assertInstanceOf( Trie_Node::class, $node );
-		$this->assertInternalType( 'array', $node->offsets() );
+		$this->assert_is_array( $node->offsets() );
 		$this->assertGreaterThan( 0, count( $node->offsets() ) );
 
 		return $trie;

--- a/tests/hyphenator/class-trie-node-test.php
+++ b/tests/hyphenator/class-trie-node-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 
 namespace PHP_Typography\Tests\Hyphenator;
 
-use PHP_Typography\Tests\PHP_Typography_Testcase;
+use PHP_Typography\Tests\Testcase;
 use PHP_Typography\Hyphenator\Trie_Node;
 
 /**
@@ -33,7 +33,7 @@ use PHP_Typography\Hyphenator\Trie_Node;
  * @coversDefaultClass \PHP_Typography\Hyphenator\Trie_Node
  * @usesDefaultClass \PHP_Typography\Hyphenator\Trie_Node
  */
-class Trie_Node_Test extends PHP_Typography_Testcase {
+class Trie_Node_Test extends Testcase {
 
 	/**
 	 * Tests build_trie.

--- a/tests/settings/class-dash-style-test.php
+++ b/tests/settings/class-dash-style-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 
 namespace PHP_Typography\Tests\Settings;
 
-use PHP_Typography\Tests\PHP_Typography_Testcase;
+use PHP_Typography\Tests\Testcase;
 
 use PHP_Typography\Settings\Dashes;
 use PHP_Typography\Settings\Dash_Style;
@@ -38,7 +38,7 @@ use PHP_Typography\U;
  *
  * @uses PHP_Typography\Settings\Simple_Dashes
  */
-class Dash_Style_Test extends PHP_Typography_Testcase {
+class Dash_Style_Test extends Testcase {
 
 
 	/**

--- a/tests/settings/class-quote-style-test.php
+++ b/tests/settings/class-quote-style-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 
 namespace PHP_Typography\Tests\Settings;
 
-use PHP_Typography\Tests\PHP_Typography_Testcase;
+use PHP_Typography\Tests\Testcase;
 
 use PHP_Typography\Settings\Quotes;
 use PHP_Typography\Settings\Quote_Style;
@@ -38,7 +38,7 @@ use PHP_Typography\U;
  *
  * @uses PHP_Typography\Settings\Simple_Quotes
  */
-class Quote_Style_Test extends PHP_Typography_Testcase {
+class Quote_Style_Test extends Testcase {
 
 
 	/**

--- a/tests/settings/class-simple-dashes-test.php
+++ b/tests/settings/class-simple-dashes-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 
 namespace PHP_Typography\Tests\Settings;
 
-use PHP_Typography\Tests\PHP_Typography_Testcase;
+use PHP_Typography\Tests\Testcase;
 
 use PHP_Typography\Settings\Quotes;
 use PHP_Typography\Settings\Simple_Dashes;
@@ -38,7 +38,7 @@ use PHP_Typography\U;
  *
  * @uses PHP_Typography\Settings\Simple_Dashes
  */
-class Simple_Dashes_Test extends PHP_Typography_Testcase {
+class Simple_Dashes_Test extends Testcase {
 
 	/**
 	 * Provide data for testing the Simple_Dashes class.

--- a/tests/settings/class-simple-quotes-test.php
+++ b/tests/settings/class-simple-quotes-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 
 namespace PHP_Typography\Tests\Settings;
 
-use PHP_Typography\Tests\PHP_Typography_Testcase;
+use PHP_Typography\Tests\Testcase;
 
 use PHP_Typography\Settings\Quotes;
 use PHP_Typography\Settings\Simple_Quotes;
@@ -38,7 +38,7 @@ use PHP_Typography\U;
  *
  * @uses PHP_Typography\Settings\Simple_Quotes
  */
-class Simple_Quotes_Test extends PHP_Typography_Testcase {
+class Simple_Quotes_Test extends Testcase {
 
 	/**
 	 * Provide data for testing the Simple_Quotes class.

--- a/tests/text-parser/class-token-test.php
+++ b/tests/text-parser/class-token-test.php
@@ -85,15 +85,16 @@ class Token_Test extends Testcase {
 	 * @covers ::__construct
 	 *
 	 * @dataProvider provide___construct_with_exception_data
-	 * @expectedException \UnexpectedValueException
 	 *
 	 * @param  string $value The token value.
 	 * @param  int    $type  The token type.
 	 */
 	public function test___construct_with_exception( $value, $type ) {
+		$this->expect_exception( \UnexpectedValueException::class );
+
 		$token = new Token( $value, $type );
 
-		$this->$this->assertInstanceOf( Token::class, $token );
+		$this->assertInstanceOf( Token::class, $token );
 	}
 
 	/**
@@ -102,12 +103,13 @@ class Token_Test extends Testcase {
 	 * @covers ::__construct
 	 *
 	 * @dataProvider provide___construct_data
-	 * @expectedException \BadMethodCallException
 	 *
 	 * @param  string $value The token value.
 	 * @param  int    $type  The token type.
 	 */
 	public function test___construct_called_twice( $value, $type ) {
+		$this->expect_exception( \BadMethodCallException::class );
+
 		$token = new Token( $value, $type );
 		$token->__construct( 'foo', 0 );
 	}
@@ -166,7 +168,6 @@ class Token_Test extends Testcase {
 	 * @uses ::__construct
 	 *
 	 * @dataProvider provide___set_data
-	 * @expectedException \BadMethodCallException
 	 *
 	 * @param  string $value     Token value.
 	 * @param  int    $type      Token type.
@@ -174,7 +175,10 @@ class Token_Test extends Testcase {
 	 * @param  mixed  $new_value Property value to set.
 	 */
 	public function test___set( $value, $type, $property, $new_value ) {
-		$token            = new Token( $value, $type );
+		$token = new Token( $value, $type );
+
+		$this->expect_exception( \BadMethodCallException::class );
+
 		$token->$property = $new_value;
 	}
 
@@ -184,7 +188,6 @@ class Token_Test extends Testcase {
 	 * @uses ::__construct
 	 *
 	 * @dataProvider provide___set_data
-	 * @expectedException \BadMethodCallException
 	 *
 	 * @param  string $value     Token value.
 	 * @param  int    $type      Token type.
@@ -193,6 +196,9 @@ class Token_Test extends Testcase {
 	 */
 	public function test___unset( $value, $type, $property, $ignored ) {
 		$token = new Token( $value, $type );
+
+		$this->expect_exception( \BadMethodCallException::class );
+
 		unset( $token->$property );
 	}
 

--- a/tests/text-parser/class-token-test.php
+++ b/tests/text-parser/class-token-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2020 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@
 
 namespace PHP_Typography\Tests\Text_Parser;
 
-use PHP_Typography\Tests\PHP_Typography_Testcase;
+use PHP_Typography\Tests\Testcase;
 use PHP_Typography\Text_Parser\Token;
 
 /**
@@ -33,7 +33,7 @@ use PHP_Typography\Text_Parser\Token;
  * @coversDefaultClass \PHP_Typography\Text_Parser\Token
  * @usesDefaultClass \PHP_Typography\Text_Parser\Token
  */
-class Token_Test extends PHP_Typography_Testcase {
+class Token_Test extends Testcase {
 
 	/**
 	 * Provide value pairs for testing the Token constructor.


### PR DESCRIPTION
- Uses new base class from `mundschenk-at/phpunit-cross-version`.
- Renames `PHP_Typography\Tests\PHP_Typography_Testcase to `PHP_Typography\Tests\Testcase`.
- Allows newer PHPUnit versions to be used. Fixes #128.