### PR TITLE
#150: Fix PHP 8.1 deprecation warnings

### DIFF
--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -231,6 +231,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 *
 	 * @param string $key The settings key.
 	 */
+  #[\ReturnTypeWillChange]
 	public function __unset( $key ) {
 		unset( $this->data[ $key ] );
 	}
@@ -241,6 +242,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 * @param string $offset The settings key.
 	 * @param mixed  $value  The settings value.
 	 */
+  #[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		if ( ! empty( $offset ) ) {
 			$this->data[ $offset ] = $value;
@@ -252,6 +254,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 *
 	 * @param string $offset The settings key.
 	 */
+  #[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		return isset( $this->data[ $offset ] );
 	}
@@ -261,6 +264,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 *
 	 * @param string $offset The settings key.
 	 */
+  #[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {
 		unset( $this->data[ $offset ] );
 	}
@@ -272,6 +276,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 *
 	 * @return mixed
 	 */
+  #[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		return isset( $this->data[ $offset ] ) ? $this->data[ $offset ] : null;
 	}
@@ -281,6 +286,7 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 *
 	 * @return mixed
 	 */
+  #[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return \array_merge(
 			$this->data,


### PR DESCRIPTION
Fixes #150 

Fixed so that the code stays compatible with the composer PHP
requirements:

Added #[\ReturnTypeWillChange] comments to the methods that do not have
the proper return type set.

Better would be to release a new version of the package that supports
^7.4 || ^8.0 and that defines the proper input and output types.