### PR TITLE
Update GItHub actions and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
                       experimental: true
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   # Disabling shallow clone is recommended for improving relevancy of reporting
                   fetch-depth: 0
@@ -40,7 +40,7 @@ jobs:
               id: composer-cache
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                 path: ${{ steps.composer-cache.outputs.dir }}
                 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -59,7 +59,7 @@ jobs:
                 php-versions: ['8.2']
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   # Disabling shallow clone is recommended for improving relevancy of reporting
                   fetch-depth: 0
@@ -75,7 +75,7 @@ jobs:
               id: composer-cache
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                 path: ${{ steps.composer-cache.outputs.dir }}
                 key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -107,7 +107,7 @@ jobs:
                 php-versions: ['8.2']
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP, with Composer and extensions
               uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
@@ -125,7 +125,7 @@ jobs:
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -146,7 +146,7 @@ jobs:
                 php-versions: ['8.2']
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
             - name: Setup PHP, with Composer and extensions
               uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
               with:
@@ -160,7 +160,7 @@ jobs:
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-versions: ['7.4', '8.0', '8.1', '8.2']
+                php-versions: ['7.4', '8.0', '8.1', '8.2','8.3']
                 experimental: [false]
                 include:
-                    - php-versions: '8.3'
+                    - php-versions: '8.4'
                       experimental: true
         steps:
             - name: Checkout repository
@@ -56,7 +56,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['8.2']
+                php-versions: ['8.3']
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['8.2']
+                php-versions: ['8.3']
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
@@ -143,7 +143,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php-versions: ['8.2']
+                php-versions: ['8.3']
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4


### PR DESCRIPTION
- Updates `actions/checkout` and `actions/cache` to `v4`.
- Does not mark PHP 8.3 as "experimental" anymore.