### PR TITLE
Refactor `DOM` API

### DIFF
--- a/src/class-dom.php
+++ b/src/class-dom.php
@@ -243,7 +243,7 @@ abstract class DOM {
 	 * @return string A single character (or the empty string).
 	 */
 	public static function get_previous_character( DOMNode $node ): string {
-		return self::get_adjacent_character( $node, -1, 1, [ __CLASS__, 'get_previous_acceptable_node' ] );
+		return self::get_adjacent_character( $node, -1, [ __CLASS__, 'get_previous_acceptable_node' ] );
 	}
 
 	/**
@@ -256,23 +256,23 @@ abstract class DOM {
 	 * @return string A single character (or the empty string).
 	 */
 	public static function get_next_character( DOMNode $node ): string {
-		return self::get_adjacent_character( $node, 0, 1, [ __CLASS__, 'get_next_acceptable_node' ] );
+		return self::get_adjacent_character( $node, 0, [ __CLASS__, 'get_next_acceptable_node' ] );
 	}
 
 	/**
 	 * Retrieves a character from the given DOMNode.
 	 *
 	 * @since 5.0.0
-	 * @since 7.0.0 Renamed to `get_adjacent_character`. Parameter `$get_textnode` renamed to `$get_node`
+	 * @since 7.0.0 Renamed to `get_adjacent_character`. Parameter `$get_textnode` renamed to `$get_node` and
+	 *              obsolete parameter `$length` removed.
 	 *
 	 * @param  DOMNode  $node     The starting node.
 	 * @param  int      $position The position parameter for `substr`.
-	 * @param  int      $length   The length parameter for `substr`.
 	 * @param  callable $get_node A function to retrieve the adjacent node from the starting node.
 	 *
 	 * @return string The character or an empty string.
 	 */
-	private static function get_adjacent_character( DOMNode $node, int $position, int $length, callable $get_node ): string {
+	private static function get_adjacent_character( DOMNode $node, int $position, callable $get_node ): string {
 		$character     = '';
 		$adjacent_node = $get_node(
 			// Determines if the node is a textnode or one of the acceptable elements.
@@ -295,7 +295,7 @@ abstract class DOM {
 				}
 			} elseif ( $adjacent_node instanceof DOMText ) {
 				$node_data = $adjacent_node->data;
-				$character = \preg_replace( '/\p{C}/Su', '', Strings::functions( $node_data )['substr']( $node_data, $position, $length ) );
+				$character = \preg_replace( '/\p{C}/Su', '', Strings::functions( $node_data )['substr']( $node_data, $position, 1 ) );
 			}
 		}
 

--- a/src/class-dom.php
+++ b/src/class-dom.php
@@ -33,6 +33,8 @@ use Masterminds\HTML5\Elements;
  * Some static methods for DOM manipulation.
  *
  * @since 4.2.0
+ * @since 7.0.0 The obsolete and/or unused methods `get_block_parent_name`, `get_previous_textnode`,
+ *              `get_next_textnode`, and `get_last_textnode` have been removed.
  */
 abstract class DOM {
 
@@ -246,8 +248,14 @@ abstract class DOM {
 	 * @return string The character or an empty string.
 	 */
 	private static function get_adjacent_character( \DOMNode $node, $position, $length, callable $get_node ) {
-		$adjacent_node = $get_node( [ __CLASS__, 'is_acceptable_neighbor_node' ], $node );
 		$character     = '';
+		$adjacent_node = $get_node(
+			// Determines if the node is a textnode or one of the acceptable elements.
+			function ( ?\DOMNode $n ): bool {
+				return $n instanceof \DOMText || ( $n instanceof \DOMElement && isset( self::ACCEPTABLE_NEIGHBOR_ELEMENTS[ $n->tagName ] ) );
+			},
+			$node
+		);
 
 		if ( null !== $adjacent_node ) {
 			if ( $adjacent_node instanceof \DOMElement ) {
@@ -270,60 +278,7 @@ abstract class DOM {
 	}
 
 	/**
-	 * Determines if the node is a textnode.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param ?\DOMNode $node The node to test.
-	 *
-	 * @return bool
-	 */
-	private static function is_textnode( ?\DOMNode $node ): bool {
-		return $node instanceof \DOMText;
-	}
-
-	/**
-	 * Determines if the node is a textnode or one of the acceptable elements.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param ?\DOMNode $node The node to test.
-	 *
-	 * @return bool
-	 */
-	private static function is_acceptable_neighbor_node( ?\DOMNode $node ): bool {
-		return $node instanceof \DOMText || ( $node instanceof \DOMElement && isset( self::ACCEPTABLE_NEIGHBOR_ELEMENTS[ $node->tagName ] ) );
-	}
-
-
-	/**
-	 * Retrieves the previous \DOMText sibling (if there is one).
-	 *
-	 * @param \DOMNode|null $node Optional. The content node. Default null.
-	 *
-	 * @return \DOMText|null Null if $node is a block-level element or no text sibling exists.
-	 */
-	public static function get_previous_textnode( ?\DOMNode $node ): ?\DOMText {
-		$result = self::get_previous_acceptable_node( [ __CLASS__, 'is_textnode' ], $node );
-
-		return $result instanceof \DOMText ? $result : null;
-	}
-
-	/**
-	 * Retrieves the next \DOMText sibling (if there is one).
-	 *
-	 * @param \DOMNode|null $node Optional. The content node. Default null.
-	 *
-	 * @return \DOMText|null Null if $node is a block-level element or no text sibling exists.
-	 */
-	public static function get_next_textnode( ?\DOMNode $node ): ?\DOMText {
-		$result = self::get_next_acceptable_node( [ __CLASS__, 'is_textnode' ], $node );
-
-		return $result instanceof \DOMText ? $result : null;
-	}
-
-	/**
-	 * Retrieves the previous \DOMText sibling (if there is one).
+	 * Retrieves the previous acceptable sibling (if there is one).
 	 *
 	 * @param callable      $is_acceptable Returns true if the \DOMnode is acceptable.
 	 * @param \DOMNode|null $node          Optional. The content node. Default null.
@@ -343,7 +298,7 @@ abstract class DOM {
 	}
 
 	/**
-	 * Retrieves the next \DOMText sibling (if there is one).
+	 * Retrieves the next accceptable sibling (if there is one).
 	 *
 	 * @param callable      $is_acceptable Returns true if the \DOMnode is acceptable.
 	 * @param \DOMNode|null $node          Optional. The content node. Default null.
@@ -363,7 +318,7 @@ abstract class DOM {
 	}
 
 	/**
-	 * Retrieves an adjacent \DOMText sibling if there is one.
+	 * Retrieves an adjacent acceptable sibling if there is one.
 	 *
 	 * @since 5.0.0
 	 * @since 7.0.0 Renamed to `get_adjacent_node` and refactored to take a callable to determine acceptable nodes.
@@ -416,23 +371,18 @@ abstract class DOM {
 	 * @return \DOMText|null The first child of type \DOMText, the element itself if it is of type \DOMText or null.
 	 */
 	public static function get_first_textnode( \DOMNode $node = null, $recursive = false ) {
-		$result = self::get_first_acceptable_node( [ __CLASS__, 'is_textnode' ], $node, $recursive );
-
-		return $result instanceof \DOMText ? $result : null;
-	}
-
-	/**
-	 * Retrieves the last \DOMText child of the element. Block-level child elements are ignored.
-	 *
-	 * @param \DOMNode|null $node      Optional. Default null.
-	 * @param bool          $recursive Should be set to true on recursive calls. Optional. Default false.
-	 *
-	 * @return \DOMText|null The last child of type \DOMText, the element itself if it is of type \DOMText or null.
-	 */
-	public static function get_last_textnode( \DOMNode $node = null, $recursive = false ) {
-		$result = self::get_last_acceptable_node( [ __CLASS__, 'is_textnode' ], $node, $recursive );
-
-		return $result instanceof \DOMText ? $result : null;
+		/**
+		 * We only allow textnodes in our `is_acceptable` callable.
+		 *
+		 * @phpstan-var ?\DOMText
+		 */
+		return self::get_first_acceptable_node(
+			function ( ?\DOMNode $node ): bool {
+				return $node instanceof \DOMText;
+			},
+			$node,
+			$recursive
+		);
 	}
 
 	/**
@@ -479,7 +429,7 @@ abstract class DOM {
 	private static function get_edge_node( callable $is_acceptable, callable $get_acceptable_node, \DOMNode $node = null, $recursive = false, $reverse = false ): ?\DOMNode {
 		if ( $is_acceptable( $node ) ) {
 			return $node;
-		} elseif ( ! $node instanceof \DOMElement || $recursive && self::is_block_tag( $node ) ) {
+		} elseif ( ! $node instanceof \DOMElement || ( $recursive && self::is_block_tag( $node ) ) ) {
 			// Return null if $node is neither an acceptable node nor \DOMElement or
 			// when we are recursing and already at the block level.
 			return null;
@@ -530,23 +480,6 @@ abstract class DOM {
 		}
 
 		return $parent;
-	}
-
-	/**
-	 * Retrieves the tag name of the nearest block-level parent.
-	 *
-	 * @param \DOMNode $node A node.
-
-	 * @return string The tag name (or the empty string).
-	 */
-	public static function get_block_parent_name( \DOMNode $node ) {
-		$parent = self::get_block_parent( $node );
-
-		if ( ! empty( $parent ) ) {
-			return $parent->tagName;
-		} else {
-			return '';
-		}
 	}
 
 	/**

--- a/src/class-dom.php
+++ b/src/class-dom.php
@@ -48,14 +48,14 @@ abstract class DOM {
 	 *
 	 * @var array<string,int>
 	 */
-	private static $block_tags;
+	private static array $block_tags;
 
 	/**
 	 * A flipped array of tags that should never be modified. Checked via isset/has_key.
 	 *
 	 * @var array<string,int>
 	 */
-	private static $inappropriate_tags;
+	private static array $inappropriate_tags;
 
 	const ADDITIONAL_INAPPROPRIATE_TAGS = [
 		'button',
@@ -92,7 +92,7 @@ abstract class DOM {
 	 *         @type int $tag Only the existence of the $tag key is relevant.
 	 * }
 	 */
-	public static function block_tags( $reset = false ) {
+	public static function block_tags( bool $reset = false ): array {
 		if ( empty( self::$block_tags ) || $reset ) {
 			self::$block_tags = \array_merge(
 				\array_flip(
@@ -121,7 +121,7 @@ abstract class DOM {
 	 *         @type int $tag Only the existence of the $tag key is relevant.
 	 * }
 	 */
-	public static function inappropriate_tags( $reset = false ) {
+	public static function inappropriate_tags( bool $reset = false ): array {
 		if ( empty( self::$inappropriate_tags ) || $reset ) {
 			self::$inappropriate_tags = \array_flip(
 				\array_merge(
@@ -152,7 +152,7 @@ abstract class DOM {
 	 *
 	 * @phpstan-param DOMNodeList<DOMNode> $node_list
 	 */
-	public static function nodelist_to_array( DOMNodeList $node_list ) {
+	public static function nodelist_to_array( DOMNodeList $node_list ): array {
 		$out = [];
 
 		foreach ( $node_list as $node ) {
@@ -170,7 +170,7 @@ abstract class DOM {
 	 *
 	 * @return DOMNode[] An array of DOMNode.
 	 */
-	public static function get_ancestors( DOMNode $node ) {
+	public static function get_ancestors( DOMNode $node ): array {
 		$result = [];
 
 		while ( ( $node = $node->parentNode ) && ( $node instanceof DOMElement ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
@@ -189,7 +189,7 @@ abstract class DOM {
 	 *
 	 * @return bool True if the element has any of the given class(es).
 	 */
-	public static function has_class( DOMNode $tag, $classnames ) {
+	public static function has_class( DOMNode $tag, $classnames ): bool {
 		if ( $tag instanceof DOMText ) {
 			$tag = $tag->parentNode;
 		}
@@ -224,7 +224,7 @@ abstract class DOM {
 	 *
 	 * @return string A single character (or the empty string).
 	 */
-	public static function get_prev_chr( DOMNode $node ) {
+	public static function get_prev_chr( DOMNode $node ): string {
 		return self::get_adjacent_character( $node, -1, 1, [ __CLASS__, 'get_previous_acceptable_node' ] );
 	}
 
@@ -235,7 +235,7 @@ abstract class DOM {
 	 *
 	 * @return string A single character (or the empty string).
 	 */
-	public static function get_next_chr( DOMNode $node ) {
+	public static function get_next_chr( DOMNode $node ): string {
 		return self::get_adjacent_character( $node, 0, 1, [ __CLASS__, 'get_next_acceptable_node' ] );
 	}
 
@@ -252,7 +252,7 @@ abstract class DOM {
 	 *
 	 * @return string The character or an empty string.
 	 */
-	private static function get_adjacent_character( DOMNode $node, $position, $length, callable $get_node ) {
+	private static function get_adjacent_character( DOMNode $node, int $position, int $length, callable $get_node ): string {
 		$character     = '';
 		$adjacent_node = $get_node(
 			// Determines if the node is a textnode or one of the acceptable elements.
@@ -335,7 +335,7 @@ abstract class DOM {
 	 *
 	 * @return DOMNode|null Null if $node is a block-level element or no acceptable sibling exists.
 	 */
-	private static function get_adjacent_node( callable $is_acceptable, callable $iterate, callable $get_adjacent_parent, DOMNode $node = null ): ?DOMNode {
+	private static function get_adjacent_node( callable $is_acceptable, callable $iterate, callable $get_adjacent_parent, ?DOMNode $node ): ?DOMNode {
 		if ( ! isset( $node ) || self::is_block_tag( $node ) ) {
 			return null;
 		}
@@ -375,7 +375,7 @@ abstract class DOM {
 	 *
 	 * @return DOMText|null The first child of type DOMText, the element itself if it is of type DOMText or null.
 	 */
-	public static function get_first_textnode( DOMNode $node = null, $recursive = false ) {
+	public static function get_first_textnode( DOMNode $node = null, bool $recursive = false ): ?DOMText {
 		/**
 		 * We only allow textnodes in our `is_acceptable` callable.
 		 *
@@ -431,7 +431,7 @@ abstract class DOM {
 	 *
 	 * @return DOMNode|null The last acceptable child, the element itself if it is acceptable or null.
 	 */
-	private static function get_edge_node( callable $is_acceptable, callable $get_acceptable_node, DOMNode $node = null, $recursive = false, $reverse = false ): ?DOMNode {
+	private static function get_edge_node( callable $is_acceptable, callable $get_acceptable_node, ?DOMNode $node, bool $recursive = false, bool $reverse = false ): ?DOMNode {
 		if ( $is_acceptable( $node ) ) {
 			return $node;
 		} elseif ( ! $node instanceof DOMElement || ( $recursive && self::is_block_tag( $node ) ) ) {
@@ -469,7 +469,7 @@ abstract class DOM {
 	 *
 	 * @return DOMElement|null
 	 */
-	public static function get_block_parent( DOMNode $node ) {
+	public static function get_block_parent( DOMNode $node ): ?DOMElement {
 		$parent = $node->parentNode;
 		if ( ! $parent instanceof DOMElement ) {
 			return null;
@@ -496,7 +496,7 @@ abstract class DOM {
 	 *
 	 * @return bool
 	 */
-	public static function is_block_tag( DOMNode $node ) {
+	public static function is_block_tag( DOMNode $node ): bool {
 		return $node instanceof DOMElement && isset( self::$block_tags[ $node->tagName ] );
 	}
 }

--- a/src/class-dom.php
+++ b/src/class-dom.php
@@ -29,6 +29,11 @@ namespace PHP_Typography;
 
 use Masterminds\HTML5\Elements;
 
+use DOMNodeList;
+use DOMNode;
+use DOMElement;
+use DOMText;
+
 /**
  * Some static methods for DOM manipulation.
  *
@@ -141,13 +146,13 @@ abstract class DOM {
 	 *
 	 * @since 7.0.0 The Parameter $list has been renamed to $node_list.
 	 *
-	 * @param \DOMNodeList $node_list Required.
+	 * @param DOMNodeList $node_list Required.
 	 *
-	 * @return array<string,\DOMNode> An associative array in the form ( $spl_object_hash => $node ).
+	 * @return array<string,DOMNode> An associative array in the form ( $spl_object_hash => $node ).
 	 *
-	 * @phpstan-param \DOMNodeList<\DOMNode> $node_list
+	 * @phpstan-param DOMNodeList<DOMNode> $node_list
 	 */
-	public static function nodelist_to_array( \DOMNodeList $node_list ) {
+	public static function nodelist_to_array( DOMNodeList $node_list ) {
 		$out = [];
 
 		foreach ( $node_list as $node ) {
@@ -161,14 +166,14 @@ abstract class DOM {
 	 * Retrieves an array containing all the ancestors of the node. This could be done
 	 * via an XPath query for "ancestor::*", but DOM walking is in all likelyhood faster.
 	 *
-	 * @param \DOMNode $node Required.
+	 * @param DOMNode $node Required.
 	 *
-	 * @return \DOMNode[] An array of \DOMNode.
+	 * @return DOMNode[] An array of DOMNode.
 	 */
-	public static function get_ancestors( \DOMNode $node ) {
+	public static function get_ancestors( DOMNode $node ) {
 		$result = [];
 
-		while ( ( $node = $node->parentNode ) && ( $node instanceof \DOMElement ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+		while ( ( $node = $node->parentNode ) && ( $node instanceof DOMElement ) ) { // phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 			$result[] = $node;
 		}
 
@@ -176,21 +181,21 @@ abstract class DOM {
 	}
 
 	/**
-	 * Checks whether the \DOMNode has one of the given classes.
-	 * If $tag is a \DOMText, the parent DOMElement is checked instead.
+	 * Checks whether the DOMNode has one of the given classes.
+	 * If $tag is a DOMText, the parent DOMElement is checked instead.
 	 *
-	 * @param \DOMNode        $tag        An element or textnode.
+	 * @param DOMNode         $tag        An element or textnode.
 	 * @param string|string[] $classnames A single classname or an array of classnames.
 	 *
 	 * @return bool True if the element has any of the given class(es).
 	 */
-	public static function has_class( \DOMNode $tag, $classnames ) {
-		if ( $tag instanceof \DOMText ) {
+	public static function has_class( DOMNode $tag, $classnames ) {
+		if ( $tag instanceof DOMText ) {
 			$tag = $tag->parentNode;
 		}
 
 		// Bail if we are not working with a tag or if there is no classname.
-		if ( ! ( $tag instanceof \DOMElement ) || empty( $classnames ) ) {
+		if ( ! ( $tag instanceof DOMElement ) || empty( $classnames ) ) {
 			return false;
 		}
 
@@ -213,52 +218,52 @@ abstract class DOM {
 	}
 
 	/**
-	 * Retrieves the last character of the previous \DOMText sibling (if there is one).
+	 * Retrieves the last character of the previous DOMText sibling (if there is one).
 	 *
-	 * @param \DOMNode $node The content node.
+	 * @param DOMNode $node The content node.
 	 *
 	 * @return string A single character (or the empty string).
 	 */
-	public static function get_prev_chr( \DOMNode $node ) {
+	public static function get_prev_chr( DOMNode $node ) {
 		return self::get_adjacent_character( $node, -1, 1, [ __CLASS__, 'get_previous_acceptable_node' ] );
 	}
 
 	/**
-	 * Retrieves the first character of the next \DOMText sibling (if there is one).
+	 * Retrieves the first character of the next DOMText sibling (if there is one).
 	 *
-	 * @param \DOMNode $node The content node.
+	 * @param DOMNode $node The content node.
 	 *
 	 * @return string A single character (or the empty string).
 	 */
-	public static function get_next_chr( \DOMNode $node ) {
+	public static function get_next_chr( DOMNode $node ) {
 		return self::get_adjacent_character( $node, 0, 1, [ __CLASS__, 'get_next_acceptable_node' ] );
 	}
 
 	/**
-	 * Retrieves a character from the given \DOMNode.
+	 * Retrieves a character from the given DOMNode.
 	 *
 	 * @since 5.0.0
 	 * @since 7.0.0 Renamed to `get_adjacent_character`. Parameter `$get_textnode` renamed to `$get_node`
 	 *
-	 * @param  \DOMNode $node     The starting node.
+	 * @param  DOMNode  $node     The starting node.
 	 * @param  int      $position The position parameter for `substr`.
 	 * @param  int      $length   The length parameter for `substr`.
 	 * @param  callable $get_node A function to retrieve the adjacent node from the starting node.
 	 *
 	 * @return string The character or an empty string.
 	 */
-	private static function get_adjacent_character( \DOMNode $node, $position, $length, callable $get_node ) {
+	private static function get_adjacent_character( DOMNode $node, $position, $length, callable $get_node ) {
 		$character     = '';
 		$adjacent_node = $get_node(
 			// Determines if the node is a textnode or one of the acceptable elements.
-			function ( ?\DOMNode $n ): bool {
-				return $n instanceof \DOMText || ( $n instanceof \DOMElement && isset( self::ACCEPTABLE_NEIGHBOR_ELEMENTS[ $n->tagName ] ) );
+			function ( ?DOMNode $n ): bool {
+				return $n instanceof DOMText || ( $n instanceof DOMElement && isset( self::ACCEPTABLE_NEIGHBOR_ELEMENTS[ $n->tagName ] ) );
 			},
 			$node
 		);
 
 		if ( null !== $adjacent_node ) {
-			if ( $adjacent_node instanceof \DOMElement ) {
+			if ( $adjacent_node instanceof DOMElement ) {
 				switch ( $adjacent_node->tagName ) {
 					case 'br':
 						$character = ' ';
@@ -268,7 +273,7 @@ abstract class DOM {
 					default:
 						$character = '';
 				}
-			} elseif ( $adjacent_node instanceof \DOMText ) {
+			} elseif ( $adjacent_node instanceof DOMText ) {
 				$node_data = $adjacent_node->data;
 				$character = \preg_replace( '/\p{C}/Su', '', Strings::functions( $node_data )['substr']( $node_data, $position, $length ) );
 			}
@@ -280,15 +285,15 @@ abstract class DOM {
 	/**
 	 * Retrieves the previous acceptable sibling (if there is one).
 	 *
-	 * @param callable      $is_acceptable Returns true if the \DOMnode is acceptable.
-	 * @param \DOMNode|null $node          Optional. The content node. Default null.
+	 * @param  callable $is_acceptable Returns true if the \DOMnode is acceptable.
+	 * @param  ?DOMNode $node          Optional. The content node. Default null.
 	 *
-	 * @return \DOMNode|null Null if $node is a block-level element or no text sibling exists.
+	 * @return DOMNode|null Null if $node is a block-level element or no text sibling exists.
 	 */
-	public static function get_previous_acceptable_node( callable $is_acceptable, ?\DOMNode $node ): ?\DOMNode {
+	public static function get_previous_acceptable_node( callable $is_acceptable, ?DOMNode $node ): ?DOMNode {
 		return self::get_adjacent_node(
 			$is_acceptable,
-			function ( callable $is_node_acceptable, \DOMNode &$another_node ): ?\DOMNode {
+			function ( callable $is_node_acceptable, DOMNode &$another_node ): ?DOMNode {
 				$another_node = $another_node->previousSibling ?? null;
 				return self::get_last_acceptable_node( $is_node_acceptable, $another_node );
 			},
@@ -300,15 +305,15 @@ abstract class DOM {
 	/**
 	 * Retrieves the next accceptable sibling (if there is one).
 	 *
-	 * @param callable      $is_acceptable Returns true if the \DOMnode is acceptable.
-	 * @param \DOMNode|null $node          Optional. The content node. Default null.
+	 * @param  callable $is_acceptable Returns true if the \DOMnode is acceptable.
+	 * @param  ?DOMNode $node          Optional. The content node. Default null.
 	 *
-	 * @return \DOMNode|null Null if $node is a block-level element or no text sibling exists.
+	 * @return DOMNode|null Null if $node is a block-level element or no text sibling exists.
 	 */
-	public static function get_next_acceptable_node( callable $is_acceptable, ?\DOMNode $node ): ?\DOMNode {
+	public static function get_next_acceptable_node( callable $is_acceptable, ?DOMNode $node ): ?DOMNode {
 		return self::get_adjacent_node(
 			$is_acceptable,
-			function ( callable $is_node_acceptable, \DOMNode &$another_node ): ?\DOMNode {
+			function ( callable $is_node_acceptable, DOMNode &$another_node ): ?DOMNode {
 				$another_node = $another_node->nextSibling;
 				return self::get_first_acceptable_node( $is_node_acceptable, $another_node );
 			},
@@ -323,14 +328,14 @@ abstract class DOM {
 	 * @since 5.0.0
 	 * @since 7.0.0 Renamed to `get_adjacent_node` and refactored to take a callable to determine acceptable nodes.
 	 *
-	 * @param callable      $is_acceptable       Returns true if the \DOMnode is acceptable.
-	 * @param callable      $iterate             Takes a reference \DOMElement and returns a \DOMText (or null).
-	 * @param callable      $get_adjacent_parent Takes a single \DOMElement parameter and returns a \DOMText (or null).
-	 * @param \DOMNode|null $node                Optional. The content node. Default null.
+	 * @param  callable $is_acceptable       Returns true if the \DOMnode is acceptable.
+	 * @param  callable $iterate             Takes a reference DOMElement and returns a DOMText (or null).
+	 * @param  callable $get_adjacent_parent Takes a single DOMElement parameter and returns a DOMText (or null).
+	 * @param  ?DOMNode $node                Optional. The content node. Default null.
 	 *
-	 * @return \DOMNode|null Null if $node is a block-level element or no acceptable sibling exists.
+	 * @return DOMNode|null Null if $node is a block-level element or no acceptable sibling exists.
 	 */
-	private static function get_adjacent_node( callable $is_acceptable, callable $iterate, callable $get_adjacent_parent, \DOMNode $node = null ): ?\DOMNode {
+	private static function get_adjacent_node( callable $is_acceptable, callable $iterate, callable $get_adjacent_parent, DOMNode $node = null ): ?DOMNode {
 		if ( ! isset( $node ) || self::is_block_tag( $node ) ) {
 			return null;
 		}
@@ -338,14 +343,14 @@ abstract class DOM {
 		/**
 		 * The result node.
 		 *
-		 * @var \DOMNode|null
+		 * @var DOMNode|null
 		 */
 		$adjacent = null;
 
 		/**
 		 * The initial node.
 		 *
-		 * @var \DOMNode
+		 * @var DOMNode
 		 */
 		$iterated_node = $node;
 
@@ -363,22 +368,22 @@ abstract class DOM {
 	}
 
 	/**
-	 * Retrieves the first \DOMText child of the element. Block-level child elements are ignored.
+	 * Retrieves the first DOMText child of the element. Block-level child elements are ignored.
 	 *
-	 * @param \DOMNode|null $node      Optional. Default null.
-	 * @param bool          $recursive Should be set to true on recursive calls. Optional. Default false.
+	 * @param  ?DOMNode $node      Optional. Default null.
+	 * @param  bool     $recursive Should be set to true on recursive calls. Optional. Default false.
 	 *
-	 * @return \DOMText|null The first child of type \DOMText, the element itself if it is of type \DOMText or null.
+	 * @return DOMText|null The first child of type DOMText, the element itself if it is of type DOMText or null.
 	 */
-	public static function get_first_textnode( \DOMNode $node = null, $recursive = false ) {
+	public static function get_first_textnode( DOMNode $node = null, $recursive = false ) {
 		/**
 		 * We only allow textnodes in our `is_acceptable` callable.
 		 *
-		 * @phpstan-var ?\DOMText
+		 * @phpstan-var ?DOMText
 		 */
 		return self::get_first_acceptable_node(
-			function ( ?\DOMNode $node ): bool {
-				return $node instanceof \DOMText;
+			function ( ?DOMNode $node ): bool {
+				return $node instanceof DOMText;
 			},
 			$node,
 			$recursive
@@ -388,26 +393,26 @@ abstract class DOM {
 	/**
 	 * Retrieves the first acceptable child of the element. Block-level child elements are ignored.
 	 *
-	 * @param callable      $is_acceptable Returns true if the \DOMnode is acceptable.
-	 * @param \DOMNode|null $node          Optional. Default null.
-	 * @param bool          $recursive     Should be set to true on recursive calls. Optional. Default false.
+	 * @param  callable $is_acceptable Returns true if the \DOMnode is acceptable.
+	 * @param  ?DOMNode $node          Optional. Default null.
+	 * @param  bool     $recursive     Should be set to true on recursive calls. Optional. Default false.
 	 *
-	 * @return \DOMNode|null The first acceptable child node, the element itself if it is acceptable or null.
+	 * @return DOMNode|null The first acceptable child node, the element itself if it is acceptable or null.
 	 */
-	public static function get_first_acceptable_node( callable $is_acceptable, \DOMNode $node = null, bool $recursive = false ): ?\DOMNode {
+	public static function get_first_acceptable_node( callable $is_acceptable, ?DOMNode $node = null, bool $recursive = false ): ?DOMNode {
 		return self::get_edge_node( $is_acceptable, [ __CLASS__, __FUNCTION__ ], $node, $recursive, false );
 	}
 
 	/**
 	 * Retrieves the last acceptable child of the element. Block-level child elements are ignored.
 	 *
-	 * @param callable      $is_acceptable Returns true if the \DOMnode is acceptable.
-	 * @param \DOMNode|null $node          Optional. Default null.
-	 * @param bool          $recursive     Should be set to true on recursive calls. Optional. Default false.
+	 * @param  callable     $is_acceptable Returns true if the \DOMnode is acceptable.
+	 * @param  DOMNode|null $node          Optional. Default null.
+	 * @param  bool         $recursive     Should be set to true on recursive calls. Optional. Default false.
 	 *
-	 * @return \DOMNode|null The last acceptable child node, the element itself if it is acceptable or null.
+	 * @return DOMNode|null The last acceptable child node, the element itself if it is acceptable or null.
 	 */
-	public static function get_last_acceptable_node( callable $is_acceptable, \DOMNode $node = null, bool $recursive = false ): ?\DOMNode {
+	public static function get_last_acceptable_node( callable $is_acceptable, DOMNode $node = null, bool $recursive = false ): ?DOMNode {
 		return self::get_edge_node( $is_acceptable, [ __CLASS__, __FUNCTION__ ], $node, $recursive, true );
 	}
 
@@ -418,19 +423,19 @@ abstract class DOM {
 	 * @since 5.0.0
 	 * @since 7.0.0 Renamed to `get_edge_node` and refactored to take a callable to determine acceptable nodes.
 	 *
-	 * @param callable      $is_acceptable       Returns true if the \DOMnode is acceptable.
-	 * @param callable      $get_acceptable_node Takes two parameters, a \DOMNode and a boolean flag for recursive calls.
-	 * @param \DOMNode|null $node                Optional. Default null.
-	 * @param bool          $recursive           Should be set to true on recursive calls. Optional. Default false.
-	 * @param bool          $reverse             Whether to iterate forward or backward. Optional. Default false.
+	 * @param  callable $is_acceptable       Returns true if the \DOMnode is acceptable.
+	 * @param  callable $get_acceptable_node Takes two parameters, a DOMNode and a boolean flag for recursive calls.
+	 * @param  ?DOMNode $node                Optional. Default null.
+	 * @param  bool     $recursive           Should be set to true on recursive calls. Optional. Default false.
+	 * @param  bool     $reverse             Whether to iterate forward or backward. Optional. Default false.
 	 *
-	 * @return \DOMNode|null The last acceptable child, the element itself if it is acceptable or null.
+	 * @return DOMNode|null The last acceptable child, the element itself if it is acceptable or null.
 	 */
-	private static function get_edge_node( callable $is_acceptable, callable $get_acceptable_node, \DOMNode $node = null, $recursive = false, $reverse = false ): ?\DOMNode {
+	private static function get_edge_node( callable $is_acceptable, callable $get_acceptable_node, DOMNode $node = null, $recursive = false, $reverse = false ): ?DOMNode {
 		if ( $is_acceptable( $node ) ) {
 			return $node;
-		} elseif ( ! $node instanceof \DOMElement || ( $recursive && self::is_block_tag( $node ) ) ) {
-			// Return null if $node is neither an acceptable node nor \DOMElement or
+		} elseif ( ! $node instanceof DOMElement || ( $recursive && self::is_block_tag( $node ) ) ) {
+			// Return null if $node is neither an acceptable node nor DOMElement or
 			// when we are recursing and already at the block level.
 			return null;
 		}
@@ -438,7 +443,7 @@ abstract class DOM {
 		/**
 		 * The result node.
 		 *
-		 * @var \DOMNode|null
+		 * @var DOMNode|null
 		 */
 		$acceptable_edge_node = null;
 
@@ -460,21 +465,21 @@ abstract class DOM {
 	/**
 	 * Returns the nearest block-level parent (or null).
 	 *
-	 * @param \DOMNode $node Required.
+	 * @param DOMNode $node Required.
 	 *
-	 * @return \DOMElement|null
+	 * @return DOMElement|null
 	 */
-	public static function get_block_parent( \DOMNode $node ) {
+	public static function get_block_parent( DOMNode $node ) {
 		$parent = $node->parentNode;
-		if ( ! $parent instanceof \DOMElement ) {
+		if ( ! $parent instanceof DOMElement ) {
 			return null;
 		}
 
-		while ( ! self::is_block_tag( $parent ) && $parent->parentNode instanceof \DOMElement ) {
+		while ( ! self::is_block_tag( $parent ) && $parent->parentNode instanceof DOMElement ) {
 			/**
-			 * The parent is sure to be a \DOMElement.
+			 * The parent is sure to be a DOMElement.
 			 *
-			 * @var \DOMElement
+			 * @var DOMElement
 			 */
 			$parent = $parent->parentNode;
 		}
@@ -487,12 +492,12 @@ abstract class DOM {
 	 *
 	 * @since 6.0.0
 	 *
-	 * @param  \DOMNode $node Required.
+	 * @param  DOMNode $node Required.
 	 *
 	 * @return bool
 	 */
-	public static function is_block_tag( \DOMNode $node ) {
-		return $node instanceof \DOMElement && isset( self::$block_tags[ $node->tagName ] );
+	public static function is_block_tag( DOMNode $node ) {
+		return $node instanceof DOMElement && isset( self::$block_tags[ $node->tagName ] );
 	}
 }
 

--- a/src/class-dom.php
+++ b/src/class-dom.php
@@ -57,7 +57,23 @@ abstract class DOM {
 	 */
 	private static array $inappropriate_tags;
 
-	const ADDITIONAL_INAPPROPRIATE_TAGS = [
+	/**
+	 * Block tags not included as such in the current HTML5-PHP version.
+	 *
+	 * @since 7.0.0
+	 */
+	private const ADDITIONAL_BLOCK_TAGS = [
+		'li',
+		'td',
+		'dt',
+	];
+
+	/**
+	 * Tags that should never be modified.
+	 *
+	 * @since 5.2.0
+	 */
+	private const ADDITIONAL_INAPPROPRIATE_TAGS = [
 		'button',
 		'select',
 		'optgroup',
@@ -94,16 +110,16 @@ abstract class DOM {
 	 */
 	public static function block_tags( bool $reset = false ): array {
 		if ( empty( self::$block_tags ) || $reset ) {
-			self::$block_tags = \array_merge(
-				\array_flip(
+			self::$block_tags = \array_flip(
+				\array_merge(
 					\array_filter(
 						\array_keys( Elements::$html5 ),
 						function ( $tag ) {
 							return Elements::isA( $tag, Elements::BLOCK_TAG );
 						}
-					)
-				),
-				\array_flip( [ 'li', 'td', 'dt' ] ) // not included as "block tags" in current HTML5-PHP version.
+					),
+					self::ADDITIONAL_BLOCK_TAGS
+				)
 			);
 		}
 

--- a/src/class-dom.php
+++ b/src/class-dom.php
@@ -236,22 +236,26 @@ abstract class DOM {
 	/**
 	 * Retrieves the last character of the previous DOMText sibling (if there is one).
 	 *
+	 * @since 7.0.0 Renamed to `get_previous_character`.
+	 *
 	 * @param DOMNode $node The content node.
 	 *
 	 * @return string A single character (or the empty string).
 	 */
-	public static function get_prev_chr( DOMNode $node ): string {
+	public static function get_previous_character( DOMNode $node ): string {
 		return self::get_adjacent_character( $node, -1, 1, [ __CLASS__, 'get_previous_acceptable_node' ] );
 	}
 
 	/**
 	 * Retrieves the first character of the next DOMText sibling (if there is one).
 	 *
+	 * @since 7.0.0 Renamed to `get_next_character`.
+	 *
 	 * @param DOMNode $node The content node.
 	 *
 	 * @return string A single character (or the empty string).
 	 */
-	public static function get_next_chr( DOMNode $node ): string {
+	public static function get_next_character( DOMNode $node ): string {
 		return self::get_adjacent_character( $node, 0, 1, [ __CLASS__, 'get_next_acceptable_node' ] );
 	}
 

--- a/src/fixes/node-fixes/class-dewidow-fix.php
+++ b/src/fixes/node-fixes/class-dewidow-fix.php
@@ -97,7 +97,7 @@ class Dewidow_Fix extends Abstract_Node_Fix {
 			return;
 		}
 
-		if ( '' === DOM::get_next_chr( $textnode ) ) {
+		if ( '' === DOM::get_next_character( $textnode ) ) {
 			// We have the last type "text" child of a block level element.
 			$textnode->data = $this->dewidow( $textnode->data, Strings::functions( $textnode->data ), $settings[ Settings::DEWIDOW_MAX_PULL ], $settings[ Settings::DEWIDOW_MAX_LENGTH ], $settings[ Settings::DEWIDOW_WORD_NUMBER ] );
 		}

--- a/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
+++ b/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
@@ -70,8 +70,8 @@ class French_Punctuation_Spacing_Fix extends Abstract_Node_Fix {
 
 		// Need to get context of adjacent characters outside adjacent inline tags or HTML comment
 		// if we have adjacent characters add them to the text.
-		$previous_character = DOM::get_prev_chr( $textnode );
-		$next_character     = DOM::get_next_chr( $textnode );
+		$previous_character = DOM::get_previous_character( $textnode );
+		$next_character     = DOM::get_next_character( $textnode );
 		$node_data          = "{$previous_character}{$textnode->data}"; // $next_character is not included on purpose.
 
 		// Check encoding.

--- a/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
+++ b/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
@@ -69,8 +69,8 @@ class Single_Character_Word_Spacing_Fix extends Abstract_Node_Fix {
 		}
 
 		// Add $next_character and $previous_character for context.
-		$previous_character = DOM::get_prev_chr( $textnode );
-		$next_character     = DOM::get_next_chr( $textnode );
+		$previous_character = DOM::get_previous_character( $textnode );
+		$next_character     = DOM::get_next_character( $textnode );
 		$node_data          = "{$previous_character}{$textnode->data}{$next_character}";
 
 		// Check encoding.

--- a/src/fixes/node-fixes/class-smart-quotes-fix.php
+++ b/src/fixes/node-fixes/class-smart-quotes-fix.php
@@ -104,8 +104,8 @@ class Smart_Quotes_Fix extends Abstract_Node_Fix {
 
 		// Need to get context of adjacent characters outside adjacent inline tags or HTML comment
 		// if we have adjacent characters add them to the text.
-		$previous_character = DOM::get_prev_chr( $textnode );
-		$next_character     = DOM::get_next_chr( $textnode );
+		$previous_character = DOM::get_previous_character( $textnode );
+		$next_character     = DOM::get_next_character( $textnode );
 		$node_data          = "{$previous_character}{$textnode->data}{$next_character}";
 
 		// Check encoding.

--- a/src/fixes/node-fixes/class-space-collapse-fix.php
+++ b/src/fixes/node-fixes/class-space-collapse-fix.php
@@ -85,7 +85,7 @@ class Space_Collapse_Fix extends Abstract_Node_Fix {
 		);
 
 		// Remove all spacing at beginning of block level elements.
-		if ( null === DOM::get_previous_textnode( $textnode ) ) {
+		if ( DOM::get_first_textnode( $textnode ) === $textnode ) {
 			$node_data = (string) \preg_replace( self::COLLAPSE_SPACES_AT_START_OF_BLOCK, '', $node_data );
 		}
 

--- a/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
+++ b/src/fixes/node-fixes/class-style-hanging-punctuation-fix.php
@@ -129,7 +129,7 @@ class Style_Hanging_Punctuation_Fix extends Classes_Dependent_Fix {
 
 		// Need to get context of adjacent characters outside adjacent inline tags or HTML comment
 		// if we have adjacent characters add them to the text.
-		$next_character = DOM::get_next_chr( $textnode );
+		$next_character = DOM::get_next_character( $textnode );
 		$node_data      = "{$textnode->data}$next_character"; // We have no interest in preceeding characters for this fix.
 
 		// Check encoding.

--- a/src/fixes/node-fixes/class-style-initial-quotes-fix.php
+++ b/src/fixes/node-fixes/class-style-initial-quotes-fix.php
@@ -82,7 +82,7 @@ class Style_Initial_Quotes_Fix extends Classes_Dependent_Fix {
 	 * @return void
 	 */
 	protected function apply_internal( \DOMText $textnode, Settings $settings, $is_title ) {
-		if ( empty( $settings[ Settings::STYLE_INITIAL_QUOTES ] ) || empty( $settings[ Settings::INITIAL_QUOTE_TAGS ] ) || null !== DOM::get_previous_textnode( $textnode ) ) {
+		if ( empty( $settings[ Settings::STYLE_INITIAL_QUOTES ] ) || empty( $settings[ Settings::INITIAL_QUOTE_TAGS ] ) || DOM::get_first_textnode( $textnode ) !== $textnode ) {
 			return;
 		}
 
@@ -104,7 +104,7 @@ class Style_Initial_Quotes_Fix extends Classes_Dependent_Fix {
 
 		if ( ! empty( $span_class ) ) {
 			// Assume page title is <h2>.
-			$block_level_parent = $is_title ? 'h2' : DOM::get_block_parent_name( $textnode );
+			$block_level_parent = $is_title ? 'h2' : DOM::get_block_parent( $textnode )->tagName ?? '';
 
 			if ( ! empty( $block_level_parent ) && isset( $settings[ Settings::INITIAL_QUOTE_TAGS ][ $block_level_parent ] ) ) {
 				$textnode->data = RE::escape_tags( '<span class="' . $span_class . '">' ) . $first_character . RE::escape_tags( '</span>' ) . $f['substr']( $node_data, 1, $f['strlen']( $node_data ) );

--- a/src/fixes/token-fixes/class-hyphenate-fix.php
+++ b/src/fixes/token-fixes/class-hyphenate-fix.php
@@ -99,7 +99,7 @@ class Hyphenate_Fix extends Abstract_Token_Fix {
 
 		$is_heading = false;
 		if ( ! empty( $textnode->parentNode ) ) {
-			$block_level_parent = DOM::get_block_parent_name( $textnode );
+			$block_level_parent = DOM::get_block_parent( $textnode )->tagName ?? '';
 
 			if ( ! empty( $block_level_parent ) && isset( $this->heading_tags[ $block_level_parent ] ) ) {
 				$is_heading = true;

--- a/tests/class-dom-test.php
+++ b/tests/class-dom-test.php
@@ -271,30 +271,6 @@ class DOM_Test extends Testcase {
 	}
 
 	/**
-	 * Test get_block_parent_name.
-	 *
-	 * @covers ::get_block_parent_name
-	 *
-	 * @uses ::get_block_parent
-	 * @uses ::is_block_tag
-	 *
-	 * @dataProvider provide_get_block_parent_data
-	 *
-	 * @param string $input_xpath  Input element/node.
-	 * @param string $parent_xpath Ignored.
-	 * @param string $parent_tag   Parent tag name.
-	 * @param string $html         HTML code.
-	 */
-	public function test_get_block_parent_name( $input_xpath, $parent_xpath, $parent_tag, $html ) {
-		$doc   = $this->load_html( $html );
-		$xpath = new \DOMXPath( $doc );
-
-		$input_node = $xpath->query( $input_xpath )->item( 0 ); // really only one.
-
-		$this->assertSame( $parent_tag, DOM::get_block_parent_name( $input_node ) );
-	}
-
-	/**
 	 * Test get_prev_chr.
 	 *
 	 * @covers ::get_prev_chr
@@ -302,7 +278,6 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_previous_acceptable_node
 	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_acceptable_neighbor_node
 	 *
 	 * @uses ::get_last_acceptable_node
 	 * @uses ::get_edge_node
@@ -329,7 +304,6 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_adjacent_character
 	 * @covers ::get_previous_acceptable_node
 	 * @covers ::get_adjacent_node
-	 * @covers ::is_acceptable_neighbor_node
 	 *
 	 * @uses ::is_block_tag
 	 * @uses ::get_last_acceptable_node
@@ -351,17 +325,22 @@ class DOM_Test extends Testcase {
 	}
 
 	/**
-	 * Test get_previous_textnode.
+	 * Test get_previous_acceptable_node.
 	 *
-	 * @covers ::get_previous_textnode
+	 * @covers ::get_previous_acceptable_node
 	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
-	 *
-	 * @uses ::get_previous_acceptable_node
 	 */
-	public function test_get_previous_textnode_null() {
-		$node = DOM::get_previous_textnode( null );
-		$this->assertNull( $node );
+	public function test_get_previous_acceptable_node_null() {
+		$is_text       = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText;
+		};
+		$is_text_or_br = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText || ( $n instanceof \DOMElement && 'br' === $n->tagName );
+		};
+
+		$this->assertNull( DOM::get_previous_acceptable_node( $is_text, null ) );
+		$this->assertNull( DOM::get_previous_acceptable_node( $is_text_or_br, null ) );
 	}
 
 	/**
@@ -372,7 +351,6 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_next_acceptable_node
 	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_acceptable_neighbor_node
 	 *
 	 * @uses ::get_first_acceptable_node
 	 * @uses ::get_edge_node
@@ -400,7 +378,6 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_next_acceptable_node
 	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_acceptable_neighbor_node
 	 *
 	 * @uses ::get_first_acceptable_node
 	 * @uses ::get_edge_node
@@ -428,7 +405,6 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_next_acceptable_node
 	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_acceptable_neighbor_node
 	 *
 	 * @uses ::get_first_acceptable_node
 	 * @uses ::get_edge_node
@@ -449,18 +425,22 @@ class DOM_Test extends Testcase {
 	}
 
 	/**
-	 * Test get_next_textnode.
+	 * Test get_next_acceptable_node.
 	 *
-	 * @covers ::get_next_textnode
+	 * @covers ::get_next_acceptable_node
 	 * @covers ::get_adjacent_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_textnode
-	 *
-	 * @uses ::get_next_acceptable_node
 	 */
-	public function test_get_next_textnode_null() {
-		$node = DOM::get_next_textnode( null );
-		$this->assertNull( $node );
+	public function test_get_next_acceptable_node_null() {
+		$is_text       = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText;
+		};
+		$is_text_or_br = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText || ( $n instanceof \DOMElement && 'br' === $n->tagName );
+		};
+
+		$this->assertNull( DOM::get_next_acceptable_node( $is_text, null ) );
+		$this->assertNull( DOM::get_next_acceptable_node( $is_text_or_br, null ) );
 	}
 
 
@@ -470,7 +450,6 @@ class DOM_Test extends Testcase {
 	 * @covers ::get_first_textnode
 	 * @covers ::get_edge_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_textnode
 	 *
 	 * @uses ::get_first_acceptable_node
 	 */
@@ -497,106 +476,233 @@ class DOM_Test extends Testcase {
 	}
 
 	/**
-	 * Test get_first_textnode.
+	 * Test get_first_acceptable_node.
 	 *
-	 * @covers ::get_first_textnode
-	 * @covers ::get_edge_node
-	 * @covers ::is_textnode
 	 * @covers ::get_first_acceptable_node
+	 * @covers ::get_edge_node
+	 * @covers ::is_block_tag
 	 */
-	public function test_get_first_textnode_null() {
-		// Passing null returns null.
-		$this->assertNull( DOM::get_first_textnode( null ) );
+	public function test_get_first_acceptable_node() {
+		$html          = '<p><br><span id="foo">A</span><span id="bar">new hope.</span></p>';
+		$doc           = $this->load_html( $html );
+		$xpath         = new \DOMXPath( $doc );
+		$is_text       = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText;
+		};
+		$is_text_or_br = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText || ( $n instanceof \DOMElement && 'br' === $n->tagName );
+		};
 
-		// Passing a DOMNode that is not a DOMElement or a DOMText returns null as well.
-		$this->assertNull( DOM::get_first_textnode( new \DOMDocument() ) );
+		// Same result regardless of acceptability predicate.
+		$query = "//*[@id='foo']/text()";
+
+		$node = DOM::get_first_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'A', $node->nodeValue );
+
+		$node = DOM::get_first_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'A', $node->nodeValue );
+
+		// Same result regardless of acceptability predicate.
+		$query = "//*[@id='foo']";
+		$node  = DOM::get_first_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'A', $node->nodeValue );
+		$node = DOM::get_first_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'A', $node->nodeValue );
+
+		// Same result regardless of acceptability predicate.
+		$query = "//*[@id='bar']";
+		$node  = DOM::get_first_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'new hope.', $node->nodeValue );
+		$node = DOM::get_first_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'new hope.', $node->nodeValue );
+
+		// Different result depending on acceptability predicate.
+		$query = '//p';
+		$node  = DOM::get_first_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'A', $node->nodeValue );
+		$node = DOM::get_first_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMElement::class, $node );
+		$this->assertSame( 'br', $node->tagName );
+
+		// Different result depending on acceptability predicate.
+		$query = '//br';
+		$node  = DOM::get_first_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertNull( $node );
+		$node = DOM::get_first_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMElement::class, $node );
+		$this->assertSame( 'br', $node->tagName );
 	}
 
 	/**
-	 * Test get_first_textnode.
+	 * Test get_first_acceptable_node.
 	 *
-	 * @covers ::get_first_textnode
+	 * @covers ::get_first_acceptable_node
+	 * @covers ::get_edge_node
+	 */
+	public function test_get_first_acceptable_node_null() {
+		$is_text       = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText;
+		};
+		$is_text_or_br = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText || ( $n instanceof \DOMElement && 'br' === $n->tagName );
+		};
+
+		// Passing null returns null.
+		$this->assertNull( DOM::get_first_acceptable_node( $is_text, null ) );
+		$this->assertNull( DOM::get_first_acceptable_node( $is_text_or_br, null ) );
+
+		// Passing a DOMNode that is not a DOMElement or a DOMText returns null as well.
+		$this->assertNull( DOM::get_first_acceptable_node( $is_text, new \DOMDocument() ) );
+		$this->assertNull( DOM::get_first_acceptable_node( $is_text_or_br, new \DOMDocument() ) );
+	}
+
+	/**
+	 * Test get_first_acceptable_node.
+	 *
+	 * @covers ::get_first_acceptable_node
 	 * @covers ::get_edge_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_textnode
 	 * @covers ::get_first_acceptable_node
 	 */
-	public function test_get_first_textnode_only_block_level() {
-		$html  = '<div><div id="foo">No</div><div id="bar">hope</div></div>';
-		$doc   = $this->load_html( $html );
-		$xpath = new \DOMXPath( $doc );
+	public function test_get_first_acceptable_node_only_block_level() {
+		$html          = '<div><div id="foo">No</div><div id="bar">hope</div></div>';
+		$doc           = $this->load_html( $html );
+		$xpath         = new \DOMXPath( $doc );
+		$is_text       = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText;
+		};
+		$is_text_or_br = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText || ( $n instanceof \DOMElement && 'br' === $n->tagName );
+		};
 
-		$textnodes = $xpath->query( '//div' ); // really only one.
-		$node      = DOM::get_first_textnode( $textnodes->item( 0 ) );
+		// Same result regardless of acceptability predicate.
+		$query = '//div';
+		$node  = DOM::get_first_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertNull( $node );
+		$node = DOM::get_first_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
 		$this->assertNull( $node );
 	}
 
+
 	/**
-	 * Test get_last_textnode.
+	 * Test get_last_acceptable_node.
 	 *
-	 * @covers ::get_last_textnode
+	 * @covers ::get_last_acceptable_node
 	 * @covers ::get_edge_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_textnode
-	 *
-	 * @uses ::get_last_acceptable_node
 	 */
-	public function test_get_last_textnode() {
+	public function test_get_last_acceptable_node() {
+		$html          = '<p><span id="foo">A</span><span id="bar">new hope.</span> Really.<br></p>';
+		$doc           = $this->load_html( $html );
+		$xpath         = new \DOMXPath( $doc );
+		$is_text       = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText;
+		};
+		$is_text_or_br = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText || ( $n instanceof \DOMElement && 'br' === $n->tagName );
+		};
 
-		$html  = '<p><span id="foo">A</span><span id="bar">new hope.</span> Really.</p>';
-		$doc   = $this->load_html( $html );
-		$xpath = new \DOMXPath( $doc );
+		// Same result regardless of acceptability predicate.
+		$query = "//*[@id='foo']/text()";
 
-		$textnodes = $xpath->query( "//*[@id='foo']/text()" ); // really only one.
-		$node      = DOM::get_last_textnode( $textnodes->item( 0 ) );
+		$node = DOM::get_last_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
 		$this->assertSame( 'A', $node->nodeValue );
 
-		$textnodes = $xpath->query( "//*[@id='foo']" ); // really only one.
-		$node      = DOM::get_last_textnode( $textnodes->item( 0 ) );
+		$node = DOM::get_last_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
 		$this->assertSame( 'A', $node->nodeValue );
 
-		$textnodes = $xpath->query( "//*[@id='bar']" ); // really only one.
-		$node      = DOM::get_last_textnode( $textnodes->item( 0 ) );
+		// Same result regardless of acceptability predicate.
+		$query = "//*[@id='foo']";
+		$node  = DOM::get_last_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'A', $node->nodeValue );
+		$node = DOM::get_last_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'A', $node->nodeValue );
+
+		// Same result regardless of acceptability predicate.
+		$query = "//*[@id='bar']";
+		$node  = DOM::get_last_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
+		$this->assertSame( 'new hope.', $node->nodeValue );
+		$node = DOM::get_last_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
 		$this->assertSame( 'new hope.', $node->nodeValue );
 
-		$textnodes = $xpath->query( '//p' ); // really only one.
-		$node      = DOM::get_last_textnode( $textnodes->item( 0 ) );
+		// Different result depending on acceptability predicate.
+		$query = '//p';
+		$node  = DOM::get_last_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMText::class, $node );
 		$this->assertSame( ' Really.', $node->nodeValue );
+		$node = DOM::get_last_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMElement::class, $node );
+		$this->assertSame( 'br', $node->tagName );
+
+		// Different result depending on acceptability predicate.
+		$query = '//br';
+		$node  = DOM::get_last_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertNull( $node );
+		$node = DOM::get_last_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
+		$this->assertInstanceOf( \DOMElement::class, $node );
+		$this->assertSame( 'br', $node->tagName );
 	}
 
 	/**
-	 * Test get_last_textnode.
+	 * Test get_last_acceptable_node.
 	 *
-	 * @covers ::get_last_textnode
-	 * @covers ::get_edge_node
-	 * @covers ::is_textnode
 	 * @covers ::get_last_acceptable_node
+	 * @covers ::get_edge_node
 	 */
-	public function test_get_last_textnode_null() {
+	public function test_get_last_acceptable_node_null() {
+		$is_text       = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText;
+		};
+		$is_text_or_br = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText || ( $n instanceof \DOMElement && 'br' === $n->tagName );
+		};
+
 		// Passing null returns null.
-		$this->assertNull( DOM::get_last_textnode( null ) );
+		$this->assertNull( DOM::get_last_acceptable_node( $is_text, null ) );
+		$this->assertNull( DOM::get_last_acceptable_node( $is_text_or_br, null ) );
 
 		// Passing a DOMNode that is not a DOMElement or a DOMText returns null as well.
-		$this->assertNull( DOM::get_last_textnode( new \DOMDocument() ) );
+		$this->assertNull( DOM::get_last_acceptable_node( $is_text, new \DOMDocument() ) );
+		$this->assertNull( DOM::get_last_acceptable_node( $is_text_or_br, new \DOMDocument() ) );
 	}
 
 
 	/**
-	 * Test get_last_textnode.
+	 * Test get_last_acceptable_node.
 	 *
-	 * @covers ::get_last_textnode
+	 * @covers ::get_last_acceptable_node
 	 * @covers ::get_edge_node
 	 * @covers ::is_block_tag
-	 * @covers ::is_textnode
-	 * @covers ::get_last_acceptable_node
 	 */
-	public function test_get_last_textnode_only_block_level() {
-		$html  = '<div><div id="foo">No</div><div id="bar">hope</div></div>';
-		$doc   = $this->load_html( $html );
-		$xpath = new \DOMXPath( $doc );
+	public function test_get_last_acceptable_only_block_level() {
+		$html          = '<div><div id="foo">No</div><div id="bar">hope</div></div>';
+		$doc           = $this->load_html( $html );
+		$xpath         = new \DOMXPath( $doc );
+		$is_text       = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText;
+		};
+		$is_text_or_br = function ( ?\DOMNode $n ): bool {
+			return $n instanceof \DOMText || ( $n instanceof \DOMElement && 'br' === $n->tagName );
+		};
 
-		$textnodes = $xpath->query( '//div' ); // really only one.
-		$node      = DOM::get_last_textnode( $textnodes->item( 0 ) );
+		// Same result regardless of acceptability predicate.
+		$query = '//div';
+		$node  = DOM::get_last_acceptable_node( $is_text, $xpath->query( $query )->item( 0 ) );
+		$this->assertNull( $node );
+		$node = DOM::get_last_acceptable_node( $is_text_or_br, $xpath->query( $query )->item( 0 ) );
 		$this->assertNull( $node );
 	}
 }

--- a/tests/class-dom-test.php
+++ b/tests/class-dom-test.php
@@ -271,9 +271,9 @@ class DOM_Test extends Testcase {
 	}
 
 	/**
-	 * Test get_prev_chr.
+	 * Test get_previous_character.
 	 *
-	 * @covers ::get_prev_chr
+	 * @covers ::get_previous_character
 	 * @covers ::get_adjacent_character
 	 * @covers ::get_previous_acceptable_node
 	 * @covers ::get_adjacent_node
@@ -283,24 +283,24 @@ class DOM_Test extends Testcase {
 	 * @uses ::get_edge_node
 	 * @uses PHP_Typography\Strings::functions
 	 */
-	public function test_get_prev_chr() {
+	public function test_get_previous_character() {
 		$html  = '<p><span>A</span><span id="foo">new hope.</span></p><p><span id="bar">The empire</span> strikes back.</p<';
 		$doc   = $this->load_html( $html );
 		$xpath = new \DOMXPath( $doc );
 
 		$textnodes = $xpath->query( "//*[@id='foo']/text()" ); // really only one.
-		$prev_char = DOM::get_prev_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_previous_character( $textnodes->item( 0 ) );
 		$this->assertSame( 'A', $prev_char );
 
 		$textnodes = $xpath->query( "//*[@id='bar']/text()" ); // really only one.
-		$prev_char = DOM::get_prev_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_previous_character( $textnodes->item( 0 ) );
 		$this->assertSame( '', $prev_char );
 	}
 
 	/**
-	 * Test get_prev_chr when the textnode is preceeded by <br>.
+	 * Test get_previous_character when the textnode is preceeded by <br>.
 	 *
-	 * @covers ::get_prev_chr
+	 * @covers ::get_previous_character
 	 * @covers ::get_adjacent_character
 	 * @covers ::get_previous_acceptable_node
 	 * @covers ::get_adjacent_node
@@ -310,17 +310,17 @@ class DOM_Test extends Testcase {
 	 * @uses ::get_edge_node
 	 * @uses PHP_Typography\Strings::functions
 	 */
-	public function test_get_prev_chr_with_br() {
+	public function test_get_previous_character_with_br() {
 		$html  = '<p><span>A</span><br><span id="foo">new hope.</span></p><p><br><span id="bar">The empire</span> strikes back.</p<';
 		$doc   = $this->load_html( $html );
 		$xpath = new \DOMXPath( $doc );
 
 		$textnodes = $xpath->query( "//*[@id='foo']/text()" ); // really only one.
-		$prev_char = DOM::get_prev_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_previous_character( $textnodes->item( 0 ) );
 		$this->assertSame( ' ', $prev_char );
 
 		$textnodes = $xpath->query( "//*[@id='bar']/text()" ); // really only one.
-		$prev_char = DOM::get_prev_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_previous_character( $textnodes->item( 0 ) );
 		$this->assertSame( ' ', $prev_char );
 	}
 
@@ -344,9 +344,9 @@ class DOM_Test extends Testcase {
 	}
 
 	/**
-	 * Test get_next_chr.
+	 * Test get_next_character.
 	 *
-	 * @covers ::get_next_chr
+	 * @covers ::get_next_character
 	 * @covers ::get_adjacent_character
 	 * @covers ::get_next_acceptable_node
 	 * @covers ::get_adjacent_node
@@ -356,24 +356,24 @@ class DOM_Test extends Testcase {
 	 * @uses ::get_edge_node
 	 * @uses PHP_Typography\Strings::functions
 	 */
-	public function test_get_next_chr() {
+	public function test_get_next_character() {
 		$html  = '<p><span id="foo">A</span><span id="bar">new hope.</span></p><p><span>The empire</span> strikes back.</p<';
 		$doc   = $this->load_html( $html );
 		$xpath = new \DOMXPath( $doc );
 
 		$textnodes = $xpath->query( "//*[@id='foo']/text()" ); // really only one.
-		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_next_character( $textnodes->item( 0 ) );
 		$this->assertSame( 'n', $prev_char );
 
 		$textnodes = $xpath->query( "//*[@id='bar']/text()" ); // really only one.
-		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_next_character( $textnodes->item( 0 ) );
 		$this->assertSame( '', $prev_char );
 	}
 
 	/**
-	 * Test get_next_chr followed by <br>.
+	 * Test get_next_character followed by <br>.
 	 *
-	 * @covers ::get_next_chr
+	 * @covers ::get_next_character
 	 * @covers ::get_adjacent_character
 	 * @covers ::get_next_acceptable_node
 	 * @covers ::get_adjacent_node
@@ -383,24 +383,24 @@ class DOM_Test extends Testcase {
 	 * @uses ::get_edge_node
 	 * @uses PHP_Typography\Strings::functions
 	 */
-	public function test_get_next_chr_with_br() {
+	public function test_get_next_character_with_br() {
 		$html  = '<p><span id="foo">A</span><span id="bar"><br>new hope.</span><br></p><p><span>The empire</span> strikes back.</p<';
 		$doc   = $this->load_html( $html );
 		$xpath = new \DOMXPath( $doc );
 
 		$textnodes = $xpath->query( "//*[@id='foo']/text()" ); // really only one.
-		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_next_character( $textnodes->item( 0 ) );
 		$this->assertSame( ' ', $prev_char );
 
 		$textnodes = $xpath->query( "//*[@id='bar']/text()" ); // really only one.
-		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_next_character( $textnodes->item( 0 ) );
 		$this->assertSame( ' ', $prev_char );
 	}
 
 	/**
-	 * Test get_next_chr followed by <br>.
+	 * Test get_next_character followed by <br>.
 	 *
-	 * @covers ::get_next_chr
+	 * @covers ::get_next_character
 	 * @covers ::get_adjacent_character
 	 * @covers ::get_next_acceptable_node
 	 * @covers ::get_adjacent_node
@@ -410,17 +410,17 @@ class DOM_Test extends Testcase {
 	 * @uses ::get_edge_node
 	 * @uses PHP_Typography\Strings::functions
 	 */
-	public function test_get_next_chr_with_sub_sup() {
+	public function test_get_next_character_with_sub_sup() {
 		$html  = '<p><span id="foo">A</span><span id="bar"><sup>new</sup> hope.</span><sub>x</sub></p><p><span>The empire</span> strikes back.</p<';
 		$doc   = $this->load_html( $html );
 		$xpath = new \DOMXPath( $doc );
 
 		$textnodes = $xpath->query( "//*[@id='foo']/text()" ); // really only one.
-		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_next_character( $textnodes->item( 0 ) );
 		$this->assertSame( '', $prev_char );
 
 		$textnodes = $xpath->query( "//*[@id='bar']/text()" ); // really only one.
-		$prev_char = DOM::get_next_chr( $textnodes->item( 0 ) );
+		$prev_char = DOM::get_next_character( $textnodes->item( 0 ) );
 		$this->assertSame( '', $prev_char );
 	}
 


### PR DESCRIPTION
- Removes unused or obsolete methods from class `PHP_Typography\DOM`:
  * `::get_block_parent_name`
  * `::get_previous_textnode`
  * `::get_next_textnode`
  * `::get_last_textnode`
- Adds type declarations to all methods.
- Renames `::get_prev_chr` to `::get_previous_character`.
- Renames `::get_next_chr` to `::get_next_character`.
- Cleans up private methods.