### PR TITLE
Handle specific elements when looking for adjacent characters

### DIFF
--- a/tests/class-dom-test.php
+++ b/tests/class-dom-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -298,13 +298,15 @@ class DOM_Test extends Testcase {
 	 * Test get_prev_chr.
 	 *
 	 * @covers ::get_prev_chr
-	 * @covers ::get_adjacent_chr
-	 * @covers ::get_previous_textnode
-	 * @covers ::get_adjacent_textnode
+	 * @covers ::get_adjacent_character
+	 * @covers ::get_previous_acceptable_node
+	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
+	 * @covers ::is_linebreak
+	 * @covers ::is_text_or_linebreak
 	 *
-	 * @uses ::get_last_textnode
-	 * @uses ::get_edge_textnode
+	 * @uses ::get_last_acceptable_node
+	 * @uses ::get_edge_node
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_get_prev_chr() {
@@ -322,11 +324,42 @@ class DOM_Test extends Testcase {
 	}
 
 	/**
+	 * Test get_prev_chr when the textnode is preceeded by <br>.
+	 *
+	 * @covers ::get_prev_chr
+	 * @covers ::get_adjacent_character
+	 * @covers ::get_previous_acceptable_node
+	 * @covers ::get_adjacent_node
+	 * @covers ::is_linebreak
+	 * @covers ::is_text_or_linebreak
+	 *
+	 * @uses ::is_block_tag
+	 * @uses ::get_last_acceptable_node
+	 * @uses ::get_edge_node
+	 * @uses PHP_Typography\Strings::functions
+	 */
+	public function test_get_prev_chr_with_br() {
+		$html  = '<p><span>A</span><br><span id="foo">new hope.</span></p><p><br><span id="bar">The empire</span> strikes back.</p<';
+		$doc   = $this->load_html( $html );
+		$xpath = new \DOMXPath( $doc );
+
+		$textnodes = $xpath->query( "//*[@id='foo']/text()" ); // really only one.
+		$prev_char = DOM::get_prev_chr( $textnodes->item( 0 ) );
+		$this->assertSame( ' ', $prev_char );
+
+		$textnodes = $xpath->query( "//*[@id='bar']/text()" ); // really only one.
+		$prev_char = DOM::get_prev_chr( $textnodes->item( 0 ) );
+		$this->assertSame( ' ', $prev_char );
+	}
+
+	/**
 	 * Test get_previous_textnode.
 	 *
 	 * @covers ::get_previous_textnode
-	 * @covers ::get_adjacent_textnode
+	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
+	 *
+	 * @uses ::get_previous_acceptable_node
 	 */
 	public function test_get_previous_textnode_null() {
 		$node = DOM::get_previous_textnode( null );
@@ -337,13 +370,15 @@ class DOM_Test extends Testcase {
 	 * Test get_next_chr.
 	 *
 	 * @covers ::get_next_chr
-	 * @covers ::get_adjacent_chr
-	 * @covers ::get_next_textnode
-	 * @covers ::get_adjacent_textnode
+	 * @covers ::get_adjacent_character
+	 * @covers ::get_next_acceptable_node
+	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
+	 * @covers ::is_linebreak
+	 * @covers ::is_text_or_linebreak
 	 *
-	 * @uses ::get_first_textnode
-	 * @uses ::get_edge_textnode
+	 * @uses ::get_first_acceptable_node
+	 * @uses ::get_edge_node
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_get_next_chr() {
@@ -361,11 +396,43 @@ class DOM_Test extends Testcase {
 	}
 
 	/**
+	 * Test get_next_chr followed by <br>.
+	 *
+	 * @covers ::get_next_chr
+	 * @covers ::get_adjacent_character
+	 * @covers ::get_next_acceptable_node
+	 * @covers ::get_adjacent_node
+	 * @covers ::is_block_tag
+	 * @covers ::is_linebreak
+	 * @covers ::is_text_or_linebreak
+	 *
+	 * @uses ::get_first_acceptable_node
+	 * @uses ::get_edge_node
+	 * @uses PHP_Typography\Strings::functions
+	 */
+	public function test_get_next_chr_with_br() {
+		$html  = '<p><span id="foo">A</span><span id="bar"><br>new hope.</span><br></p><p><span>The empire</span> strikes back.</p<';
+		$doc   = $this->load_html( $html );
+		$xpath = new \DOMXPath( $doc );
+
+		$textnodes = $xpath->query( "//*[@id='foo']/text()" ); // really only one.
+		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$this->assertSame( ' ', $prev_char );
+
+		$textnodes = $xpath->query( "//*[@id='bar']/text()" ); // really only one.
+		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$this->assertSame( ' ', $prev_char );
+	}
+
+	/**
 	 * Test get_next_textnode.
 	 *
 	 * @covers ::get_next_textnode
-	 * @covers ::get_adjacent_textnode
+	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
+	 * @covers ::is_textnode
+	 *
+	 * @uses ::get_next_acceptable_node
 	 */
 	public function test_get_next_textnode_null() {
 		$node = DOM::get_next_textnode( null );
@@ -377,8 +444,11 @@ class DOM_Test extends Testcase {
 	 * Test get_first_textnode.
 	 *
 	 * @covers ::get_first_textnode
-	 * @covers ::get_edge_textnode
+	 * @covers ::get_edge_node
 	 * @covers ::is_block_tag
+	 * @covers ::is_textnode
+	 *
+	 * @uses ::get_first_acceptable_node
 	 */
 	public function test_get_first_textnode() {
 		$html  = '<p><span id="foo">A</span><span id="bar">new hope.</span></p>';
@@ -406,7 +476,9 @@ class DOM_Test extends Testcase {
 	 * Test get_first_textnode.
 	 *
 	 * @covers ::get_first_textnode
-	 * @covers ::get_edge_textnode
+	 * @covers ::get_edge_node
+	 * @covers ::is_textnode
+	 * @covers ::get_first_acceptable_node
 	 */
 	public function test_get_first_textnode_null() {
 		// Passing null returns null.
@@ -420,8 +492,10 @@ class DOM_Test extends Testcase {
 	 * Test get_first_textnode.
 	 *
 	 * @covers ::get_first_textnode
-	 * @covers ::get_edge_textnode
+	 * @covers ::get_edge_node
 	 * @covers ::is_block_tag
+	 * @covers ::is_textnode
+	 * @covers ::get_first_acceptable_node
 	 */
 	public function test_get_first_textnode_only_block_level() {
 		$html  = '<div><div id="foo">No</div><div id="bar">hope</div></div>';
@@ -437,10 +511,11 @@ class DOM_Test extends Testcase {
 	 * Test get_last_textnode.
 	 *
 	 * @covers ::get_last_textnode
-	 * @covers ::get_edge_textnode
+	 * @covers ::get_edge_node
 	 * @covers ::is_block_tag
+	 * @covers ::is_textnode
 	 *
-	 * @uses ::get_first_textnode
+	 * @uses ::get_last_acceptable_node
 	 */
 	public function test_get_last_textnode() {
 
@@ -457,7 +532,7 @@ class DOM_Test extends Testcase {
 		$this->assertSame( 'A', $node->nodeValue );
 
 		$textnodes = $xpath->query( "//*[@id='bar']" ); // really only one.
-		$node      = DOM::get_first_textnode( $textnodes->item( 0 ) );
+		$node      = DOM::get_last_textnode( $textnodes->item( 0 ) );
 		$this->assertSame( 'new hope.', $node->nodeValue );
 
 		$textnodes = $xpath->query( '//p' ); // really only one.
@@ -469,7 +544,9 @@ class DOM_Test extends Testcase {
 	 * Test get_last_textnode.
 	 *
 	 * @covers ::get_last_textnode
-	 * @covers ::get_edge_textnode
+	 * @covers ::get_edge_node
+	 * @covers ::is_textnode
+	 * @covers ::get_last_acceptable_node
 	 */
 	public function test_get_last_textnode_null() {
 		// Passing null returns null.
@@ -484,8 +561,10 @@ class DOM_Test extends Testcase {
 	 * Test get_last_textnode.
 	 *
 	 * @covers ::get_last_textnode
-	 * @covers ::get_edge_textnode
+	 * @covers ::get_edge_node
 	 * @covers ::is_block_tag
+	 * @covers ::is_textnode
+	 * @covers ::get_last_acceptable_node
 	 */
 	public function test_get_last_textnode_only_block_level() {
 		$html  = '<div><div id="foo">No</div><div id="bar">hope</div></div>';

--- a/tests/class-dom-test.php
+++ b/tests/class-dom-test.php
@@ -302,8 +302,7 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_previous_acceptable_node
 	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_linebreak
-	 * @covers ::is_text_or_linebreak
+	 * @covers ::is_acceptable_neighbor_node
 	 *
 	 * @uses ::get_last_acceptable_node
 	 * @uses ::get_edge_node
@@ -330,8 +329,7 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_adjacent_character
 	 * @covers ::get_previous_acceptable_node
 	 * @covers ::get_adjacent_node
-	 * @covers ::is_linebreak
-	 * @covers ::is_text_or_linebreak
+	 * @covers ::is_acceptable_neighbor_node
 	 *
 	 * @uses ::is_block_tag
 	 * @uses ::get_last_acceptable_node
@@ -374,8 +372,7 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_next_acceptable_node
 	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_linebreak
-	 * @covers ::is_text_or_linebreak
+	 * @covers ::is_acceptable_neighbor_node
 	 *
 	 * @uses ::get_first_acceptable_node
 	 * @uses ::get_edge_node
@@ -403,8 +400,7 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_next_acceptable_node
 	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_linebreak
-	 * @covers ::is_text_or_linebreak
+	 * @covers ::is_acceptable_neighbor_node
 	 *
 	 * @uses ::get_first_acceptable_node
 	 * @uses ::get_edge_node
@@ -422,6 +418,34 @@ class DOM_Test extends Testcase {
 		$textnodes = $xpath->query( "//*[@id='bar']/text()" ); // really only one.
 		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
 		$this->assertSame( ' ', $prev_char );
+	}
+
+	/**
+	 * Test get_next_chr followed by <br>.
+	 *
+	 * @covers ::get_next_chr
+	 * @covers ::get_adjacent_character
+	 * @covers ::get_next_acceptable_node
+	 * @covers ::get_adjacent_node
+	 * @covers ::is_block_tag
+	 * @covers ::is_acceptable_neighbor_node
+	 *
+	 * @uses ::get_first_acceptable_node
+	 * @uses ::get_edge_node
+	 * @uses PHP_Typography\Strings::functions
+	 */
+	public function test_get_next_chr_with_sub_sup() {
+		$html  = '<p><span id="foo">A</span><span id="bar"><sup>new</sup> hope.</span><sub>x</sub></p><p><span>The empire</span> strikes back.</p<';
+		$doc   = $this->load_html( $html );
+		$xpath = new \DOMXPath( $doc );
+
+		$textnodes = $xpath->query( "//*[@id='foo']/text()" ); // really only one.
+		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$this->assertSame( '', $prev_char );
+
+		$textnodes = $xpath->query( "//*[@id='bar']/text()" ); // really only one.
+		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$this->assertSame( '', $prev_char );
 	}
 
 	/**

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -505,6 +505,7 @@ class PHP_Typography_Test extends Testcase {
 			[ 'Fugen-s', 'Fugen&#8209;s', true ],
 			[ 'ein-, zweimal', 'ein&#8209;, zweimal', true ],
 			[ 'В зависимости от региона, может выращиватся на зерно и силос. После колосовых может выращиватся на второй посев.', 'В зависимости от региона, может выращиватся на зерно и&nbsp;силос. После колосовых может выращиватся на второй посев.', false ],
+			[ '"Text."<br>Text after.', '<span class="pull-double">&ldquo;</span>Text.&rdquo;<br>Text after.', '&ldquo;Text.&rdquo;<br>Text after.' ],
 		];
 	}
 

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -506,6 +506,7 @@ class PHP_Typography_Test extends Testcase {
 			[ 'ein-, zweimal', 'ein&#8209;, zweimal', true ],
 			[ 'В зависимости от региона, может выращиватся на зерно и силос. После колосовых может выращиватся на второй посев.', 'В зависимости от региона, может выращиватся на зерно и&nbsp;силос. После колосовых может выращиватся на второй посев.', false ],
 			[ '"Text."<br>Text after.', '<span class="pull-double">&ldquo;</span>Text.&rdquo;<br>Text after.', '&ldquo;Text.&rdquo;<br>Text after.' ],
+			[ 'à "l’âge"<sup>N112</sup>', '&agrave; <span class="push-double"></span>&#8203;<span class="pull-double">&ldquo;</span>l&rsquo;&acirc;ge&rdquo;<sup><span class="caps">N<span class="numbers">112</span></span></sup>', '&agrave; &ldquo;l&rsquo;&acirc;ge&rdquo;<sup>N112</sup>' ],
 		];
 	}
 

--- a/tests/fixes/node-fixes/class-node-fix-testcase.php
+++ b/tests/fixes/node-fixes/class-node-fix-testcase.php
@@ -71,12 +71,12 @@ abstract class Node_Fix_Testcase extends Testcase {
 	/**
 	 * Assert that the output of the fix is the same as the expected result.
 	 *
-	 * @param string      $input         Text node value.
-	 * @param string      $result        Expected result.
-	 * @param string|null $left_sibling  Optional. Left sibling node value. Default null.
-	 * @param string|null $right_sibling Optional. Right sibling node value. Default null.
-	 * @param string      $parent_tag    Optional. Parent tag. Default 'p'.
-	 * @param bool        $is_title      Optional. Default false.
+	 * @param string                  $input         Text node value.
+	 * @param string                  $result        Expected result.
+	 * @param string|\DOMNode|null $left_sibling  Optional. Left sibling node value. Default null.
+	 * @param string|\DOMNode|null $right_sibling Optional. Right sibling node value. Default null.
+	 * @param string                  $parent_tag    Optional. Parent tag. Default 'p'.
+	 * @param bool                    $is_title      Optional. Default false.
 	 */
 	protected function assertFixResultSame( $input, $result, $left_sibling = null, $right_sibling = null, $parent_tag = 'p', $is_title = false ) {
 		$node = $this->create_textnode( $input );
@@ -87,13 +87,21 @@ abstract class Node_Fix_Testcase extends Testcase {
 			$dom->appendChild( $parent );
 
 			if ( ! empty( $left_sibling ) ) {
-				$parent->appendChild( $this->create_textnode( $left_sibling ) );
+				if ( ! $left_sibling instanceof \DOMNode ) {
+					$left_sibling = $this->create_textnode( $left_sibling );
+				}
+
+				$parent->appendChild( $left_sibling );
 			}
 
 			$parent->appendChild( $node );
 
 			if ( ! empty( $right_sibling ) ) {
-				$parent->appendChild( $this->create_textnode( $right_sibling ) );
+				if ( ! $right_sibling instanceof \DOMNode ) {
+					$right_sibling = $this->create_textnode( $right_sibling );
+				}
+
+				$parent->appendChild( $right_sibling );
 			}
 		}
 

--- a/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
@@ -119,10 +119,12 @@ class Smart_Quotes_Fix_Test extends Node_Fix_Testcase {
 				'"',
 			],
 			[
-				'à "l’âge"<br>N112',
-				'&agrave; &laquo;&#8239;l&rsquo;&acirc;ge&#8239;&raquo;<br>N112',
+				'à "l’âge"',
+				'&agrave; &laquo;&#8239;l&rsquo;&acirc;ge&#8239;&raquo;',
 				Quote_Style::DOUBLE_GUILLEMETS_FRENCH,
 				Quote_Style::SINGLE_GUILLEMETS,
+				null,
+				new \DOMElement( 'br' ),
 			],
 			[
 				'à "l’âge" N112',
@@ -131,10 +133,12 @@ class Smart_Quotes_Fix_Test extends Node_Fix_Testcase {
 				Quote_Style::SINGLE_GUILLEMETS,
 			],
 			[
-				'à "l’âge"<sup>N112</sup>',
-				'&agrave; &laquo;&#8239;l&rsquo;&acirc;ge&#8239;&raquo;<sup>N112</sup>',
+				'à "l’âge"',
+				'&agrave; &laquo;&#8239;l&rsquo;&acirc;ge&#8239;&raquo;',
 				Quote_Style::DOUBLE_GUILLEMETS_FRENCH,
 				Quote_Style::SINGLE_GUILLEMETS,
+				null,
+				new \DOMElement( 'sup', 'N112' ),
 			],
 		];
 	}

--- a/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -117,6 +117,24 @@ class Smart_Quotes_Fix_Test extends Node_Fix_Testcase {
 				Quote_Style::SINGLE_CURLED,
 				'"',
 				'"',
+			],
+			[
+				'à "l’âge"<br>N112',
+				'&agrave; &laquo;&#8239;l&rsquo;&acirc;ge&#8239;&raquo;<br>N112',
+				Quote_Style::DOUBLE_GUILLEMETS_FRENCH,
+				Quote_Style::SINGLE_GUILLEMETS,
+			],
+			[
+				'à "l’âge" N112',
+				'&agrave; &laquo;&#8239;l&rsquo;&acirc;ge&#8239;&raquo; N112',
+				Quote_Style::DOUBLE_GUILLEMETS_FRENCH,
+				Quote_Style::SINGLE_GUILLEMETS,
+			],
+			[
+				'à "l’âge"<sup>N112</sup>',
+				'&agrave; &laquo;&#8239;l&rsquo;&acirc;ge&#8239;&raquo;<sup>N112</sup>',
+				Quote_Style::DOUBLE_GUILLEMETS_FRENCH,
+				Quote_Style::SINGLE_GUILLEMETS,
 			],
 		];
 	}


### PR DESCRIPTION
- Fixes #142. 
- Fixes #134.
- Renames `DOM::get_adjacent_chr` to `DOM::get_adjacent_character`.
- Refactors the various `DOM::get_*_textnode` methods to allow for different acceptable nodes.
- Also adds some tests.