### PR TITLE
Use new PHP unicode features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
             "phpunit --testsuite PHP-Typography"
         ],
         "coverage": [
-            "phpunit --testsuite PHP-Typography --coverage-html tests/coverage"
+            "XDEBUG_MODE=coverage phpunit --testsuite PHP-Typography --coverage-html tests/coverage"
         ],
         "check": [
             "@phpcs",

--- a/src/bin/class-pattern-converter.php
+++ b/src/bin/class-pattern-converter.php
@@ -28,6 +28,7 @@
 namespace PHP_Typography\Bin;
 
 use PHP_Typography\Strings;
+use PHP_Typography\U;
 
 /**
  *  Convert LaTeX hyphenation pattern files to JSON.
@@ -95,10 +96,7 @@ class Pattern_Converter {
 					'\p{Thai}',
 
 					// Very special characters.
-					'[' . Strings::uchr(
-						8204, // ZERO WIDTH NON-JOINER.
-						8205  // ZERO WIDTH JOINER.
-					) . ']',
+					'[' . U::ZERO_WIDTH_JOINER . U::ZERO_WIDTH_NON_JOINER . ']',
 				]
 			)
 		. ')';

--- a/src/bin/class-pattern-converter.php
+++ b/src/bin/class-pattern-converter.php
@@ -27,7 +27,6 @@
 
 namespace PHP_Typography\Bin;
 
-use PHP_Typography\Strings;
 use PHP_Typography\U;
 
 /**
@@ -122,7 +121,7 @@ class Pattern_Converter {
 	 * @return string
 	 */
 	protected function get_sequence( $pattern ) {
-		$characters = Strings::mb_str_split( \str_replace( '.', '_', $pattern ) );
+		$characters = \mb_str_split( \str_replace( '.', '_', $pattern ) );
 		$result     = [];
 
 		foreach ( $characters as $index => $chr ) {

--- a/src/class-strings.php
+++ b/src/class-strings.php
@@ -130,6 +130,8 @@ abstract class Strings {
 	/**
 	 * Converts decimal value to unicode character.
 	 *
+	 * @deprecated 6.7.0
+	 *
 	 * @param int|string|array<string|int> $codes Decimal value(s) coresponding to unicode character(s).
 	 *
 	 * @return string Unicode character(s).

--- a/src/class-strings.php
+++ b/src/class-strings.php
@@ -70,10 +70,9 @@ abstract class Strings {
 	 * @var array{
 	 *     'UTF-8' : String_Functions,
 	 *     'ASCII' : String_Functions,
-	 *     0       : array{}
 	 * }
 	 */
-	const STRING_FUNCTIONS = [
+	private const STRING_FUNCTIONS = [
 		'UTF-8' => [
 			'strlen'     => 'mb_strlen',
 			'str_split'  => 'mb_str_split',
@@ -90,7 +89,6 @@ abstract class Strings {
 			'substr'     => 'substr',
 			'u'          => '',
 		],
-		false   => [],
 	];
 
 	/**
@@ -100,7 +98,13 @@ abstract class Strings {
 	 * @return String_Functions|array{}
 	 */
 	public static function functions( $str ) {
-		return self::STRING_FUNCTIONS[ \mb_detect_encoding( $str, self::ENCODINGS, true ) ]; // TODO: benchmark mb_check_encoding loop.
+		foreach ( self::ENCODINGS as $encoding ) {
+			if ( \mb_check_encoding( $str, $encoding ) ) {
+				return self::STRING_FUNCTIONS[ $encoding ];
+			}
+		}
+
+		return [];
 	}
 
 	/**

--- a/src/class-u.php
+++ b/src/class-u.php
@@ -74,5 +74,7 @@ interface U {
 	const RIGHT_CORNER_BRACKET       = "\xe3\x80\x8d";
 	const LEFT_WHITE_CORNER_BRACKET  = "\xe3\x80\x8e";
 	const RIGHT_WHITE_CORNER_BRACKET = "\xe3\x80\x8f";
+	const ZERO_WIDTH_JOINER          = "\u{200c}";
+	const ZERO_WIDTH_NON_JOINER      = "\u{200d}";
 
 }

--- a/src/fixes/node-fixes/class-style-caps-fix.php
+++ b/src/fixes/node-fixes/class-style-caps-fix.php
@@ -33,43 +33,16 @@ use PHP_Typography\U;
 /**
  * Wraps words of all caps (may include numbers) in <span class="caps"> if enabled.
  *
- * Call before style_numbers().Only call if you are certain that no html tags have been
- * injected containing capital letters.
+ * Call before style_numbers(). Only call if you are certain that no html tags have
+ * been injected containing capital letters.
  *
  * @author Peter Putzer <github@mundschenk.at>
  *
  * @since 5.0.0
  */
 class Style_Caps_Fix extends Simple_Style_Fix {
-	/*
-	// \p{Lu} equals upper case letters and should match non english characters; since PHP 4.4.0 and 5.1.0
-	// for more info, see http://www.regextester.com/pregsyntax.html#regexp.reference.unicode
-	$this->components[ Settings::STYLE_CAPS ]  = '
-	(?<![\w\-_'.U::ZERO_WIDTH_SPACE.U::SOFT_HYPHEN.'])
-	# negative lookbehind assertion
-	(
-	(?:							# CASE 1: " 9A "
-	[0-9]+					# starts with at least one number
-	\p{Lu}					# must contain at least one capital letter
-	(?:\p{Lu}|[0-9]|\-|_|'.U::ZERO_WIDTH_SPACE.'|'.U::SOFT_HYPHEN.')*
-	# may be followed by any number of numbers capital letters, hyphens, underscores, zero width spaces, or soft hyphens
-	)
-	|
-	(?:							# CASE 2: " A9 "
-	\p{Lu}					# starts with capital letter
-	(?:\p{Lu}|[0-9])		# must be followed a number or capital letter
-	(?:\p{Lu}|[0-9]|\-|_|'.U::ZERO_WIDTH_SPACE.'|'.U::SOFT_HYPHEN.')*
-	# may be followed by any number of numbers capital letters, hyphens, underscores, zero width spaces, or soft hyphens
 
-	)
-	)
-	(?![\w\-_'.U::ZERO_WIDTH_SPACE.U::SOFT_HYPHEN.'])
-	# negative lookahead assertion
-	'; // required modifiers: x (multiline pattern) u (utf8)
-	*/
-
-	// Servers with PCRE compiled without "--enable-unicode-properties" fail at \p{Lu} by returning an empty string (this leaving the screen void of text
-	// thus are testing this alternative.
+	// PCRE needs to be compiled with "--enable-unicode-properties", but we already depend on that elsehwere.
 	const REGEX = '/
 		(?<![\w' . self::COMBINING_MARKS . '])  # negative lookbehind assertion
 		(
@@ -77,16 +50,16 @@ class Style_Caps_Fix extends Simple_Style_Fix {
 				[0-9]+                          # starts with at least one number
 				(?:[' . self::COMBINING_MARKS . '])*
 						                        # may contain hyphens, underscores, zero width spaces, or soft hyphens,
-				[A-ZÀ-ÖØ-Ý]                     # but must contain at least one capital letter
-				(?:[A-ZÀ-ÖØ-Ý]|[0-9]|[' . self::COMBINING_MARKS . '])*
+				\p{Lu}                          # but must contain at least one capital letter
+				(?:\p{Lu}|[0-9]|[' . self::COMBINING_MARKS . '])*
 												# may be followed by any number of numbers capital letters, hyphens,
 												# underscores, zero width spaces, or soft hyphens
 			)
 			|
 			(?:                                 # CASE 2: " A9 "
-				[A-ZÀ-ÖØ-Ý]                     # starts with capital letter
-				(?:[A-ZÀ-ÖØ-Ý]|[0-9])           # must be followed a number or capital letter
-				(?:[A-ZÀ-ÖØ-Ý]|[0-9]|[' . self::COMBINING_MARKS . '])*
+				\p{Lu}                          # starts with capital letter
+				(?:\p{Lu}|[0-9])                # must be followed a number or capital letter
+				(?:\p{Lu}|[0-9]|[' . self::COMBINING_MARKS . '])*
 												# may be followed by any number of numbers capital letters, hyphens,
 												# underscores, zero width spaces, or soft hyphens
 			)

--- a/src/fixes/node-fixes/class-style-caps-fix.php
+++ b/src/fixes/node-fixes/class-style-caps-fix.php
@@ -71,25 +71,27 @@ class Style_Caps_Fix extends Simple_Style_Fix {
 	// Servers with PCRE compiled without "--enable-unicode-properties" fail at \p{Lu} by returning an empty string (this leaving the screen void of text
 	// thus are testing this alternative.
 	const REGEX = '/
-		(?<![\w' . self::COMBINING_MARKS . ']) # negative lookbehind assertion
+		(?<![\w' . self::COMBINING_MARKS . '])  # negative lookbehind assertion
 		(
-			(?:							# CASE 1: " 9A "
-				[0-9]+					# starts with at least one number
+			(?:                                 # CASE 1: " 9A "
+				[0-9]+                          # starts with at least one number
 				(?:[' . self::COMBINING_MARKS . '])*
-						                # may contain hyphens, underscores, zero width spaces, or soft hyphens,
-				[A-ZÀ-ÖØ-Ý]				# but must contain at least one capital letter
+						                        # may contain hyphens, underscores, zero width spaces, or soft hyphens,
+				[A-ZÀ-ÖØ-Ý]                     # but must contain at least one capital letter
 				(?:[A-ZÀ-ÖØ-Ý]|[0-9]|[' . self::COMBINING_MARKS . '])*
-										# may be followed by any number of numbers capital letters, hyphens, underscores, zero width spaces, or soft hyphens
+												# may be followed by any number of numbers capital letters, hyphens,
+												# underscores, zero width spaces, or soft hyphens
 			)
 			|
-			(?:							# CASE 2: " A9 "
-				[A-ZÀ-ÖØ-Ý]				# starts with capital letter
-				(?:[A-ZÀ-ÖØ-Ý]|[0-9])	# must be followed a number or capital letter
+			(?:                                 # CASE 2: " A9 "
+				[A-ZÀ-ÖØ-Ý]                     # starts with capital letter
+				(?:[A-ZÀ-ÖØ-Ý]|[0-9])           # must be followed a number or capital letter
 				(?:[A-ZÀ-ÖØ-Ý]|[0-9]|[' . self::COMBINING_MARKS . '])*
-										# may be followed by any number of numbers capital letters, hyphens, underscores, zero width spaces, or soft hyphens
+												# may be followed by any number of numbers capital letters, hyphens,
+												# underscores, zero width spaces, or soft hyphens
 			)
 		)
-		(?![\w' . self::COMBINING_MARKS . ']) # negative lookahead assertion
+		(?![\w' . self::COMBINING_MARKS . '])   # negative lookahead assertion
 	/Sxu';
 
 	const COMBINING_MARKS = '\-_' . U::HYPHEN . U::SOFT_HYPHEN . U::ZERO_WIDTH_SPACE; // Needs to be part of character class.

--- a/src/fixes/node-fixes/class-style-caps-fix.php
+++ b/src/fixes/node-fixes/class-style-caps-fix.php
@@ -67,7 +67,7 @@ class Style_Caps_Fix extends Simple_Style_Fix {
 		(?![\w' . self::COMBINING_MARKS . '])   # negative lookahead assertion
 	/Sxu';
 
-	const COMBINING_MARKS = '\-_' . U::HYPHEN . U::SOFT_HYPHEN . U::ZERO_WIDTH_SPACE; // Needs to be part of character class.
+	private const COMBINING_MARKS = '\-_' . U::HYPHEN . U::SOFT_HYPHEN . U::ZERO_WIDTH_SPACE; // Needs to be part of character class.
 
 	/**
 	 * Creates a new node fix with a class.

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests;
 
 use PHP_Typography\Settings;
-use PHP_Typography\Strings;
 use PHP_Typography\U;
 
 use PHP_Typography\Settings\Dashes;
@@ -44,7 +43,6 @@ use Mockery as m;
  * @uses PHP_Typography\Settings\Simple_Quotes
  * @uses PHP_Typography\Settings\Dash_Style::get_styled_dashes
  * @uses PHP_Typography\Settings\Quote_Style::get_styled_quotes
- * @uses PHP_Typography\Strings::uchr
  * @uses PHP_Typography\DOM::inappropriate_tags
  */
 class Settings_Test extends Testcase {

--- a/tests/class-strings-test.php
+++ b/tests/class-strings-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2022 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -72,6 +72,18 @@ class Strings_Test extends Testcase {
 		// Each function is a callable (except for the 'u' modifier string).
 		$this->assert_string_functions( $func_ascii );
 		$this->assert_string_functions( $func_utf8 );
+	}
+
+	/**
+	 * Test ::functions.
+	 *
+	 * @covers ::functions
+	 */
+	public function test_functions_invalid_encoding() {
+		$func = Strings::functions( \mb_convert_encoding( 'Ungültiges Encoding', 'ISO-8859-2' ) );
+
+		$this->assertTrue( \is_array( $func ) );
+		$this->assertCount( 0, $func );
 	}
 
 	/**

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -25,6 +25,7 @@
 namespace PHP_Typography\Tests;
 
 use PHP_Typography\Strings;
+use PHP_Typography\U;
 use PHP_Typography\Text_Parser\Token;
 
 /**
@@ -167,78 +168,78 @@ abstract class Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 	protected function assert_smart_quotes_style( $style, $open, $close ) {
 		switch ( $style ) {
 			case 'doubleCurled':
-				$this->assertSame( Strings::uchr( 8220 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8221 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::DOUBLE_QUOTE_OPEN, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::DOUBLE_QUOTE_CLOSE, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'doubleCurledReversed':
-				$this->assertSame( Strings::uchr( 8221 ), $open,  "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8221 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::DOUBLE_QUOTE_CLOSE, $open,  "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::DOUBLE_QUOTE_CLOSE, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'doubleLow9':
-				$this->assertSame( Strings::uchr( 8222 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8221 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::DOUBLE_LOW_9_QUOTE, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::DOUBLE_QUOTE_CLOSE, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'doubleLow9Reversed':
-				$this->assertSame( Strings::uchr( 8222 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8220 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::DOUBLE_LOW_9_QUOTE, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::DOUBLE_QUOTE_OPEN, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'singleCurled':
-				$this->assertSame( Strings::uchr( 8216 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8217 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::SINGLE_QUOTE_OPEN, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::SINGLE_QUOTE_CLOSE, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'singleCurledReversed':
-				$this->assertSame( Strings::uchr( 8217 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8217 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::SINGLE_QUOTE_CLOSE, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::SINGLE_QUOTE_CLOSE, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'singleLow9':
-				$this->assertSame( Strings::uchr( 8218 ), $open,  "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8217 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::SINGLE_LOW_9_QUOTE, $open,  "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::SINGLE_QUOTE_CLOSE, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'singleLow9Reversed':
-				$this->assertSame( Strings::uchr( 8218 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8216 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::SINGLE_LOW_9_QUOTE, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::SINGLE_QUOTE_OPEN, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'doubleGuillemetsFrench':
-				$this->assertSame( Strings::uchr( 171, 8239 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8239, 187 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::GUILLEMET_OPEN . U::NO_BREAK_NARROW_SPACE, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::NO_BREAK_NARROW_SPACE . U::GUILLEMET_CLOSE, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'doubleGuillemets':
-				$this->assertSame( Strings::uchr( 171 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 187 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::GUILLEMET_OPEN, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::GUILLEMET_CLOSE, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'doubleGuillemetsReversed':
-				$this->assertSame( Strings::uchr( 187 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 171 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::GUILLEMET_CLOSE, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::GUILLEMET_OPEN, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'singleGuillemets':
-				$this->assertSame( Strings::uchr( 8249 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8250 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::SINGLE_ANGLE_QUOTE_OPEN, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::SINGLE_ANGLE_QUOTE_CLOSE, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'singleGuillemetsReversed':
-				$this->assertSame( Strings::uchr( 8250 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 8249 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::SINGLE_ANGLE_QUOTE_CLOSE, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::SINGLE_ANGLE_QUOTE_OPEN, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'cornerBrackets':
-				$this->assertSame( Strings::uchr( 12300 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 12301 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::LEFT_CORNER_BRACKET, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::RIGHT_CORNER_BRACKET, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			case 'whiteCornerBracket':
-				$this->assertSame( Strings::uchr( 12302 ), $open, "Opening quote $open did not match quote style $style." );
-				$this->assertSame( Strings::uchr( 12303 ), $close, "Closeing quote $close did not match quote style $style." );
+				$this->assertSame( U::LEFT_WHITE_CORNER_BRACKET, $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( U::RIGHT_WHITE_CORNER_BRACKET, $close, "Closeing quote $close did not match quote style $style." );
 				break;
 
 			default:


### PR DESCRIPTION
- Deprecates `Strings::uchr`.
- Properly detects ASCII strings (we were really always using UTF-8 before!).
- Use the native PCRE unicode character class `\p{Lu}` to detect upper-case letters.