### PR TITLE
Refactor `Hyphenator` and its dependancies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "phpstan/phpstan": "^1.9",
         "phpbench/phpbench": "^0.17||^1.0@dev",
+        "mikey179/vfsstream": "~1",
         "mundschenk-at/phpunit-cross-version": "dev-master",
         "phpstan/phpstan-mockery": "^1.1",
         "phpstan/extension-installer": "^1.2"

--- a/src/class-hyphenator.php
+++ b/src/class-hyphenator.php
@@ -48,9 +48,9 @@ class Hyphenator {
 	/**
 	 * The hyphenation patterns, stored in a trie for easier searching.
 	 *
-	 * @var Trie_Node|null
+	 * @var ?Trie_Node
 	 */
-	protected $pattern_trie;
+	protected ?Trie_Node $pattern_trie;
 
 	/**
 	 * The hyphenation exceptions from the pattern file.
@@ -58,7 +58,7 @@ class Hyphenator {
 	 *
 	 * @var array<string,string>
 	 */
-	protected $pattern_exceptions = [];
+	protected array $pattern_exceptions = [];
 
 	/**
 	 * Custom hyphenation exceptions set by the user.
@@ -66,45 +66,43 @@ class Hyphenator {
 	 *
 	 * @var array<string,string>
 	 */
-	protected $custom_exceptions;
+	protected array $custom_exceptions;
 
 	/**
 	 * A binary hash of $custom_exceptions array.
 	 *
 	 * @var string
 	 */
-	protected $custom_exceptions_hash;
+	protected string $custom_exceptions_hash;
 
 	/**
 	 * Patterns calculated from the merged hyphenation exceptions.
 	 *
 	 * @var ?array<string,int[]|null>
 	 */
-	protected $merged_exception_patterns;
+	protected ?array $merged_exception_patterns;
 
 	/**
 	 * The current hyphenation language.
 	 * Stored in the short form (e.g. "en-US").
 	 *
-	 * @var string|null
+	 * @var ?string
 	 */
-	protected $language;
+	protected ?string $language;
 
 	/**
 	 * Constructs new Hyphenator instance.
 	 *
-	 * @param string|null $language   Optional. Short-form language name. Default null.
-	 * @param string[]    $exceptions Optional. Custom hyphenation exceptions. Default empty array.
+	 * @param ?string  $language   Optional. Short-form language name. Default null.
+	 * @param string[] $exceptions Optional. Custom hyphenation exceptions. Default empty array.
 	 */
-	public function __construct( $language = null, array $exceptions = [] ) {
+	public function __construct( ?string $language = null, array $exceptions = [] ) {
 
 		if ( ! empty( $language ) ) {
 			$this->set_language( $language );
 		}
 
-		if ( ! empty( $exceptions ) ) {
-			$this->set_custom_exceptions( $exceptions );
-		}
+		$this->set_custom_exceptions( $exceptions );
 	}
 
 	/**
@@ -113,13 +111,9 @@ class Hyphenator {
 	 * @param array<string,string> $exceptions Optional. An array of words with all hyphenation points marked with a hard hyphen. Default empty array.
 	 */
 	public function set_custom_exceptions( array $exceptions = [] ): void {
-		if ( empty( $exceptions ) && empty( $this->custom_exceptions ) ) {
-			return; // Nothing to do at all.
-		}
-
 		// Calculate hash & check against previous exceptions.
 		$new_hash = self::get_object_hash( $exceptions );
-		if ( $this->custom_exceptions_hash === $new_hash ) {
+		if ( isset( $this->custom_exceptions_hash ) && $this->custom_exceptions_hash === $new_hash ) {
 			return; // No need to update exceptions.
 		}
 
@@ -158,7 +152,7 @@ class Hyphenator {
 	 *
 	 * @return string
 	 */
-	protected static function get_object_hash( $data ) {
+	protected static function get_object_hash( $data ): string {
 		return \md5( (string) \json_encode( $data ), false );
 	}
 
@@ -169,7 +163,7 @@ class Hyphenator {
 	 *
 	 * @return bool Whether loading the pattern file was successful.
 	 */
-	public function set_language( $lang = 'en-US' ) {
+	public function set_language( string $lang = 'en-US' ): bool {
 		if ( isset( $this->language ) && $this->language === $lang ) {
 			return true; // Bail out, no need to do anything.
 		}
@@ -218,7 +212,7 @@ class Hyphenator {
 	 *
 	 * @return Token[] The modified text tokens.
 	 */
-	public function hyphenate( array $parsed_text_tokens, $hyphen = '-', $hyphenate_title_case = false, $min_length = 2, $min_before = 2, $min_after = 2 ) {
+	public function hyphenate( array $parsed_text_tokens, string $hyphen = '-', bool $hyphenate_title_case = false, int $min_length = 2, int $min_before = 2, int $min_after = 2 ): array {
 		if ( empty( $min_length ) || empty( $min_before ) || ! isset( $this->pattern_trie ) ) {
 			return $parsed_text_tokens;
 		}
@@ -247,7 +241,7 @@ class Hyphenator {
 	 *
 	 * @return string
 	 */
-	protected function hyphenate_word( $word, $hyphen, $hyphenate_title_case, $min_length, $min_before, $min_after ) {
+	protected function hyphenate_word( string $word, string $hyphen, bool $hyphenate_title_case, int $min_length, int $min_before, int $min_after ): string {
 		// Quickly reference string functions according to encoding.
 		$f = Strings::functions( $word );
 
@@ -299,7 +293,7 @@ class Hyphenator {
 	 *
 	 * @return int[] The hyphenation pattern.
 	 */
-	protected function lookup_word_pattern( $key, callable $strlen, callable $str_split ) {
+	protected function lookup_word_pattern( string $key, callable $strlen, callable $str_split ): array {
 		if ( null === $this->pattern_trie ) {
 			return []; // abort early.
 		}
@@ -380,13 +374,13 @@ class Hyphenator {
 	/**
 	 * Generates a hyphenation pattern from an exception.
 	 *
-	 * @param string $exception A hyphenation exception in the form "foo-bar". Needs to be encoded in ASCII or UTF-8.
+	 * @param  string $exception A hyphenation exception in the form "foo-bar". Needs to be encoded in ASCII or UTF-8.
 	 *
 	 * @return int[]|null Returns the hyphenation pattern or null if `$exception` is using an invalid encoding.
 	 *
 	 * @throws Invalid_Encoding_Exception Throws an exception if an unsupported encoding is used.
 	 */
-	protected static function convert_hyphenation_exception_to_pattern( $exception ) {
+	protected static function convert_hyphenation_exception_to_pattern( $exception ): ?array {
 		$f = Strings::functions( $exception );
 
 		// Set the word_pattern - this method keeps any contextually important capitalization.
@@ -414,7 +408,7 @@ class Hyphenator {
 	 *
 	 * @return bool true if $number is odd, false if it is even.
 	 */
-	protected static function is_odd( $number ) {
+	protected static function is_odd( int $number ): bool {
 		return (bool) ( $number % 2 );
 	}
 }

--- a/src/class-hyphenator.php
+++ b/src/class-hyphenator.php
@@ -93,15 +93,11 @@ class Hyphenator {
 	/**
 	 * Constructs new Hyphenator instance.
 	 *
-	 * @param ?string  $language   Optional. Short-form language name. Default null.
+	 * @param string   $language   Optional. Short-form language name. Default null.
 	 * @param string[] $exceptions Optional. Custom hyphenation exceptions. Default empty array.
 	 */
-	public function __construct( ?string $language = null, array $exceptions = [] ) {
-
-		if ( ! empty( $language ) ) {
-			$this->set_language( $language );
-		}
-
+	public function __construct( string $language, array $exceptions ) {
+		$this->set_language( $language );
 		$this->set_custom_exceptions( $exceptions );
 	}
 
@@ -159,11 +155,13 @@ class Hyphenator {
 	/**
 	 * Sets the hyphenation pattern language.
 	 *
-	 * @param string $lang Optional. Has to correspond to a filename in 'lang'. Default 'en-US'.
+	 * @since  7.0.0 Parameter `$lang` is no longer optional.
+	 *
+	 * @param  string $lang Has to correspond to a filename in 'lang'.
 	 *
 	 * @return bool Whether loading the pattern file was successful.
 	 */
-	public function set_language( string $lang = 'en-US' ): bool {
+	public function set_language( string $lang ): bool {
 		if ( isset( $this->language ) && $this->language === $lang ) {
 			return true; // Bail out, no need to do anything.
 		}
@@ -203,16 +201,22 @@ class Hyphenator {
 	/**
 	 * Hyphenates parsed text tokens.
 	 *
+	 * @since 7.0.0 All Parameters are now mandatory.
+	 *
 	 * @param Token[] $parsed_text_tokens   An array of text tokens.
-	 * @param string  $hyphen               Optional. The hyphen character. Default '-'.
-	 * @param bool    $hyphenate_title_case Optional. Whether words in Title Case should be hyphenated. Default false.
-	 * @param int     $min_length           Optional. Minimum word length for hyphenation. Default 2.
-	 * @param int     $min_before           Optional. Minimum number of characters before a hyphenation point. Default 2.
-	 * @param int     $min_after            Optional. Minimum number of characters after a hyphenation point. Default 2.
+	 * @param string  $hyphen               The hyphen character to use.
+	 * @param bool    $hyphenate_title_case Whether words in Title Case should be hyphenated.
+	 * @param int     $min_length           Minimum word length for hyphenation.
+	 * @param int     $min_before           Minimum number of characters before a hyphenation point.
+	 * @param int     $min_after            Minimum number of characters after a hyphenation point.
 	 *
 	 * @return Token[] The modified text tokens.
+	 *
+	 * @phpstan-param int<2,max> $min_length
+	 * @phpstan-param positive-int $min_before
+	 * @phpstan-param positive-int $min_after
 	 */
-	public function hyphenate( array $parsed_text_tokens, string $hyphen = '-', bool $hyphenate_title_case = false, int $min_length = 2, int $min_before = 2, int $min_after = 2 ): array {
+	public function hyphenate( array $parsed_text_tokens, string $hyphen, bool $hyphenate_title_case, int $min_length, int $min_before, int $min_after ): array {
 		if ( empty( $min_length ) || empty( $min_before ) || ! isset( $this->pattern_trie ) ) {
 			return $parsed_text_tokens;
 		}

--- a/src/class-hyphenator.php
+++ b/src/class-hyphenator.php
@@ -28,6 +28,10 @@
 namespace PHP_Typography;
 
 use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
+use PHP_Typography\Exceptions\Invalid_File_Exception;
+use PHP_Typography\Exceptions\Invalid_Hyphenation_Pattern_File_Exception;
+use PHP_Typography\Exceptions\Invalid_JSON_Exception;
+
 use PHP_Typography\Hyphenator\Trie_Node;
 use PHP_Typography\Text_Parser\Token;
 
@@ -42,6 +46,8 @@ use PHP_Typography\Text_Parser\Token;
  * @author Peter Putzer <github@mundschenk.at>
  *
  * @since 3.4.0
+ *
+ * @phpstan-type Pattern_File array{ patterns: array<string,string>, exceptions: array<string,string> }
  */
 class Hyphenator {
 
@@ -159,44 +165,72 @@ class Hyphenator {
 	 *
 	 * @param  string $lang Has to correspond to a filename in 'lang'.
 	 *
-	 * @return bool Whether loading the pattern file was successful.
+	 * @return void
+	 *
+	 * @throws \RuntimeException Throws an exception when the language file cannot be read correctly.
 	 */
-	public function set_language( string $lang ): bool {
+	public function set_language( string $lang ): void {
 		if ( isset( $this->language ) && $this->language === $lang ) {
-			return true; // Bail out, no need to do anything.
+			return; // Bail out, no need to do anything.
 		}
 
-		$success            = false;
-		$language_file_name = __DIR__ . '/lang/' . $lang . '.json';
+		try {
+			$pattern_file = $this->read_patterns_from_file( __DIR__ . '/lang/' . $lang . '.json' );
 
-		if ( \file_exists( $language_file_name ) ) {
-			$raw_language_file = \file_get_contents( $language_file_name );
-
-			if ( false !== $raw_language_file ) {
-				$language_file = \json_decode( $raw_language_file, true );
-
-				if ( false !== $language_file ) {
-					$this->language           = $lang;
-					$this->pattern_trie       = Trie_Node::build_trie( $language_file['patterns'] );
-					$this->pattern_exceptions = $language_file['exceptions'] ?? [];
-
-					$success = true;
-				}
-			}
-		}
-
-		// Clean up.
-		if ( ! $success ) {
-			$this->language           = null;
+			$this->pattern_trie       = Trie_Node::build_trie( $pattern_file['patterns'] );
+			$this->pattern_exceptions = $pattern_file['exceptions'];
+			$this->language           = $lang;
+		} catch ( \RuntimeException $e ) {
+			// Clean up object state.
 			$this->pattern_trie       = null;
 			$this->pattern_exceptions = [];
+			$this->language           = null;
+
+			throw $e;
+		} finally {
+			// Make sure hyphenationExceptions is not set to force remerging of patgen and custom exceptions.
+			$this->merged_exception_patterns = null;
 		}
-
-		// Make sure hyphenationExceptions is not set to force remerging of patgen and custom exceptions.
-		$this->merged_exception_patterns = null;
-
-		return $success;
 	}
+
+	/**
+	 * Reads the hyphenation patterns and exceptions from a given pattern file and builds the
+	 * corresponding trie and exceptions array.
+	 *
+	 * @since  7.0.0
+	 *
+	 * @param  string $file The full path to the pattern file.
+	 *
+	 * @return Pattern_File
+	 *
+	 * @throws Invalid_File_Exception Throws an exception if the pattern file cannot be read.
+	 * @throws Invalid_JSON_Exception Throws an exception if the pattern file cannot decoded.
+	 * @throws Invalid_Hyphenation_Pattern_File_Exception Throws an exception if the pattern file is structurally invalid.
+	 */
+	protected function read_patterns_from_file( string $file ): array {
+		$pattern_file = @\file_get_contents( $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- return value is checked.
+
+		if ( false !== $pattern_file ) {
+			$pattern_file = \json_decode( $pattern_file, true );
+
+			if ( null !== $pattern_file ) {
+				if ( ! isset( $pattern_file['patterns'] ) || ! \is_array( $pattern_file['patterns'] ) ) {
+					throw new Invalid_Hyphenation_Pattern_File_Exception( "Invalid pattern file {$file}" );
+				}
+
+				if ( ! isset( $pattern_file['exceptions'] ) || ! \is_array( $pattern_file['exceptions'] ) ) {
+					$pattern_file['exceptions'] = [];
+				}
+
+				return $pattern_file;
+			} else {
+				throw new Invalid_JSON_Exception( "Error decoding JSON from language file {$file}" );
+			}
+		} else {
+			throw new Invalid_File_Exception( "Could not open language file {$file}" );
+		}
+	}
+
 
 	/**
 	 * Hyphenates parsed text tokens.

--- a/src/exceptions/class-invalid-file-exception.php
+++ b/src/exceptions/class-invalid-file-exception.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ *  This file is part of PHP-Typography.
+ *
+ *  Copyright 2024 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/php-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace PHP_Typography\Exceptions;
+
+/**
+ * An invalid filename or path was given.
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ *
+ * @since 7.0.0
+ */
+class Invalid_File_Exception extends \UnexpectedValueException {
+}

--- a/src/exceptions/class-invalid-hyphenation-pattern-file-exception.php
+++ b/src/exceptions/class-invalid-hyphenation-pattern-file-exception.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ *  This file is part of PHP-Typography.
+ *
+ *  Copyright 2024 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/php-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace PHP_Typography\Exceptions;
+
+/**
+ * A hyphenation pattern file has an invalid structure.
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ *
+ * @since 7.0.0
+ */
+class Invalid_Hyphenation_Pattern_File_Exception extends \RuntimeException {
+}

--- a/src/exceptions/class-invalid-json-exception.php
+++ b/src/exceptions/class-invalid-json-exception.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ *  This file is part of PHP-Typography.
+ *
+ *  Copyright 2024 Peter Putzer.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ *  ***
+ *
+ *  @package mundschenk-at/php-typography
+ *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace PHP_Typography\Exceptions;
+
+/**
+ * An invalid JSON string was given.
+ *
+ * @author Peter Putzer <github@mundschenk.at>
+ *
+ * @since 7.0.0
+ */
+class Invalid_JSON_Exception extends \UnexpectedValueException {
+}

--- a/src/hyphenator/class-cache.php
+++ b/src/hyphenator/class-cache.php
@@ -42,21 +42,21 @@ class Cache {
 	 *
 	 * @var array<string,Hyphenator>
 	 */
-	protected $cache = [];
+	protected array $cache = [];
 
 	/**
 	 * A flag that indicated that the cache has changed since creation/deserialization.
 	 *
 	 * @var bool
 	 */
-	protected $changed = false;
+	protected bool $changed = false;
 
 	/**
 	 * Ignore the "changed" flag during serialization.
 	 *
 	 * @return string[]
 	 */
-	public function __sleep() {
+	public function __sleep(): array {
 		return [
 			'cache',
 		];
@@ -68,7 +68,7 @@ class Cache {
 	 * @param string     $lang       A language code.
 	 * @param Hyphenator $hyphenator The object to cache.
 	 */
-	public function set_hyphenator( $lang, Hyphenator $hyphenator ): void {
+	public function set_hyphenator( string $lang, Hyphenator $hyphenator ): void {
 		$this->cache[ $lang ] = $hyphenator;
 		$this->changed        = true;
 	}
@@ -78,9 +78,9 @@ class Cache {
 	 *
 	 * @param string $lang A language code.
 	 *
-	 * @return Hyphenator|null
+	 * @return ?Hyphenator
 	 */
-	public function get_hyphenator( $lang ) {
+	public function get_hyphenator( string $lang ): ?Hyphenator {
 		if ( isset( $this->cache[ $lang ] ) ) {
 			return $this->cache[ $lang ];
 		}
@@ -94,7 +94,7 @@ class Cache {
 	 *
 	 * @return bool
 	 */
-	public function has_changed() {
+	public function has_changed(): bool {
 		return $this->changed;
 	}
 }

--- a/src/hyphenator/class-trie-node.php
+++ b/src/hyphenator/class-trie-node.php
@@ -26,8 +26,6 @@
 
 namespace PHP_Typography\Hyphenator;
 
-use PHP_Typography\Strings;
-
 /**
  * A hyphenation pattern trie node.
  *
@@ -45,7 +43,7 @@ final class Trie_Node {
 	 *
 	 * @var array<int,int[]>
 	 */
-	private $offsets = [];
+	private array $offsets = [];
 
 	/**
 	 * Linked trie nodes.
@@ -54,7 +52,7 @@ final class Trie_Node {
 	 *      @type Trie_Node $char The next node in the given character path.
 	 * }
 	 */
-	private $links = [];
+	private array $links = [];
 
 	/**
 	 * Create new Trie_Node.
@@ -69,7 +67,7 @@ final class Trie_Node {
 	 *
 	 * @return Trie_Node
 	 */
-	public function get_node( $char ) {
+	public function get_node( string $char ): Trie_Node {
 		if ( ! isset( $this->links[ $char ] ) ) {
 			$this->links[ $char ] = new Trie_Node();
 		}
@@ -84,7 +82,7 @@ final class Trie_Node {
 	 *
 	 * @return bool
 	 */
-	public function exists( $char ) {
+	public function exists( string $char ): bool {
 		return ! empty( $this->links[ $char ] );
 	}
 
@@ -93,7 +91,7 @@ final class Trie_Node {
 	 *
 	 * @return array<int,int[]>
 	 */
-	public function offsets() {
+	public function offsets(): array {
 		return $this->offsets;
 	}
 
@@ -104,7 +102,7 @@ final class Trie_Node {
 	 *
 	 * @return Trie_Node The starting node of the trie.
 	 */
-	public static function build_trie( array $patterns ) {
+	public static function build_trie( array $patterns ): Trie_Node {
 		$trie = new Trie_Node();
 
 		foreach ( $patterns as $key => $pattern ) {

--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -24,6 +24,7 @@
 
 namespace PHP_Typography\Tests;
 
+use PHP_Typography\Hyphenator;
 use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 
 /**
@@ -32,13 +33,18 @@ use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
  * @coversDefaultClass \PHP_Typography\Hyphenator
  * @usesDefaultClass \PHP_Typography\Hyphenator
  *
- * @uses PHP_Typography\Hyphenator
+ * @uses ::__construct
+ * @uses ::get_object_hash
+ * @uses ::is_odd
+ * @uses ::set_custom_exceptions
+ * @uses ::set_language
+ * @uses PHP_Typography\Hyphenator\Trie_Node
  */
 class Hyphenator_Test extends Testcase {
 	/**
 	 * Hyphenator fixture.
 	 *
-	 * @var \PHP_Typography\Hyphenator
+	 * @var Hyphenator
 	 */
 	protected $h;
 
@@ -49,7 +55,7 @@ class Hyphenator_Test extends Testcase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->h = new \PHP_Typography\Hyphenator();
+		$this->h = new Hyphenator( 'en-US', [] );
 	}
 
 	/**
@@ -57,20 +63,14 @@ class Hyphenator_Test extends Testcase {
 	 *
 	 * @covers ::__construct
 	 *
+	 * @uses ::get_object_hash
+	 * @uses ::set_custom_exceptions
 	 * @uses PHP_Typography\Strings::functions
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::__construct
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
 	 */
 	public function test_constructor() {
-		$h = $this->h;
-
-		$this->assertNotNull( $h );
-		$this->assertInstanceOf( '\PHP_Typography\Hyphenator', $h );
-
-		$h2 = new \PHP_Typography\Hyphenator( 'en-US', [ 'foo-bar' ] );
+		$h2 = new Hyphenator( 'en-US', [ 'foo-bar' ] );
 		$this->assertNotNull( $h2 );
-		$this->assertInstanceOf( '\PHP_Typography\Hyphenator', $h2 );
+		$this->assertInstanceOf( Hyphenator::class, $h2 );
 		$this->assert_attribute_same( 'en-US', 'language', $h2 );
 		$this->assert_attribute_count( 1, 'custom_exceptions', $h2 );
 	}
@@ -79,10 +79,6 @@ class Hyphenator_Test extends Testcase {
 	 * Tests set_language.
 	 *
 	 * @covers ::set_language
-	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::__construct
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
 	 */
 	public function test_set_language() {
 		$h = $this->h;
@@ -108,11 +104,8 @@ class Hyphenator_Test extends Testcase {
 	 *
 	 * @covers ::set_language
 	 *
-	 * @uses ::set_custom_exceptions
 	 * @uses ::merge_hyphenation_exceptions
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::__construct
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
+	 * @uses ::convert_hyphenation_exception_to_pattern
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_set_language_with_custom_exceptions() {
@@ -123,6 +116,7 @@ class Hyphenator_Test extends Testcase {
 				'KINGdesk' => 'KING-desk',
 			]
 		);
+
 		$h->set_language( 'en-US' );
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
 		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
@@ -137,10 +131,6 @@ class Hyphenator_Test extends Testcase {
 	 * Tests set_language.
 	 *
 	 * @covers ::set_language
-	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::__construct
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
 	 */
 	public function test_set_same_hyphenation_language() {
 		$h = $this->h;
@@ -210,9 +200,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::set_custom_exceptions
 	 *
 	 * @uses ::merge_hyphenation_exceptions
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::__construct
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::build_trie
-	 * @uses PHP_Typography\Hyphenator\Trie_Node::get_node
+	 * @uses ::convert_hyphenation_exception_to_pattern
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_set_custom_exceptions_again() {
@@ -275,7 +263,8 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node
+	 * @uses ::convert_hyphenation_exception_to_pattern
+	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 *
@@ -317,7 +306,8 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node
+	 * @uses ::convert_hyphenation_exception_to_pattern
+	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 *
@@ -344,7 +334,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node
+	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 */
@@ -368,7 +358,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node
+	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 */
@@ -387,7 +377,6 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 */
@@ -404,7 +393,6 @@ class Hyphenator_Test extends Testcase {
 	 *
 	 * @covers ::lookup_word_pattern
 	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 */
@@ -424,7 +412,8 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node
+	 * @uses ::convert_hyphenation_exception_to_pattern
+	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 */
@@ -445,7 +434,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node
+	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 */
@@ -453,7 +442,7 @@ class Hyphenator_Test extends Testcase {
 		$this->h->set_language( 'en-US' );
 
 		// Unset some internal stuff.
-		$ref  = new \ReflectionClass( '\PHP_Typography\Hyphenator' );
+		$ref  = new \ReflectionClass( Hyphenator::class );
 		$prop = $ref->getProperty( 'pattern_exceptions' );
 		$prop->setAccessible( true );
 		$prop->setValue( $this->h, [] );
@@ -499,7 +488,7 @@ class Hyphenator_Test extends Testcase {
 	 *
 	 * @covers ::merge_hyphenation_exceptions
 	 *
-	 * @uses PHP_Typography\Hyphenator\Trie_Node
+	 * @uses ::convert_hyphenation_exception_to_pattern
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_merge_hyphenation_exceptions() {
@@ -561,9 +550,9 @@ class Hyphenator_Test extends Testcase {
 	 */
 	public function test_is_odd( $number, $result ) {
 		if ( $result ) {
-			$this->assertTrue( $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'is_odd', [ $number ] ) );
+			$this->assertTrue( $this->invoke_static_method( Hyphenator::class, 'is_odd', [ $number ] ) );
 		} else {
-			$this->assertFalse( $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'is_odd', [ $number ] ) );
+			$this->assertFalse( $this->invoke_static_method( Hyphenator::class, 'is_odd', [ $number ] ) );
 		}
 	}
 
@@ -573,11 +562,11 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::get_object_hash
 	 */
 	public function test_get_object_hash() {
-		$hash1 = $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'get_object_hash', [ 666 ] );
+		$hash1 = $this->invoke_static_method( Hyphenator::class, 'get_object_hash', [ 666 ] );
 		$this->assert_is_string( $hash1 );
 		$this->assertGreaterThan( 0, strlen( $hash1 ) );
 
-		$hash2 = $this->invoke_static_method( \PHP_Typography\Hyphenator::class, 'get_object_hash', [ new \stdClass() ] );
+		$hash2 = $this->invoke_static_method( Hyphenator::class, 'get_object_hash', [ new \stdClass() ] );
 		$this->assert_is_string( $hash2 );
 		$this->assertGreaterThan( 0, strlen( $hash2 ) );
 

--- a/tests/class-hyphenator-test.php
+++ b/tests/class-hyphenator-test.php
@@ -27,6 +27,10 @@ namespace PHP_Typography\Tests;
 use PHP_Typography\Hyphenator;
 use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 
+use org\bovigo\vfs\vfsStream;
+
+use Mockery as m;
+
 /**
  * Test Hyphenator class.
  *
@@ -44,7 +48,7 @@ class Hyphenator_Test extends Testcase {
 	/**
 	 * Hyphenator fixture.
 	 *
-	 * @var Hyphenator
+	 * @var Hyphenator&m::MockInterface
 	 */
 	protected $h;
 
@@ -55,7 +59,22 @@ class Hyphenator_Test extends Testcase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->h = new Hyphenator( 'en-US', [] );
+		// Set up virtual filesystem.
+		vfsStream::setup(
+			'root',
+			null,
+			[
+				'lang' => [
+					'missing_patterns.json'   => '{ "exceptions": [] }',
+					'invalid_patterns.json'   => '{ "patterns": "foo", "exceptions": [] }',
+					'missing_exceptions.json' => '{ "patterns": [] }',
+					'invalid_exceptions.json' => '{ "patterns": [], "exceptions": "foo" }',
+					'invalid.json'            => 'This is not a JSON file',
+				],
+			]
+		);
+
+		$this->h = m::mock( Hyphenator::class )->shouldAllowMockingProtectedMethods()->makePartial();
 	}
 
 	/**
@@ -68,11 +87,14 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_constructor() {
-		$h2 = new Hyphenator( 'en-US', [ 'foo-bar' ] );
-		$this->assertNotNull( $h2 );
-		$this->assertInstanceOf( Hyphenator::class, $h2 );
-		$this->assert_attribute_same( 'en-US', 'language', $h2 );
-		$this->assert_attribute_count( 1, 'custom_exceptions', $h2 );
+		$lang       = 'en-US';
+		$exceptions = [ 'foo-bar' ];
+		$h          = m::mock( Hyphenator::class )->shouldAllowMockingProtectedMethods()->makePartial();
+
+		$h->shouldReceive( 'set_language' )->once()->with( $lang );
+		$h->shouldReceive( 'set_custom_exceptions' )->once()->with( $exceptions );
+
+		$this->assertNull( $h->__construct( $lang, $exceptions ) );
 	}
 
 	/**
@@ -80,69 +102,216 @@ class Hyphenator_Test extends Testcase {
 	 *
 	 * @covers ::set_language
 	 */
-	public function test_set_language() {
+	public function test_set_language_success() {
+		$language     = 'language_code';
+		$pattern_file = [
+			'patterns'   => [
+				'_ach' => '00004',
+			],
+			'exceptions' => [
+				'associate' => 'as-so-ciate',
+			],
+		];
+
 		$h = $this->h;
-		$h->set_language( 'en-US' );
-		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty English-US pattern array' );
+		$h->shouldReceive( 'read_patterns_from_file' )->once()->with( m::pattern( "#/lang/$language\.json\$#" ) )->andReturn( $pattern_file );
+
+		$h->set_language( $language );
+
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
+		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
+	}
+
+	/**
+	 * Tests set_language.
+	 *
+	 * @covers ::set_language
+	 */
+	public function test_set_language_exception() {
+		$language = 'invalid_language_code';
+
+		$h = $this->h;
+		$h->shouldReceive( 'read_patterns_from_file' )->once()->with( m::pattern( "#/lang/$language\.json\$#" ) )->andThrow( \RuntimeException::class );
+
+		$this->expect_exception( \RuntimeException::class );
+
+		$h->set_language( $language );
+
+		$this->assert_attribute_empty( 'pattern_trie', $h, 'Pattern array should be empty' );
+		$this->assert_attribute_empty( 'pattern_exceptions', $h, 'Pattern exceptions array should be empty' );
+	}
+
+	/**
+	 * Tests set_language.
+	 *
+	 * @covers ::set_language
+	 */
+	public function test_set_language_called_twice() {
+		$language     = 'another_language_code';
+		$pattern_file = [
+			'patterns'   => [
+				'_ach' => '00004',
+			],
+			'exceptions' => [
+				'associate' => 'as-so-ciate',
+			],
+		];
+
+		// First call.
+		$h = $this->h;
+		$this->h->shouldReceive( 'read_patterns_from_file' )->once()->with( m::pattern( "#/lang/$language\.json\$#" ) )->andReturn( $pattern_file );
+
+		$h->set_language( $language );
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
 		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
 
-		$h->set_language( 'foobar' );
-		$this->assert_attribute_empty( 'pattern_trie', $h );
-		$this->assert_attribute_empty( 'pattern_exceptions', $h );
+		// Second call.
+		$this->h->shouldReceive( 'read_patterns_from_file' )->never();
 
-		$h->set_language( 'no' );
-		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty Norwegian pattern array' );
-		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' ); // Norwegian has exceptions.
-
-		$h->set_language( 'de' );
-		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty German pattern array' );
-		$this->assert_attribute_empty( 'pattern_exceptions', $h, 'Unexpected pattern exceptions found' ); // no exceptions in the German pattern file.
+		$h->set_language( $language );
+		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
+		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
 	}
 
 	/**
-	 * Tests set_language.
+	 * Provides data for testing set_language.
 	 *
-	 * @covers ::set_language
-	 *
-	 * @uses ::merge_hyphenation_exceptions
-	 * @uses ::convert_hyphenation_exception_to_pattern
-	 * @uses PHP_Typography\Strings::functions
+	 * @return array
 	 */
-	public function test_set_language_with_custom_exceptions() {
-		$h = $this->h;
+	public function provide_read_patterns_from_file_data(): array {
+		$prefix = \dirname( __DIR__ ) . '/src/lang';
 
-		$h->set_custom_exceptions(
+		return \array_map(
+			function ( array $a ) use ( $prefix ): array {
+				return [ "$prefix/$a[0].json", $a[1] ];
+			},
 			[
-				'KINGdesk' => 'KING-desk',
+				[ 'en-US', true ],
+				[ 'no', true ],
+				[ 'de', false ],
 			]
 		);
-
-		$h->set_language( 'en-US' );
-		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
-		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
-		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
-
-		$h->set_language( 'de' );
-		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
-		$this->assert_attribute_empty( 'pattern_exceptions', $h, 'Unexpected pattern exceptions found' ); // no exceptions in the German pattern file.
 	}
 
 	/**
-	 * Tests set_language.
+	 * Tests read_patterns_from_file.
 	 *
-	 * @covers ::set_language
+	 * @covers ::read_patterns_from_file
+	 *
+	 * @dataProvider provide_read_patterns_from_file_data
+	 *
+	 * @param  string $file              The pattern file.
+	 * @param  bool   $expect_exceptions Whether to expect pattern exceptions.
+	 *
+	 * @return void
 	 */
-	public function test_set_same_hyphenation_language() {
-		$h = $this->h;
+	public function test_read_patterns_from_file( string $file, bool $expect_exceptions ) {
+		$result = $this->h->read_patterns_from_file( $file );
 
-		$h->set_language( 'en-US' );
-		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
-		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
+		$this->assertArrayHasKey( 'patterns', $result );
+		$this->assertGreaterThan( 0, count( $result ), 'No hyphenation patterns found.' );
 
-		$h->set_language( 'en-US' );
-		$this->assert_attribute_not_empty( 'pattern_trie', $h, 'Empty pattern array' );
-		$this->assert_attribute_not_empty( 'pattern_exceptions', $h, 'Empty pattern exceptions array' );
+		$this->assertArrayHasKey( 'exceptions', $result );
+		$this->assertIsArray( $result['exceptions'] );
+		if ( $expect_exceptions ) {
+			$this->assertGreaterThan( 0, count( $result['exceptions'] ), 'No pattern exceptions found.' );
+		}
 	}
+
+	/**
+	 * Tests read_patterns_from_file with an invalid JSON.
+	 *
+	 * @covers ::read_patterns_from_file
+	 *
+	 * @return void
+	 */
+	public function test_read_patterns_from_file_invalid_json() {
+		$this->expect_exception_message_matches( '/^Error decoding JSON from language file/' );
+
+		$result = $this->h->read_patterns_from_file( vfsStream::url( 'root/lang/invalid.json' ) );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests read_patterns_from_file with a missing patterns array.
+	 *
+	 * @covers ::read_patterns_from_file
+	 *
+	 * @return void
+	 */
+	public function test_read_patterns_from_file_missing_patterns() {
+		$this->expect_exception_message_matches( '/^Invalid pattern file/' );
+
+		$result = $this->h->read_patterns_from_file( vfsStream::url( 'root/lang/missing_patterns.json' ) );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests read_patterns_from_file with a missing patterns array.
+	 *
+	 * @covers ::read_patterns_from_file
+	 *
+	 * @return void
+	 */
+	public function test_read_patterns_from_file_invalid_patterns() {
+		$this->expect_exception_message_matches( '/^Invalid pattern file/' );
+
+		$result = $this->h->read_patterns_from_file( vfsStream::url( 'root/lang/invalid_patterns.json' ) );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests read_patterns_from_file with a missing exceptions array.
+	 *
+	 * @covers ::read_patterns_from_file
+	 *
+	 * @return void
+	 */
+	public function test_read_patterns_from_file_missing_exceptions() {
+		$result = $this->h->read_patterns_from_file( vfsStream::url( 'root/lang/missing_exceptions.json' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'patterns', $result );
+		$this->assertIsArray( $result['patterns'] );
+		$this->assertArrayHasKey( 'exceptions', $result );
+		$this->assertIsArray( $result['exceptions'] );
+	}
+
+	/**
+	 * Tests read_patterns_from_file with a missing exceptions array.
+	 *
+	 * @covers ::read_patterns_from_file
+	 *
+	 * @return void
+	 */
+	public function test_read_patterns_from_file_invalid_exceptions() {
+		$result = $this->h->read_patterns_from_file( vfsStream::url( 'root/lang/invalid_exceptions.json' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'patterns', $result );
+		$this->assertIsArray( $result['patterns'] );
+		$this->assertArrayHasKey( 'exceptions', $result );
+		$this->assertIsArray( $result['exceptions'] );
+	}
+
+	/**
+	 * Tests read_patterns_from_file with a missing patterns array.
+	 *
+	 * @covers ::read_patterns_from_file
+	 *
+	 * @return void
+	 */
+	public function test_read_patterns_from_file_invalid_filename() {
+		$this->expect_exception_message_matches( '/^Could not open language file/' );
+
+		$result = $this->h->read_patterns_from_file( vfsStream::url( 'root/lang/non_existing.json' ) );
+
+		$this->assertNull( $result );
+	}
+
 
 	/**
 	 * Provides data for testing set_custom_exceptions.
@@ -204,17 +373,30 @@ class Hyphenator_Test extends Testcase {
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_set_custom_exceptions_again() {
-		$h          = $this->h;
-		$exceptions = [ 'Hu-go', 'Fö-ba-ß' ];
-		$h->set_custom_exceptions( $exceptions );
-		$h->set_language( 'de' ); // German has no pattern exceptions.
+		$language     = 'language_code';
+		$pattern_file = [
+			'patterns'   => [],
+			'exceptions' => [],
+		];
+
+		// Set initial custom exceptions.
+		$h = $this->h;
+		$h->set_custom_exceptions( [ 'Hu-go', 'Fö-ba-ß' ] );
+
+		$h->shouldReceive( 'read_patterns_from_file' )->once()->with( m::pattern( "#/lang/$language\.json\$#" ) )->andReturn( $pattern_file );
+		$h->set_language( $language ); // No pattern exceptions.
+
+		// Force update of merged exception patterns.
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
 		$this->assert_attribute_not_empty( 'merged_exception_patterns', $h );
 
-		$exceptions = [ 'Hu-go' ];
-		$h->set_custom_exceptions( $exceptions );
+		// Set a different set of custom exceptions.
+		$h->set_custom_exceptions( [ 'Hu-go' ] );
+
+		// Assert that the merged exception patterns are reset.
 		$this->assert_attribute_empty( 'merged_exception_patterns', $h );
 
+		// Assert the content of the custom exceptions.
 		$this->assert_attribute_contains_only( 'string', 'custom_exceptions', $h );
 		$this->assert_attribute_contains( 'hu-go', 'custom_exceptions', $h );
 		$this->assert_attribute_count( 1, 'custom_exceptions', $h );
@@ -263,6 +445,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
+	 * @uses ::read_patterns_from_file
 	 * @uses ::convert_hyphenation_exception_to_pattern
 	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
@@ -306,6 +489,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
+	 * @uses ::read_patterns_from_file
 	 * @uses ::convert_hyphenation_exception_to_pattern
 	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
@@ -334,6 +518,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
+	 * @uses ::read_patterns_from_file
 	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
@@ -358,6 +543,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
+	 * @uses ::read_patterns_from_file
 	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
@@ -377,6 +563,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
+	 * @uses ::read_patterns_from_file
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
 	 */
@@ -412,6 +599,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
+	 * @uses ::read_patterns_from_file
 	 * @uses ::convert_hyphenation_exception_to_pattern
 	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
@@ -434,6 +622,7 @@ class Hyphenator_Test extends Testcase {
 	 * @covers ::hyphenate_word
 	 * @covers ::lookup_word_pattern
 	 *
+	 * @uses ::read_patterns_from_file
 	 * @uses ::merge_hyphenation_exceptions
 	 * @uses PHP_Typography\Text_Parser\Token
 	 * @uses PHP_Typography\Strings::functions
@@ -488,11 +677,18 @@ class Hyphenator_Test extends Testcase {
 	 *
 	 * @covers ::merge_hyphenation_exceptions
 	 *
+	 * @uses ::read_patterns_from_file
 	 * @uses ::convert_hyphenation_exception_to_pattern
 	 * @uses PHP_Typography\Strings::functions
 	 */
 	public function test_merge_hyphenation_exceptions() {
-		$h = $this->h;
+		$h            = $this->h;
+		$language     = 'fake_language';
+		$pattern_file = [
+			'patterns'   => [],
+			'exceptions' => [ \mb_convert_encoding( 'Fö-ba-ß', 'ISO-8859-2' ) ],
+		];
+
 		$h->set_custom_exceptions( [ 'Hu-go', 'Fä-vi-ken' ] );
 
 		$h->set_language( 'en-US' ); // w/ pattern exceptions.
@@ -509,6 +705,15 @@ class Hyphenator_Test extends Testcase {
 		$this->assert_attribute_array_has_key( 'hugo', 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_has_key( 'fäviken', 'merged_exception_patterns', $h );
 
+		// Simulate a pattern file with invalid encoding in pattern exceptions.
+		$h->shouldReceive( 'read_patterns_from_file' )->once()->with( m::pattern( "#/lang/$language\.json\$#" ) )->andReturn( $pattern_file );
+		$h->set_language( $language ); // No pattern exceptions.
+		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
+		$this->assert_attribute_count( 2, 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_key( 'hugo', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_has_key( 'fäviken', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_not_has_key( 'föbaß', 'merged_exception_patterns', $h );
+
 		$h->set_language( 'en-US' ); // w/ pattern exceptions.
 		$h->set_custom_exceptions( [] );
 		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
@@ -521,6 +726,15 @@ class Hyphenator_Test extends Testcase {
 		$this->assert_attribute_count( 0, 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_not_has_key( 'hugo', 'merged_exception_patterns', $h );
 		$this->assert_attribute_array_not_has_key( 'fäviken', 'merged_exception_patterns', $h );
+
+		// Simulate a pattern file with invalid encoding in pattern exceptions.
+		$h->shouldReceive( 'read_patterns_from_file' )->once()->with( m::pattern( "#/lang/$language\.json\$#" ) )->andReturn( $pattern_file );
+		$h->set_language( $language ); // No pattern exceptions.
+		$this->invoke_method( $h, 'merge_hyphenation_exceptions', [] );
+		$this->assert_attribute_count( 0, 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_not_has_key( 'hugo', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_not_has_key( 'fäviken', 'merged_exception_patterns', $h );
+		$this->assert_attribute_array_not_has_key( 'föbaß', 'merged_exception_patterns', $h );
 	}
 
 	/**

--- a/tests/fixes/token-fixes/class-hyphenate-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-fix-test.php
@@ -169,6 +169,7 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 	 * @covers ::get_hyphenator()
 	 *
 	 * @uses PHP_Typography\Hyphenator::__construct
+	 * @uses PHP_Typography\Hyphenator::read_patterns_from_file
 	 * @uses PHP_Typography\Hyphenator::set_custom_exceptions
 	 * @uses PHP_Typography\Hyphenator::set_language
 	 * @uses PHP_Typography\Hyphenator::get_object_hash

--- a/tests/hyphenator/class-cache-test.php
+++ b/tests/hyphenator/class-cache-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2016-2020 Peter Putzer.
+ *  Copyright 2016-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,6 +26,8 @@ namespace PHP_Typography\Tests\Hyphenator;
 
 use PHP_Typography\Tests\Testcase;
 
+use PHP_Typography\Hyphenator\Cache;
+
 /**
  * Test Hyphenator\Cache class.
  *
@@ -38,7 +40,7 @@ class Cache_Test extends Testcase {
 	/**
 	 * Hyphenator\Cache fixture.
 	 *
-	 * @var \PHP_Typography\Hyphenator\Cache|null
+	 * @var Cache|null
 	 */
 	protected $c;
 
@@ -49,7 +51,7 @@ class Cache_Test extends Testcase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->c = new \PHP_Typography\Hyphenator\Cache();
+		$this->c = new Cache();
 	}
 
 	/**
@@ -67,7 +69,7 @@ class Cache_Test extends Testcase {
 		$this->assertTrue( $this->c->has_changed() );
 
 		$new_c = unserialize( serialize( $this->c ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize,WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
-		$this->assertInstanceOf( \PHP_Typography\Hyphenator\Cache::class, $new_c );
+		$this->assertInstanceOf( Cache::class, $new_c );
 		$this->assertInstanceOf( \PHP_Typography\Hyphenator::class, $new_c->get_hyphenator( 'de' ) );
 		$this->assertFalse( $new_c->has_changed() );
 	}
@@ -77,9 +79,11 @@ class Cache_Test extends Testcase {
 	 *
 	 * @covers ::set_hyphenator
 	 * @covers ::get_hyphenator
+	 *
+	 * @uses PHP_Typography\Hyphenator\Trie_Node
 	 */
 	public function test_hyphenator_cache() {
-		$hyphenator = new \PHP_Typography\Hyphenator();
+		$hyphenator = new \PHP_Typography\Hyphenator( 'en-US', [] );
 
 		$this->assertSame( null, $this->c->get_hyphenator( 'de' ) );
 		$this->c->set_hyphenator( 'de', $hyphenator );


### PR DESCRIPTION
- Removes unnecessary default values from methods.
- Adds type declarations.
- Extracts new method `::read_patterns_from_file` method.