### PR TITLE
Update CI workflow & Composer requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,175 @@
+name: CI
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        types: [opened, synchronize, reopened]
+
+jobs:
+    unit-tests:
+        name: Unit tests (PHP ${{ matrix.php-versions }})
+        runs-on: ubuntu-18.04
+        continue-on-error: ${{ matrix.experimental }}
+        env:
+            COVERAGE_PHP: '8.0'
+        strategy:
+            fail-fast: false
+            matrix:
+                php-versions: ['7.2', '7.3', '7.4', '8.0']
+                experimental: [false]
+                include:
+                    - php-versions: '8.1'
+                      experimental: true
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+              with:
+                  # Disabling shallow clone is recommended for improving relevancy of reporting
+                  fetch-depth: 0
+            - name: Setup PHP, with Composer and extensions
+              uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+              with:
+                  php-version: ${{ matrix.php-versions }}
+                  coverage: none
+                  extensions: gd
+            - name: Setup problem matchers for PHPUnit
+              run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+            - name: Remove unused Composer dependencies
+              run: composer remove humbug/php-scoper sirbrillig/phpcs-import-detection phpstan/phpstan szepeviktor/phpstan-wordpress --dev --no-interaction --no-update
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                restore-keys: ${{ runner.os }}-composer-
+            - name: Install dependencies
+              run: composer install --prefer-dist
+            - name: Run PHPUnit tests
+              run: composer test
+
+    coverage:
+        name: Coverage & SonarCloud (PHP ${{ matrix.php-versions }})
+        runs-on: ubuntu-18.04
+        strategy:
+            fail-fast: true
+            matrix:
+                php-versions: ['8.0']
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+              with:
+                  # Disabling shallow clone is recommended for improving relevancy of reporting
+                  fetch-depth: 0
+            - name: Setup PHP, with Composer and extensions
+              uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+              with:
+                  php-version: ${{ matrix.php-versions }}
+                  coverage: xdebug
+                  extensions: gd
+            - name: Remove unused Composer dependencies
+              run: composer remove humbug/php-scoper sirbrillig/phpcs-import-detection szepeviktor/phpstan-wordpress --dev --no-interaction --no-update
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                path: ${{ steps.composer-cache.outputs.dir }}
+                key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                restore-keys: ${{ runner.os }}-composer-
+            - name: Install dependencies
+              run: composer install --prefer-dist
+            - name: Run PHPUnit tests with coverage generation
+              run: |
+                  mkdir -p build/logs
+                  composer test -- --coverage-clover build/logs/phpunit.coverage.xml --log-junit=build/logs/phpunit.test-report.xml
+            - name: Fix code coverage paths for SonarCloud
+              working-directory: ./build/logs/
+              run: |
+                  sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' phpunit.coverage.xml
+                  sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' phpunit.test-report.xml
+            - name: SonarCloud Scan
+              uses: SonarSource/sonarcloud-github-action@master
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+              if: env.SONAR_TOKEN != ''
+
+    phpcs:
+        name: Check Coding Standards
+        runs-on: ubuntu-18.04
+        strategy:
+            fail-fast: true
+            matrix:
+                php-versions: ['8.0']
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Setup PHP, with Composer and extensions
+              uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+              with:
+                  php-version: ${{ matrix.php-versions }}
+                  coverage: none
+                  extensions: gd
+                  tools: cs2pr
+
+            - name: Remove unused Composer dependencies
+              run: composer remove humbug/php-scoper --dev --no-interaction --no-update
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
+
+            - name: Install dependencies
+              run: composer install --prefer-dist
+
+            - name: Run PHPCS checks
+              run: vendor/bin/phpcs -q src/ --extensions=php --report=checkstyle | cs2pr
+
+    phpstan:
+        name: Static Analysis
+        runs-on: ubuntu-18.04
+        strategy:
+            fail-fast: true
+            matrix:
+                php-versions: ['8.0']
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+            - name: Setup PHP, with Composer and extensions
+              uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+              with:
+                  php-version: ${{ matrix.php-versions }}
+                  coverage: none
+                  extensions: gd
+            - name: Remove unused Composer dependencies
+              run: composer remove humbug/php-scoper sirbrillig/phpcs-import-detection --dev --no-interaction --no-update
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache dependencies
+              uses: actions/cache@v2
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
+
+            - name: Install dependencies
+              run: composer install --prefer-dist
+
+            - name: Run PHPStan
+              run: composer run-script phpstan

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ node_modules/*
 # SASS
 .sass-cache/*
 
+# PHPUnit cache
+.phpunit.result.cache
+
 # ignore generated code coverage files
 tests/coverage/*
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PHP-Typography
 
-[![Build Status](https://travis-ci.org/mundschenk-at/php-typography.svg?branch=master)](https://travis-ci.org/mundschenk-at/php-typography)
+![Build Status](https://github.com/mundschenk-at/php-typography/actions/workflows/ci.yml/badge.svg)
 [![Latest Stable Version](https://poser.pugx.org/mundschenk-at/php-typography/v/stable)](https://packagist.org/packages/mundschenk-at/php-typography)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/mundschenk-at/php-typography/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/mundschenk-at/php-typography/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/mundschenk-at/php-typography/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/mundschenk-at/php-typography/?branch=master)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=mundschenk-at_php-typography&metric=alert_status)](https://sonarcloud.io/dashboard?id=mundschenk-at_php-typography)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=mundschenk-at_php-typography&metric=coverage)](https://sonarcloud.io/dashboard?id=mundschenk-at_php-typography)
 [![License](https://poser.pugx.org/mundschenk-at/php-typography/license)](https://packagist.org/packages/mundschenk-at/php-typography)
 
 A PHP library for improving your web typography:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A PHP library for improving your web typography:
 
 ## Requirements
 
-*   PHP 5.6.0 or above
+*   PHP 7.2.0 or above
 *   The `mbstring` extension
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "squizlabs/php_codesniffer": "^3",
         "wp-coding-standards/wpcs": "^2.0",
         "phpcompatibility/php-compatibility": "^9.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
-        "phpstan/phpstan": "^0.12",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "phpstan/phpstan": "^1.9",
         "phpbench/phpbench": "^0.17||^1.0@dev",
         "mundschenk-at/phpunit-cross-version": "dev-master"
     },
@@ -79,5 +79,10 @@
             "phpstan analyse --configuration=.phpstan.neon --level=7 --ansi src/",
             "phpstan analyse --configuration=.phpstan.neon --level=6 --ansi tests/"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
 
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.2.0",
         "ext-pcre": "*",
         "ext-mbstring": "*",
         "masterminds/html5": "^2.5.0"

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,4 +1,4 @@
 {
-    "bootstrap": "vendor/autoload.php",
-    "path": "tests/benchmarks"
+    "runner.bootstrap": "vendor/autoload.php",
+    "runner.path": "tests/benchmarks"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,7 @@
     * See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml
 	</description>
 
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.2-"/>
 
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,16 @@
+sonar.projectKey=mundschenk-at_php-typography
+sonar.organization=mundschenk-at
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=php-typography
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=src
+sonar.tests=tests
+sonar.test.exclusions=tests/phpstan/*.php
+sonar.php.coverage.reportPaths=build/logs/phpunit.coverage.xml
+sonar.php.tests.reportPath=build/logs/phpunit.test-report.xml
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
- Requires at least PHP 7.2.0.
- Switches to GitHub Actions and SonarCloud for CI.
- Updates `composer.json` for Composer 2.x.