### PR TITLE
Require at least PHP 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-versions: ['7.2', '7.3', '7.4', '8.0']
+                php-versions: ['7.4', '8.0']
                 experimental: [false]
                 include:
                     - php-versions: '8.1'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A PHP library for improving your web typography:
 
 ## Requirements
 
-*   PHP 7.2.0 or above
+*   PHP 7.4.0 or above
 *   The `mbstring` extension
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
 
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.4.0",
         "ext-pcre": "*",
         "ext-mbstring": "*",
         "masterminds/html5": "^2.5.0"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,7 @@
     * See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml
 	</description>
 
-	<config name="testVersion" value="7.2-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">

--- a/src/class-strings.php
+++ b/src/class-strings.php
@@ -76,7 +76,7 @@ abstract class Strings {
 	const STRING_FUNCTIONS = [
 		'UTF-8' => [
 			'strlen'     => 'mb_strlen',
-			'str_split'  => [ __CLASS__, 'mb_str_split' ],
+			'str_split'  => 'mb_str_split',
 			'strtolower' => 'mb_strtolower',
 			'strtoupper' => 'mb_strtoupper',
 			'substr'     => 'mb_substr',
@@ -107,6 +107,8 @@ abstract class Strings {
 	 * Multibyte-safe str_split function. Unlike regular str_split, behavior for
 	 * `$split_length` < 1 is undefined and may or may not result in an error
 	 * being raised.
+	 *
+	 * @deprecated 6.7.0
 	 *
 	 * @param string     $string       The input string.
 	 * @param int<1,max> $split_length Optional. Maximum length of the chunk. Default 1.


### PR DESCRIPTION
- Updates minimum PHP version to 7.4.
- Enables native `mb_str_split`.