### PR TITLE
Refactor Settings

### DIFF
--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -40,9 +40,49 @@ use PHP_Typography\Settings\Quotes;
  * @since 4.0.0
  * @since 6.5.0 The protected property $no_break_narrow_space has been deprecated.
  * @since 7.0.0 Deprecated properties and methods relating to $no_break_narrow_space have been removed.
- *              The deprecated method array_map_assoc has been removed.
+ *              The deprecated method array_map_assoc has been removed. Most setter methods have been
+ *              virtualized via `__call`.
  *
  * @implements \ArrayAccess<string,mixed>
+ *
+ * @method void set_ignore_parser_errors( bool $on = false ) Enable lenient parser error handling (HTML is "best guess" if enabled).
+ * @method void set_parser_errors_handler( callable $handler = null ) Sets an optional handler for parser errors. The callable takes an array of error strings as its parameter. Invalid callbacks will be silently ignored.
+ * @method void set_classes_to_ignore( string[] $classes = ['vcard','noTypo'] )  Sets classes for which the typography of their children will be left untouched.
+ * @method void set_ids_to_ignore( string[] $ids = [] ) Sets IDs for which the typography of their children will be left untouched.
+ * @method void set_smart_quotes( bool $on = true ) Enables/disables typographic quotes.
+ * @method void set_smart_dashes( bool $on = true ) Enables/disables replacement of "a--a" with En Dash " -- " and "---" with Em Dash.
+ * @method void set_smart_ellipses( bool $on = true ) Enables/disables replacement of "..." with "…".
+ * @method void set_smart_diacritics( bool $on = true ) Enables/disables replacement "creme brulee" with "crème brûlée".
+ * @method void set_smart_marks( bool $on = true ) Enables/disables replacement of (r) (c) (tm) (sm) (p) (R) (C) (TM) (SM) (P) with ® © ™ ℠ ℗.
+ * @method void set_smart_math( bool $on = true ) Enables/disables proper mathematical symbols.
+ * @method void set_smart_exponents( bool $on = true ) Enables/disables replacement of 2^2 with 2<sup>2</sup>.
+ * @method void set_smart_fractions( bool $on = true ) Enables/disables replacement of 1/4 with <sup>1</sup>&#8260;<sub>4</sub>.
+ * @method void set_smart_ordinal_suffix( bool $on = true ) Enables/disables replacement of 1st with 1<sup>st</sup>.
+ * @method void set_smart_ordinal_suffix_match_roman_numerals( bool $on = false ) Enables/disables replacement of XXe with XX<sup>e</sup>.
+ * @method void set_smart_area_units( bool $on = true ) Enables/disables replacement of m2 with m³ and m3 with m³.
+ * @method void set_single_character_word_spacing( bool $on = true ) Enables/disables forcing single character words to next line with the insertion of &nbsp;.
+ * @method void set_fraction_spacing( bool $on = true ) Enables/disables fraction spacing.
+ * @method void set_unit_spacing( bool $on = true ) Enables/disables keeping units and values together with the insertion of &nbsp;.
+ * @method void set_numbered_abbreviation_spacing( bool $on = true ) Enables/disables numbered abbreviations like "ISO 9000" together with the insertion of &nbsp;.
+ * @method void set_french_punctuation_spacing( bool $on = false ) Enables/disables extra whitespace before certain punction marks, as is the French custom.
+ * @method void set_dash_spacing( bool $on = true ) Enables/disables wrapping of Em and En dashes are in thin spaces.
+ * @method void set_space_collapse( bool $on = true ) Enables/disables removal of extra whitespace characters.
+ * @method void set_dewidow( bool $on = true ) Enables/disables widow handling.
+ * @method void set_wrap_hard_hyphens( bool $on = true ) Enables/disables wrapping at internal hard hyphens with the insertion of a zero-width-space.
+ * @method void set_url_wrap( bool $on = true ) Enables/disables wrapping of urls.
+ * @method void set_email_wrap( bool $on = true ) Enables/disables wrapping of email addresses.
+ * @method void set_style_ampersands( bool $on = true ) Enables/disables wrapping of ampersands in <span class="amp">.
+ * @method void set_style_caps( bool $on = true ) Enables/disables wrapping caps in <span class="caps">.
+ * @method void set_style_initial_quotes( bool $on = true ) Enables/disables wrapping of initial quotes in <span class="quo"> or <span class="dquo">.
+ * @method void set_style_numbers( bool $on = true ) Enables/disables wrapping of numbers in <span class="numbers">.
+ * @method void set_style_hanging_punctuation( bool $on = true ) Enables/disables wrapping of punctuation and wide characters in <span class="pull-*">.
+ * @method void set_hyphenation( bool $on = true ) Enables/disables hyphenation.
+ * @method void set_hyphenation_language( string $lang = 'en-US' ) Sets the hyphenation pattern language.
+ * @method void set_hyphenate_headings( bool $on = true ) Enables/disables hyphenation of titles and headings.
+ * @method void set_hyphenate_all_caps( bool $on = true ) Enables/disables hyphenation of words set completely in capital letters.
+ * @method void set_hyphenate_title_case( bool $on = true ) Enables/disables hyphenation of words starting with a capital letter.
+ * @method void set_hyphenate_compounds( bool $on = true ) Enables/disables hyphenation of compound words (e.g. "editor-in-chief").
+ * @method void set_hyphenation_exceptions( array $exceptions = [] ) Sets custom word hyphenations. Takes an array of words with all hyphenation points marked with a hard hyphen.
  */
 class Settings implements \ArrayAccess, \JsonSerializable {
 
@@ -164,6 +204,246 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 */
 	protected $remapped_characters;
 
+	protected const VIRTUAL_PROPERTIES = [
+		[
+			'property' => self::PARSER_ERRORS_IGNORE,
+			'name'     => 'ignore_parser_errors',
+			'default'  => false,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::PARSER_ERRORS_HANDLER,
+			'name'     => 'parser_errors_handler',
+			'default'  => null,
+			'verify'   => 'is_callable',
+		],
+		[
+			'property' => self::IGNORE_CLASSES,
+			'name'     => 'classes_to_ignore',
+			'default'  => [ 'vcard', 'noTypo' ],
+			'verify'   => 'is_array',
+		],
+		[
+			'property' => self::IGNORE_IDS,
+			'name'     => 'ids_to_ignore',
+			'default'  => [],
+			'verify'   => 'is_array',
+		],
+		[
+			'property' => self::SMART_QUOTES,
+			'name'     => 'smart_quotes',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_DASHES,
+			'name'     => 'smart_dashes',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_ELLIPSES,
+			'name'     => 'smart_ellipses',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_DIACRITICS,
+			'name'     => 'smart_diacritics',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_MARKS,
+			'name'     => 'smart_marks',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_MATH,
+			'name'     => 'smart_math',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_EXPONENTS,
+			'name'     => 'smart_exponents',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_FRACTIONS,
+			'name'     => 'smart_fractions',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_ORDINAL_SUFFIX,
+			'name'     => 'smart_ordinal_suffix',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_ORDINAL_SUFFIX_ROMAN_NUMERALS,
+			'name'     => 'smart_ordinal_suffix_match_roman_numerals',
+			'default'  => false,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SMART_AREA_UNITS,
+			'name'     => 'smart_area_units',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SINGLE_CHARACTER_WORD_SPACING,
+			'name'     => 'single_character_word_spacing',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::FRACTION_SPACING,
+			'name'     => 'fraction_spacing',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::UNIT_SPACING,
+			'name'     => 'unit_spacing',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::NUMBERED_ABBREVIATION_SPACING,
+			'name'     => 'numbered_abbreviation_spacing',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::FRENCH_PUNCTUATION_SPACING,
+			'name'     => 'french_punctuation_spacing',
+			'default'  => false,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::DASH_SPACING,
+			'name'     => 'dash_spacing',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::SPACE_COLLAPSE,
+			'name'     => 'space_collapse',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::DEWIDOW,
+			'name'     => 'dewidow',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::HYPHEN_HARD_WRAP,
+			'name'     => 'wrap_hard_hyphens',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::URL_WRAP,
+			'name'     => 'url_wrap',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::EMAIL_WRAP,
+			'name'     => 'email_wrap',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::STYLE_AMPERSANDS,
+			'name'     => 'style_ampersands',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::STYLE_CAPS,
+			'name'     => 'style_caps',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::STYLE_INITIAL_QUOTES,
+			'name'     => 'style_initial_quotes',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::STYLE_NUMBERS,
+			'name'     => 'style_numbers',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::STYLE_HANGING_PUNCTUATION,
+			'name'     => 'style_hanging_punctuation',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::HYPHENATION,
+			'name'     => 'hyphenation',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::HYPHENATION_LANGUAGE,
+			'name'     => 'hyphenation_language',
+			'default'  => 'en-US',
+			'verify'   => 'is_string',
+		],
+		[
+			'property' => self::HYPHENATE_HEADINGS,
+			'name'     => 'hyphenate_headings',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::HYPHENATE_ALL_CAPS,
+			'name'     => 'hyphenate_all_caps',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::HYPHENATE_TITLE_CASE,
+			'name'     => 'hyphenate_title_case',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::HYPHENATE_COMPOUNDS,
+			'name'     => 'hyphenate_compounds',
+			'default'  => true,
+			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::HYPHENATION_CUSTOM_EXCEPTIONS,
+			'name'     => 'hyphenation_exceptions',
+			'default'  => [],
+			'verify'   => 'is_array',
+		],
+	];
+
+	/**
+	 * An index of virtual method names to properties.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @var array<string,mixed>
+	 */
+	protected array $virtual_setters = [];
+
 	/**
 	 * Sets up a new Settings object.
 	 *
@@ -178,12 +458,41 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 * @param string[] $mapping      Optional. Unicode characters to remap. The default maps the narrow no-break space to the normal NO-BREAK SPACE and the apostrophe to the RIGHT SINGLE QUOTATION MARK.
 	 */
 	public function __construct( bool $set_defaults = true, array $mapping = [ U::NO_BREAK_NARROW_SPACE => U::NO_BREAK_SPACE, U::APOSTROPHE => U::SINGLE_QUOTE_CLOSE ] ) { // phpcs:ignore WordPress.Arrays.ArrayDeclarationSpacing
+		// Set up virtualized set_* methods.
+		foreach ( self::VIRTUAL_PROPERTIES as $definition ) {
+			$this->virtual_setters[ "set_{$definition['name']}" ] = $definition;
+		}
+
 		if ( $set_defaults ) {
 			$this->set_defaults();
 		}
 
 		// Merge default character mapping with given mapping.
 		$this->unicode_mapping = $mapping;
+	}
+
+	/**
+	 * Provides virtual setter methods.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param  string  $name      The method name.
+	 * @param  mixed[] $arguments The method arguments.
+	 *
+	 * @return mixed
+	 *
+	 * @throws \TypeError Throws an error if a given argument is of an incorrect type.
+	 */
+	public function __call( string $name, array $arguments ) {
+		if ( isset( $this->virtual_setters[ $name ] ) ) {
+			$argument = isset( $arguments[0] ) ? $arguments[0] : $this->virtual_setters[ $name ]['default'];
+
+			if ( ! $this->virtual_setters[ $name ]['verify']( $argument ) ) {
+				throw new \TypeError( "Argument for {$name} should be compatible with {$this->virtual_setters[ $name ]['verify']}." );
+			}
+
+			$this->data[ $this->virtual_setters[ $name ]['property'] ] = $argument;
+		}
 	}
 
 	/**
@@ -438,26 +747,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	}
 
 	/**
-	 * Enable lenient parser error handling (HTML is "best guess" if enabled).
-	 *
-	 * @param bool $on Optional. Default false.
-	 */
-	public function set_ignore_parser_errors( bool $on = false ): void {
-		$this->data[ self::PARSER_ERRORS_IGNORE ] = $on;
-	}
-
-	/**
-	 * Sets an optional handler for parser errors. Invalid callbacks will be silently ignored.
-	 *
-	 * @since 6.0.0. callable type is enforced via typehinting.
-	 *
-	 * @param callable|null $handler Optional. A callable that takes an array of error strings as its parameter. Default null.
-	 */
-	public function set_parser_errors_handler( callable $handler = null ): void {
-		$this->data[ self::PARSER_ERRORS_HANDLER ] = $handler;
-	}
-
-	/**
 	 * Sets tags for which the typography of their children will be left untouched.
 	 *
 	 * @since 7.0.0 The parameter $tags can now only be passed as an array.
@@ -469,37 +758,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		$tags = array_filter( array_map( 'strtolower', $tags ), 'ctype_alnum' );
 
 		$this->data[ self::IGNORE_TAGS ] = array_unique( array_merge( $tags, array_flip( DOM::inappropriate_tags() ) ) );
-	}
-
-	/**
-	 * Sets classes for which the typography of their children will be left untouched.
-	 *
-	 * @since 7.0.0 The parameter $classes can now only be passed as an array.
-	 *
-	 * @param string[] $classes An array of HTML class names.
-	 */
-	public function set_classes_to_ignore( array $classes = [ 'vcard', 'noTypo' ] ): void {
-		$this->data[ self::IGNORE_CLASSES ] = $classes;
-	}
-
-	/**
-	 * Sets IDs for which the typography of their children will be left untouched.
-	 *
-	 * @since 7.0.0 The parameter $ids can now only be passed as an array.
-	 *
-	 * @param string[] $ids An array of HTML IDs.
-	 */
-	public function set_ids_to_ignore( array $ids = [] ): void {
-		$this->data[ self::IGNORE_IDS ] = $ids;
-	}
-
-	/**
-	 * Enables/disables typographic quotes.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_quotes( bool $on = true ): void {
-		$this->data[ self::SMART_QUOTES ] = $on;
 	}
 
 	/**
@@ -627,15 +885,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	}
 
 	/**
-	 * Enables/disables replacement of "a--a" with En Dash " -- " and "---" with Em Dash.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_dashes( bool $on = true ): void {
-		$this->data[ self::SMART_DASHES ] = $on;
-	}
-
-	/**
 	 * Sets the typographical conventions used by smart_dashes.
 	 *
 	 * Allowed values for $style:
@@ -648,24 +897,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 */
 	public function set_smart_dashes_style( $style = Dash_Style::TRADITIONAL_US ): void {
 		$this->dash_style = $this->get_style( $style, Dashes::class, [ Dash_Style::class, 'get_styled_dashes' ], 'dash' );
-	}
-
-	/**
-	 * Enables/disables replacement of "..." with "…".
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_ellipses( bool $on = true ): void {
-		$this->data[ self::SMART_ELLIPSES ] = $on;
-	}
-
-	/**
-	 * Enables/disables replacement "creme brulee" with "crème brûlée".
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_diacritics( bool $on = true ): void {
-		$this->data[ self::SMART_DIACRITICS ] = $on;
 	}
 
 	/**
@@ -776,118 +1007,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	}
 
 	/**
-	 * Enables/disables replacement of (r) (c) (tm) (sm) (p) (R) (C) (TM) (SM) (P) with ® © ™ ℠ ℗.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_marks( bool $on = true ): void {
-		$this->data[ self::SMART_MARKS ] = $on;
-	}
-
-	/**
-	 * Enables/disables proper mathematical symbols.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_math( bool $on = true ): void {
-		$this->data[ self::SMART_MATH ] = $on;
-	}
-
-	/**
-	 * Enables/disables replacement of 2^2 with 2<sup>2</sup>
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_exponents( bool $on = true ): void {
-		$this->data[ self::SMART_EXPONENTS ] = $on;
-	}
-
-	/**
-	 * Enables/disables replacement of 1/4 with <sup>1</sup>&#8260;<sub>4</sub>.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_fractions( bool $on = true ): void {
-		$this->data[ self::SMART_FRACTIONS ] = $on;
-	}
-
-	/**
-	 * Enables/disables replacement of 1st with 1<sup>st</sup>.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_ordinal_suffix( bool $on = true ): void {
-		$this->data[ self::SMART_ORDINAL_SUFFIX ] = $on;
-	}
-
-	/**
-	 * Enables/disables replacement of XXe with XX<sup>e</sup>.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @param bool $on Optional. Default false.
-	 */
-	public function set_smart_ordinal_suffix_match_roman_numerals( bool $on = false ): void {
-		$this->data[ self::SMART_ORDINAL_SUFFIX_ROMAN_NUMERALS ] = $on;
-	}
-
-	/**
-	 * Enables/disables replacement of m2 with m³ and m3 with m³.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_smart_area_units( bool $on = true ): void {
-		$this->data[ self::SMART_AREA_UNITS ] = $on;
-	}
-
-	/**
-	 * Enables/disables forcing single character words to next line with the insertion of &nbsp;.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_single_character_word_spacing( bool $on = true ): void {
-		$this->data[ self::SINGLE_CHARACTER_WORD_SPACING ] = $on;
-	}
-
-	/**
-	 * Enables/disables fraction spacing.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_fraction_spacing( bool $on = true ): void {
-		$this->data[ self::FRACTION_SPACING ] = $on;
-	}
-
-	/**
-	 * Enables/disables keeping units and values together with the insertion of &nbsp;.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_unit_spacing( bool $on = true ): void {
-		$this->data[ self::UNIT_SPACING ] = $on;
-	}
-
-	/**
-	 * Enables/disables numbered abbreviations like "ISO 9000" together with the insertion of &nbsp;.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_numbered_abbreviation_spacing( bool $on = true ): void {
-		$this->data[ self::NUMBERED_ABBREVIATION_SPACING ] = $on;
-	}
-
-	/**
-	 * Enables/disables extra whitespace before certain punction marks, as is the French custom.
-	 *
-	 * @since 6.0.0 The default value is now `false`.`
-	 *
-	 * @param bool $on Optional. Default false.
-	 */
-	public function set_french_punctuation_spacing( bool $on = false ): void {
-		$this->data[ self::FRENCH_PUNCTUATION_SPACING ] = $on;
-	}
-
-	/**
 	 * Sets the list of units to keep together with their values.
 	 *
 	 * @since 7.0.0 The parameter $units can now only be passed as an array.
@@ -918,33 +1037,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		$custom_units .= ! empty( $custom_units ) ? '|' : '';
 
 		return $custom_units;
-	}
-
-	/**
-	 * Enables/disables wrapping of Em and En dashes are in thin spaces.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_dash_spacing( bool $on = true ): void {
-		$this->data[ self::DASH_SPACING ] = $on;
-	}
-
-	/**
-	 * Enables/disables removal of extra whitespace characters.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_space_collapse( $on = true ): void {
-		$this->data[ self::SPACE_COLLAPSE ] = $on;
-	}
-
-	/**
-	 * Enables/disables widow handling.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_dewidow( bool $on = true ): void {
-		$this->data[ self::DEWIDOW ] = $on;
 	}
 
 	/**
@@ -981,33 +1073,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	}
 
 	/**
-	 * Enables/disables wrapping at internal hard hyphens with the insertion of a zero-width-space.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_wrap_hard_hyphens( $on = true ): void {
-		$this->data[ self::HYPHEN_HARD_WRAP ] = $on;
-	}
-
-	/**
-	 * Enables/disables wrapping of urls.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_url_wrap( bool $on = true ): void {
-		$this->data[ self::URL_WRAP ] = $on;
-	}
-
-	/**
-	 * Enables/disables wrapping of email addresses.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_email_wrap( bool $on = true ): void {
-		$this->data[ self::EMAIL_WRAP ] = $on;
-	}
-
-	/**
 	 * Sets the minimum character requirement after an URL wrapping point.
 	 *
 	 * @param int $length Defaults to 5. Trying to set the value to less than 1 resets the length to the default.
@@ -1016,51 +1081,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		$length = ( $length > 0 ) ? $length : 5;
 
 		$this->data[ self::URL_MIN_AFTER_WRAP ] = $length;
-	}
-
-	/**
-	 * Enables/disables wrapping of ampersands in <span class="amp">.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_style_ampersands( bool $on = true ): void {
-		$this->data[ self::STYLE_AMPERSANDS ] = $on;
-	}
-
-	/**
-	 * Enables/disables wrapping caps in <span class="caps">.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_style_caps( bool $on = true ): void {
-		$this->data[ self::STYLE_CAPS ] = $on;
-	}
-
-	/**
-	 * Enables/disables wrapping of initial quotes in <span class="quo"> or <span class="dquo">.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_style_initial_quotes( bool $on = true ): void {
-		$this->data[ self::STYLE_INITIAL_QUOTES ] = $on;
-	}
-
-	/**
-	 * Enables/disables wrapping of numbers in <span class="numbers">.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_style_numbers( bool $on = true ): void {
-		$this->data[ self::STYLE_NUMBERS ] = $on;
-	}
-
-	/**
-	 * Enables/disables wrapping of punctuation and wide characters in <span class="pull-*">.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_style_hanging_punctuation( bool $on = true ): void {
-		$this->data[ self::STYLE_HANGING_PUNCTUATION ] = $on;
 	}
 
 	/**
@@ -1073,28 +1093,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	public function set_initial_quote_tags( array $tags = [ 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'li', 'dd', 'dt' ] ): void {
 		// Store the tag array inverted (with the tagName as its index for faster lookup).
 		$this->data[ self::INITIAL_QUOTE_TAGS ] = \array_change_key_case( \array_flip( $tags ), \CASE_LOWER );
-	}
-
-	/**
-	 * Enables/disables hyphenation.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_hyphenation( bool $on = true ): void {
-		$this->data[ self::HYPHENATION ] = $on;
-	}
-
-	/**
-	 * Sets the hyphenation pattern language.
-	 *
-	 * @param string $lang Has to correspond to a filename in 'lang'. Optional. Default 'en-US'.
-	 */
-	public function set_hyphenation_language( string $lang = 'en-US' ): void {
-		if ( isset( $this->data[ self::HYPHENATION_LANGUAGE ] ) && $this->data[ self::HYPHENATION_LANGUAGE ] === $lang ) {
-			return; // Bail out, no need to do anything.
-		}
-
-		$this->data[ self::HYPHENATION_LANGUAGE ] = $lang;
 	}
 
 	/**
@@ -1128,54 +1126,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 		$length = ( $length > 0 ) ? $length : 2;
 
 		$this->data[ self::HYPHENATION_MIN_AFTER ] = $length;
-	}
-
-	/**
-	 * Enables/disables hyphenation of titles and headings.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_hyphenate_headings( $on = true ): void {
-		$this->data[ self::HYPHENATE_HEADINGS ] = $on;
-	}
-
-	/**
-	 * Enables/disables hyphenation of words set completely in capital letters.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_hyphenate_all_caps( bool $on = true ): void {
-		$this->data[ self::HYPHENATE_ALL_CAPS ] = $on;
-	}
-
-	/**
-	 * Enables/disables hyphenation of words starting with a capital letter.
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_hyphenate_title_case( bool $on = true ): void {
-		$this->data[ self::HYPHENATE_TITLE_CASE ] = $on;
-	}
-
-	/**
-	 * Enables/disables hyphenation of compound words (e.g. "editor-in-chief").
-	 *
-	 * @param bool $on Optional. Default true.
-	 */
-	public function set_hyphenate_compounds( bool $on = true ): void {
-		$this->data[ self::HYPHENATE_COMPOUNDS ] = $on;
-	}
-
-	/**
-	 * Sets custom word hyphenations.
-	 *
-	 * @since 7.0.0 The parameter $exceptions can now only be passed as an array.
-	 *
-	 * @param string[] $exceptions An array of words with all hyphenation points marked with a hard hyphen.
-	 *                             The default is an empty array.
-	 */
-	public function set_hyphenation_exceptions( array $exceptions = [] ): void {
-		$this->data[ self::HYPHENATION_CUSTOM_EXCEPTIONS ] = $exceptions;
 	}
 
 	/**

--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -27,6 +27,9 @@
 
 namespace PHP_Typography;
 
+use OutOfRangeException;
+use TypeError;
+
 use PHP_Typography\Settings\Dash_Style;
 use PHP_Typography\Settings\Dashes;
 use PHP_Typography\Settings\Quote_Style;
@@ -68,8 +71,12 @@ use PHP_Typography\Settings\Quotes;
  * @method void set_dash_spacing( bool $on = true ) Enables/disables wrapping of Em and En dashes are in thin spaces.
  * @method void set_space_collapse( bool $on = true ) Enables/disables removal of extra whitespace characters.
  * @method void set_dewidow( bool $on = true ) Enables/disables widow handling.
+ * @method void set_max_dewidow_length( int $length = 5 ) Sets the maximum length of widows that will be protected. The length cannot be less than 2.
+ * @method void set_dewidow_word_number( int $number = 1 ) Sets the maximum number of words considered for dewidowing. Only 1, 2 and 3 are valid arguments.
+ * @method void set_max_dewidow_pull( int $length = 5 ) Sets the maximum length of pulled text to keep widows company. The length cannot be less than 2.
  * @method void set_wrap_hard_hyphens( bool $on = true ) Enables/disables wrapping at internal hard hyphens with the insertion of a zero-width-space.
  * @method void set_url_wrap( bool $on = true ) Enables/disables wrapping of urls.
+ * @method void set_min_after_url_wrap( int $length = 5 ) Sets the minimum character requirement after an URL wrapping point. The length cannot be less than 1.
  * @method void set_email_wrap( bool $on = true ) Enables/disables wrapping of email addresses.
  * @method void set_style_ampersands( bool $on = true ) Enables/disables wrapping of ampersands in <span class="amp">.
  * @method void set_style_caps( bool $on = true ) Enables/disables wrapping caps in <span class="caps">.
@@ -78,6 +85,9 @@ use PHP_Typography\Settings\Quotes;
  * @method void set_style_hanging_punctuation( bool $on = true ) Enables/disables wrapping of punctuation and wide characters in <span class="pull-*">.
  * @method void set_hyphenation( bool $on = true ) Enables/disables hyphenation.
  * @method void set_hyphenation_language( string $lang = 'en-US' ) Sets the hyphenation pattern language.
+ * @method void set_min_length_hyphenation( int $length = 5 ) Sets the minimum length of a word that may be hyphenated. The length cannot be less than 2.
+ * @method void set_min_before_hyphenation( int $length = 3 ) Sets the minimum character requirement before a hyphenation point. The length cannot be less than 1.
+ * @method void set_min_after_hyphenation( int $length = 2 ) Sets the minimum character requirement after a hyphenation point. The length cannot be less than 1.
  * @method void set_hyphenate_headings( bool $on = true ) Enables/disables hyphenation of titles and headings.
  * @method void set_hyphenate_all_caps( bool $on = true ) Enables/disables hyphenation of words set completely in capital letters.
  * @method void set_hyphenate_title_case( bool $on = true ) Enables/disables hyphenation of words starting with a capital letter.
@@ -344,6 +354,28 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 			'verify'   => 'is_bool',
 		],
 		[
+			'property' => self::DEWIDOW_MAX_LENGTH,
+			'name'     => 'max_dewidow_length',
+			'default'  => 5,
+			'verify'   => 'is_int',
+			'min'      => 2,
+		],
+		[
+			'property' => self::DEWIDOW_WORD_NUMBER,
+			'name'     => 'dewidow_word_number',
+			'default'  => 1,
+			'verify'   => 'is_int',
+			'min'      => 1,
+			'max'      => 3,
+		],
+		[
+			'property' => self::DEWIDOW_MAX_PULL,
+			'name'     => 'max_dewidow_pull',
+			'default'  => 5,
+			'verify'   => 'is_int',
+			'min'      => 2,
+		],
+		[
 			'property' => self::HYPHEN_HARD_WRAP,
 			'name'     => 'wrap_hard_hyphens',
 			'default'  => true,
@@ -354,6 +386,13 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 			'name'     => 'url_wrap',
 			'default'  => true,
 			'verify'   => 'is_bool',
+		],
+		[
+			'property' => self::URL_MIN_AFTER_WRAP,
+			'name'     => 'min_after_url_wrap',
+			'default'  => 5,
+			'verify'   => 'is_int',
+			'min'      => 1,
 		],
 		[
 			'property' => self::EMAIL_WRAP,
@@ -402,6 +441,27 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 			'name'     => 'hyphenation_language',
 			'default'  => 'en-US',
 			'verify'   => 'is_string',
+		],
+		[
+			'property' => self::HYPHENATION_MIN_LENGTH,
+			'name'     => 'min_length_hyphenation',
+			'default'  => 5,
+			'verify'   => 'is_int',
+			'min'      => 2,
+		],
+		[
+			'property' => self::HYPHENATION_MIN_BEFORE,
+			'name'     => 'min_before_hyphenation',
+			'default'  => 3,
+			'verify'   => 'is_int',
+			'min'      => 1,
+		],
+		[
+			'property' => self::HYPHENATION_MIN_AFTER,
+			'name'     => 'min_after_hyphenation',
+			'default'  => 2,
+			'verify'   => 'is_int',
+			'min'      => 1,
 		],
 		[
 			'property' => self::HYPHENATE_HEADINGS,
@@ -481,17 +541,30 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	 *
 	 * @return mixed
 	 *
-	 * @throws \TypeError Throws an error if a given argument is of an incorrect type.
+	 * @throws TypeError Throws an error if a given argument is of an incorrect type.
+	 * @throws OutOfRangeException Throws an exception if a given integer argument is out of bounds.
 	 */
 	public function __call( string $name, array $arguments ) {
 		if ( isset( $this->virtual_setters[ $name ] ) ) {
-			$argument = isset( $arguments[0] ) ? $arguments[0] : $this->virtual_setters[ $name ]['default'];
+			$def   = $this->virtual_setters[ $name ];
+			$value = isset( $arguments[0] ) ? $arguments[0] : $def['default'];
 
-			if ( ! $this->virtual_setters[ $name ]['verify']( $argument ) ) {
-				throw new \TypeError( "Argument for {$name} should be compatible with {$this->virtual_setters[ $name ]['verify']}." );
+			// Check argument type.
+			if ( ! $def['verify']( $value ) ) {
+				throw new TypeError( "Argument for {$name} should be compatible with {$def['verify']}." );
 			}
 
-			$this->data[ $this->virtual_setters[ $name ]['property'] ] = $argument;
+			// Check argument lower bounds.
+			if ( isset( $def['min'] ) && $value < $def['min'] ) {
+				throw new OutOfRangeException( "Argument for {$name} should not be less than {$def['min']}, {$value} given." );
+			}
+
+			// Check argument upper bounds.
+			if ( isset( $def['max'] ) && $value > $def['max'] ) {
+				throw new OutOfRangeException( "Argument for {$name} should be no more than {$def['max']}, {$value} given." );
+			}
+
+			$this->data[ $def['property'] ] = $value;
 		}
 	}
 
@@ -1040,50 +1113,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	}
 
 	/**
-	 * Sets the maximum length of widows that will be protected.
-	 *
-	 * @param int $length Defaults to 5. Trying to set the value to less than 2 resets the length to the default.
-	 */
-	public function set_max_dewidow_length( int $length = 5 ): void {
-		$length = ( $length > 1 ) ? $length : 5;
-
-		$this->data[ self::DEWIDOW_MAX_LENGTH ] = $length;
-	}
-
-	/**
-	 * Sets the maximum number of words considered for dewidowing.
-	 *
-	 * @param int $number Defaults to 1. Only 1, 2 and 3 are valid.
-	 */
-	public function set_dewidow_word_number( int $number = 1 ): void {
-		$number = ( $number > 3 || $number < 1 ) ? 1 : $number;
-
-		$this->data[ self::DEWIDOW_WORD_NUMBER ] = $number;
-	}
-
-	/**
-	 * Sets the maximum length of pulled text to keep widows company.
-	 *
-	 * @param int $length Defaults to 5. Trying to set the value to less than 2 resets the length to the default.
-	 */
-	public function set_max_dewidow_pull( int $length = 5 ): void {
-		$length = ( $length > 1 ) ? $length : 5;
-
-		$this->data[ self::DEWIDOW_MAX_PULL ] = $length;
-	}
-
-	/**
-	 * Sets the minimum character requirement after an URL wrapping point.
-	 *
-	 * @param int $length Defaults to 5. Trying to set the value to less than 1 resets the length to the default.
-	 */
-	public function set_min_after_url_wrap( int $length = 5 ): void {
-		$length = ( $length > 0 ) ? $length : 5;
-
-		$this->data[ self::URL_MIN_AFTER_WRAP ] = $length;
-	}
-
-	/**
 	 * Sets the list of tags where initial quotes and guillemets should be styled.
 	 *
 	 * @since 7.0.0 The parameter $tags can now only be passed as an array.
@@ -1093,39 +1122,6 @@ class Settings implements \ArrayAccess, \JsonSerializable {
 	public function set_initial_quote_tags( array $tags = [ 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'li', 'dd', 'dt' ] ): void {
 		// Store the tag array inverted (with the tagName as its index for faster lookup).
 		$this->data[ self::INITIAL_QUOTE_TAGS ] = \array_change_key_case( \array_flip( $tags ), \CASE_LOWER );
-	}
-
-	/**
-	 * Sets the minimum length of a word that may be hyphenated.
-	 *
-	 * @param int $length Defaults to 5. Trying to set the value to less than 2 resets the length to the default.
-	 */
-	public function set_min_length_hyphenation( int $length = 5 ): void {
-		$length = ( $length > 1 ) ? $length : 5;
-
-		$this->data[ self::HYPHENATION_MIN_LENGTH ] = $length;
-	}
-
-	/**
-	 * Sets the minimum character requirement before a hyphenation point.
-	 *
-	 * @param int $length Defaults to 3. Trying to set the value to less than 1 resets the length to the default.
-	 */
-	public function set_min_before_hyphenation( $length = 3 ): void {
-		$length = ( $length > 0 ) ? $length : 3;
-
-		$this->data[ self::HYPHENATION_MIN_BEFORE ] = $length;
-	}
-
-	/**
-	 * Sets the minimum character requirement after a hyphenation point.
-	 *
-	 * @param int $length Defaults to 2. Trying to set the value to less than 1 resets the length to the default.
-	 */
-	public function set_min_after_hyphenation( int $length = 2 ): void {
-		$length = ( $length > 0 ) ? $length : 2;
-
-		$this->data[ self::HYPHENATION_MIN_AFTER ] = $length;
 	}
 
 	/**

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -289,7 +289,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_ignore_parser_errors.
 	 *
-	 * @covers ::set_ignore_parser_errors
+	 * @uses ::__call
 	 */
 	public function test_set_ignore_parser_errors() {
 		$s = $this->settings;
@@ -304,7 +304,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_parser_errors_handler.
 	 *
-	 * @covers ::set_parser_errors_handler
+	 * @uses ::__call
 	 */
 	public function test_set_parser_errors_handler() {
 		$s = $this->settings;
@@ -325,7 +325,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_parser_errors_handler with an invalid callback.
 	 *
-	 * @covers ::set_parser_errors_handler
+	 * @uses ::__call
 	 */
 	public function test_set_parser_errors_handler_invalid() {
 		$s = $this->settings;
@@ -383,7 +383,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_classes_to_ignore.
 	 *
-	 * @covers ::set_classes_to_ignore
+	 * @uses ::__call
 	 */
 	public function test_set_classes_to_ignore() {
 		$s = $this->settings;
@@ -396,7 +396,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_ids_to_ignore.
 	 *
-	 * @covers ::set_ids_to_ignore
+	 * @uses ::__call
 	 */
 	public function test_set_ids_to_ignore() {
 		$s = $this->settings;
@@ -409,7 +409,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_smart_quotes.
 	 *
-	 * @covers ::set_smart_quotes
+	 * @uses ::__call
 	 */
 	public function test_set_smart_quotes() {
 		$this->settings->set_smart_quotes( true );
@@ -594,7 +594,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Test set_smart_dashes.
 	 *
-	 * @covers ::set_smart_dashes
+	 * @uses ::__call
 	 */
 	public function test_set_smart_dashes() {
 		$this->settings->set_smart_dashes( true );
@@ -685,7 +685,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_smart_ellipses.
 	 *
-	 * @covers ::set_smart_ellipses
+	 * @uses ::__call
 	 */
 	public function test_set_smart_ellipses() {
 		$this->settings->set_smart_ellipses( true );
@@ -698,7 +698,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_smart_diacritics.
 	 *
-	 * @covers ::set_smart_diacritics
+	 * @uses ::__call
 	 */
 	public function test_set_smart_diacritics() {
 		$this->settings->set_smart_diacritics( true );
@@ -812,7 +812,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Test set_smart_marks.
 	 *
-	 * @covers ::set_smart_marks
+	 * @uses ::__call
 	 */
 	public function test_set_smart_marks() {
 		$this->settings->set_smart_marks( true );
@@ -825,7 +825,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Test set_smart_area_units.
 	 *
-	 * @covers ::set_smart_area_units
+	 * @uses ::__call
 	 */
 	public function test_set_smart_area_units() {
 		$this->settings->set_smart_area_units( true );
@@ -838,7 +838,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_smart_math.
 	 *
-	 * @covers ::set_smart_math
+	 * @uses ::__call
 	 */
 	public function test_set_smart_math() {
 		$this->settings->set_smart_math( true );
@@ -851,7 +851,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_smart_exponents.
 	 *
-	 * @covers ::set_smart_exponents
+	 * @uses ::__call
 	 */
 	public function test_set_smart_exponents() {
 		$this->settings->set_smart_exponents( true );
@@ -864,7 +864,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_smart_fractions.
 	 *
-	 * @covers ::set_smart_fractions
+	 * @uses ::__call
 	 */
 	public function test_set_smart_fractions() {
 		$this->settings->set_smart_fractions( true );
@@ -877,7 +877,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_smart_ordinal_suffix.
 	 *
-	 * @covers ::set_smart_ordinal_suffix
+	 * @uses ::__call
 	 */
 	public function test_set_smart_ordinal_suffix() {
 		$this->settings->set_smart_ordinal_suffix( true );
@@ -890,7 +890,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_smart_ordinal_suffix_match_roman_numerals.
 	 *
-	 * @covers ::set_smart_ordinal_suffix_match_roman_numerals
+	 * @uses ::__call
 	 */
 	public function test_set_smart_ordinal_suffix_match_roman_numerals() {
 		$this->settings->set_smart_ordinal_suffix_match_roman_numerals( true );
@@ -903,7 +903,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_single_character_word_spacing.
 	 *
-	 * @covers ::set_single_character_word_spacing
+	 * @uses ::__call
 	 */
 	public function test_set_single_character_word_spacing() {
 		$this->settings->set_single_character_word_spacing( true );
@@ -916,7 +916,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_fraction_spacing.
 	 *
-	 * @covers ::set_fraction_spacing
+	 * @uses ::__call
 	 */
 	public function test_set_fraction_spacing() {
 		$this->settings->set_fraction_spacing( true );
@@ -929,7 +929,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_unit_spacing.
 	 *
-	 * @covers ::set_unit_spacing
+	 * @uses ::__call
 	 */
 	public function test_set_unit_spacing() {
 		$this->settings->set_unit_spacing( true );
@@ -942,7 +942,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_numbered_abbreviation_spacing.
 	 *
-	 * @covers ::set_numbered_abbreviation_spacing
+	 * @uses ::__call
 	 */
 	public function test_set_numbered_abbreviation_spacing() {
 		$this->settings->set_numbered_abbreviation_spacing( true );
@@ -955,7 +955,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_french_punctuation_spacing.
 	 *
-	 * @covers ::set_french_punctuation_spacing
+	 * @uses ::__call
 	 */
 	public function test_set_french_punctuation_spacing() {
 		$this->settings->set_french_punctuation_spacing( true );
@@ -973,7 +973,7 @@ class Settings_Test extends Testcase {
 	 * @uses ::update_unit_pattern
 	 */
 	public function test_set_units() {
-		$units_as_array  = [ 'foo', 'bar', 'xx/yy' ];
+		$units_as_array = [ 'foo', 'bar', 'xx/yy' ];
 
 		$this->settings->set_units( $units_as_array );
 		foreach ( $units_as_array as $unit ) {
@@ -1023,7 +1023,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_dash_spacing.
 	 *
-	 * @covers ::set_dash_spacing
+	 * @uses ::__call
 	 */
 	public function test_set_dash_spacing() {
 		$this->settings->set_dash_spacing( true );
@@ -1036,7 +1036,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_space_collapse.
 	 *
-	 * @covers ::set_space_collapse
+	 * @uses ::__call
 	 */
 	public function test_set_space_collapse() {
 		$this->settings->set_space_collapse( true );
@@ -1049,7 +1049,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_dewidow.
 	 *
-	 * @covers ::set_dewidow
+	 * @uses ::__call
 	 */
 	public function test_set_dewidow() {
 		$this->settings->set_dewidow( true );
@@ -1116,7 +1116,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_wrap_hard_hyphens.
 	 *
-	 * @covers ::set_wrap_hard_hyphens
+	 * @uses ::__call
 	 */
 	public function test_set_wrap_hard_hyphens() {
 		$this->settings->set_wrap_hard_hyphens( true );
@@ -1129,7 +1129,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_url_wrap.
 	 *
-	 * @covers ::set_url_wrap
+	 * @uses ::__call
 	 */
 	public function test_set_url_wrap() {
 		$this->settings->set_url_wrap( true );
@@ -1142,7 +1142,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_email_wrap.
 	 *
-	 * @covers ::set_email_wrap
+	 * @uses ::__call
 	 */
 	public function test_set_email_wrap() {
 		$this->settings->set_email_wrap( true );
@@ -1171,7 +1171,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_style_ampersands.
 	 *
-	 * @covers ::set_style_ampersands
+	 * @uses ::__call
 	 */
 	public function test_set_style_ampersands() {
 		$this->settings->set_style_ampersands( true );
@@ -1184,7 +1184,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_style_caps.
 	 *
-	 * @covers ::set_style_caps
+	 * @uses ::__call
 	 */
 	public function test_set_style_caps() {
 		$this->settings->set_style_caps( true );
@@ -1197,7 +1197,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_style_initial_quotes.
 	 *
-	 * @covers ::set_style_initial_quotes
+	 * @uses ::__call
 	 */
 	public function test_set_style_initial_quotes() {
 		$this->settings->set_style_initial_quotes( true );
@@ -1210,7 +1210,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_style_numbers.
 	 *
-	 * @covers ::set_style_numbers
+	 * @uses ::__call
 	 */
 	public function test_set_style_numbers() {
 		$this->settings->set_style_numbers( true );
@@ -1223,7 +1223,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_style_hanging_punctuation.
 	 *
-	 * @covers ::set_style_hanging_punctuation
+	 * @uses ::__call
 	 */
 	public function test_set_style_hanging_punctuation() {
 		$this->settings->set_style_hanging_punctuation( true );
@@ -1239,7 +1239,7 @@ class Settings_Test extends Testcase {
 	 * @covers ::set_initial_quote_tags
 	 */
 	public function test_set_initial_quote_tags() {
-		$tags_as_array  = [ 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'div' ];
+		$tags_as_array = [ 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'div' ];
 
 		$this->settings->set_initial_quote_tags( $tags_as_array );
 		foreach ( $tags_as_array as $tag ) {
@@ -1255,7 +1255,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_hyphenation.
 	 *
-	 * @covers ::set_hyphenation
+	 * @uses ::__call
 	 */
 	public function test_set_hyphenation() {
 		$this->settings->set_hyphenation( true );
@@ -1282,7 +1282,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_hyphenation_language.
 	 *
-	 * @covers ::set_hyphenation_language
+	 * @uses ::__call
 	 *
 	 * @uses PHP_Typography\Hyphenator::__construct
 	 * @uses PHP_Typography\Hyphenator::set_language
@@ -1310,7 +1310,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_hyphenation_language.
 	 *
-	 * @covers ::set_hyphenation_language
+	 * @uses ::__call
 	 *
 	 * @uses PHP_Typography\Hyphenator::__construct
 	 * @uses PHP_Typography\Hyphenator::set_language
@@ -1396,7 +1396,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_hyphenate_headings.
 	 *
-	 * @covers ::set_hyphenate_headings
+	 * @uses ::__call
 	 */
 	public function test_set_hyphenate_headings() {
 		$this->settings->set_hyphenate_headings( true );
@@ -1409,7 +1409,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_hyphenate_all_caps.
 	 *
-	 * @covers ::set_hyphenate_all_caps
+	 * @uses ::__call
 	 */
 	public function test_set_hyphenate_all_caps() {
 		$this->settings->set_hyphenate_all_caps( true );
@@ -1422,7 +1422,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_hyphenate_title_case.
 	 *
-	 * @covers ::set_hyphenate_title_case
+	 * @uses ::__call
 	 */
 	public function test_set_hyphenate_title_case() {
 		$this->settings->set_hyphenate_title_case( true );
@@ -1435,7 +1435,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_hyphenate_compounds.
 	 *
-	 * @covers ::set_hyphenate_compounds
+	 * @uses ::__call
 	 */
 	public function test_set_hyphenate_compounds() {
 		$this->settings->set_hyphenate_compounds( true );
@@ -1448,7 +1448,7 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_hyphenation_exceptions.
 	 *
-	 * @covers ::set_hyphenation_exceptions
+	 * @uses ::__call
 	 *
 	 * @uses PHP_Typography\Hyphenator::__construct
 	 * @uses PHP_Typography\Hyphenator::set_custom_exceptions

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -1062,28 +1062,37 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_max_dewidow_length.
 	 *
-	 * @covers ::set_max_dewidow_length
+	 * @uses ::__call
 	 */
 	public function test_set_max_dewidow_length() {
 		$this->settings->set_max_dewidow_length( 10 );
 		$this->assertSame( 10, $this->settings[ Settings::DEWIDOW_MAX_LENGTH ] );
-
-		$this->settings->set_max_dewidow_length( 1 );
-		$this->assertSame( 5, $this->settings[ Settings::DEWIDOW_MAX_LENGTH ] );
 
 		$this->settings->set_max_dewidow_length( 2 );
 		$this->assertSame( 2, $this->settings[ Settings::DEWIDOW_MAX_LENGTH ] );
 	}
 
 	/**
+	 * Tests set_max_dewidow_length.
+	 *
+	 * @uses ::__call
+	 */
+	public function test_set_max_dewidow_length_too_low() {
+		$this->settings->set_max_dewidow_length( 10 );
+		$this->assertSame( 10, $this->settings[ Settings::DEWIDOW_MAX_LENGTH ] );
+
+		$this->expect_exception( \OutOfRangeException::class );
+
+		$this->settings->set_max_dewidow_length( 1 );
+		$this->assertSame( 10, $this->settings[ Settings::DEWIDOW_MAX_LENGTH ] );
+	}
+
+	/**
 	 * Tests set_dewidow_word_number.
 	 *
-	 * @covers ::set_dewidow_word_number
+	 * @uses ::__call
 	 */
 	public function test_set_dewidow_word_number() {
-		$this->settings->set_dewidow_word_number( 10 );
-		$this->assertSame( 1, $this->settings[ Settings::DEWIDOW_WORD_NUMBER ] );
-
 		$this->settings->set_dewidow_word_number( 1 );
 		$this->assertSame( 1, $this->settings[ Settings::DEWIDOW_WORD_NUMBER ] );
 
@@ -1092,6 +1101,27 @@ class Settings_Test extends Testcase {
 
 		$this->settings->set_dewidow_word_number( 3 );
 		$this->assertSame( 3, $this->settings[ Settings::DEWIDOW_WORD_NUMBER ] );
+	}
+
+	/**
+	 * Tests set_dewidow_word_number.
+	 *
+	 * @uses ::__call
+	 */
+	public function test_set_dewidow_word_number_too_low() {
+		$this->expect_exception( \OutOfRangeException::class );
+
+		$this->settings->set_dewidow_word_number( 0 );
+		$this->assertSame( 1, $this->settings[ Settings::DEWIDOW_WORD_NUMBER ] );
+	}
+
+	/**
+	 * Tests set_dewidow_word_number.
+	 *
+	 * @uses ::__call
+	 */
+	public function test_set_dewidow_word_number_too_high() {
+		$this->expect_exception( \OutOfRangeException::class );
 
 		$this->settings->set_dewidow_word_number( 4 );
 		$this->assertSame( 1, $this->settings[ Settings::DEWIDOW_WORD_NUMBER ] );
@@ -1100,18 +1130,28 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_max_dewidow_pull.
 	 *
-	 * @covers ::set_max_dewidow_pull
+	 * @uses ::__call
 	 */
 	public function test_set_max_dewidow_pull() {
 		$this->settings->set_max_dewidow_pull( 10 );
 		$this->assertSame( 10, $this->settings[ Settings::DEWIDOW_MAX_PULL ] );
 
-		$this->settings->set_max_dewidow_pull( 1 );
-		$this->assertSame( 5, $this->settings[ Settings::DEWIDOW_MAX_PULL ] );
-
 		$this->settings->set_max_dewidow_pull( 2 );
 		$this->assertSame( 2, $this->settings[ Settings::DEWIDOW_MAX_PULL ] );
 	}
+
+		/**
+	 * Tests set_max_dewidow_pull.
+	 *
+	 * @uses ::__call
+	 */
+	public function test_set_max_dewidow_pull_too_low() {
+		$this->expect_exception( \OutOfRangeException::class );
+
+		$this->settings->set_max_dewidow_pull( 1 );
+		$this->assertSame( 5, $this->settings[ Settings::DEWIDOW_MAX_PULL ] );
+	}
+
 
 	/**
 	 * Tests set_wrap_hard_hyphens.
@@ -1155,17 +1195,26 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_min_after_url_wrap.
 	 *
-	 * @covers ::set_min_after_url_wrap
+	 * @uses ::__call
 	 */
 	public function test_set_min_after_url_wrap() {
 		$this->settings->set_min_after_url_wrap( 10 );
 		$this->assertSame( 10, $this->settings[ Settings::URL_MIN_AFTER_WRAP ] );
 
-		$this->settings->set_min_after_url_wrap( 0 );
-		$this->assertSame( 5, $this->settings[ Settings::URL_MIN_AFTER_WRAP ] );
-
 		$this->settings->set_min_after_url_wrap( 1 );
 		$this->assertSame( 1, $this->settings[ Settings::URL_MIN_AFTER_WRAP ] );
+	}
+
+	/**
+	 * Tests set_min_after_url_wrap.
+	 *
+	 * @uses ::__call
+	 */
+	public function test_set_min_after_url_wrap_too_low() {
+		$this->expect_exception( \OutOfRangeException::class );
+
+		$this->settings->set_min_after_url_wrap( 0 );
+		$this->assertSame( 5, $this->settings[ Settings::URL_MIN_AFTER_WRAP ] );
 	}
 
 	/**
@@ -1346,14 +1395,11 @@ class Settings_Test extends Testcase {
 	/**
 	 * Tests set_min_length_hyphenation.
 	 *
-	 * @covers ::set_min_length_hyphenation
+	 * @uses ::__call
 	 *
 	 * @uses PHP_Typography\Hyphenator::__construct
 	 */
 	public function test_set_min_length_hyphenation() {
-		$this->settings->set_min_length_hyphenation( 1 ); // too low, resets to default 5.
-		$this->assertSame( 5, $this->settings[ Settings::HYPHENATION_MIN_LENGTH ] );
-
 		$this->settings->set_min_length_hyphenation( 2 );
 		$this->assertSame( 2, $this->settings[ Settings::HYPHENATION_MIN_LENGTH ] );
 
@@ -1362,14 +1408,25 @@ class Settings_Test extends Testcase {
 	}
 
 	/**
+	 * Tests set_min_length_hyphenation.
+	 *
+	 * @uses ::__call
+	 *
+	 * @uses PHP_Typography\Hyphenator::__construct
+	 */
+	public function test_set_min_length_hyphenation_too_low() {
+		$this->expect_exception( \OutOfRangeException::class );
+
+		$this->settings->set_min_length_hyphenation( 1 );
+		$this->assertSame( 5, $this->settings[ Settings::HYPHENATION_MIN_LENGTH ] );
+	}
+
+	/**
 	 * Tests set_min_before_hyphenation.
 	 *
-	 * @covers ::set_min_before_hyphenation
+	 * @uses ::__call
 	 */
 	public function test_set_min_before_hyphenation() {
-		$this->settings->set_min_before_hyphenation( 0 ); // too low, resets to default 3.
-		$this->assertSame( 3, $this->settings[ Settings::HYPHENATION_MIN_BEFORE ] );
-
 		$this->settings->set_min_before_hyphenation( 1 );
 		$this->assertSame( 1, $this->settings[ Settings::HYPHENATION_MIN_BEFORE ] );
 
@@ -1378,19 +1435,40 @@ class Settings_Test extends Testcase {
 	}
 
 	/**
+	 * Tests set_min_before_hyphenation.
+	 *
+	 * @uses ::__call
+	 */
+	public function test_set_min_before_hyphenation_too_low() {
+		$this->expect_exception( \OutOfRangeException::class );
+
+		$this->settings->set_min_before_hyphenation( 0 ); // too low, resets to default 3.
+		$this->assertSame( 3, $this->settings[ Settings::HYPHENATION_MIN_BEFORE ] );
+	}
+
+	/**
 	 * Tests set_min_after_hyphenation.
 	 *
-	 * @covers ::set_min_after_hyphenation
+	 * @uses ::__call
 	 */
 	public function test_set_min_after_hyphenation() {
-		$this->settings->set_min_after_hyphenation( 0 ); // too low, resets to default 2.
-		$this->assertSame( 2, $this->settings[ Settings::HYPHENATION_MIN_AFTER ] );
-
 		$this->settings->set_min_after_hyphenation( 1 );
 		$this->assertSame( 1, $this->settings[ Settings::HYPHENATION_MIN_AFTER ] );
 
 		$this->settings->set_min_after_hyphenation( 66 );
 		$this->assertSame( 66, $this->settings[ Settings::HYPHENATION_MIN_AFTER ] );
+	}
+
+	/**
+	 * Tests set_min_after_hyphenation.
+	 *
+	 * @uses ::__call
+	 */
+	public function test_set_min_after_hyphenation_too_low() {
+		$this->expect_exception( \OutOfRangeException::class );
+
+		$this->settings->set_min_after_hyphenation( 0 ); // too low, resets to default 2.
+		$this->assertSame( 2, $this->settings[ Settings::HYPHENATION_MIN_AFTER ] );
 	}
 
 	/**


### PR DESCRIPTION
- Removes all trivial `set_*` methods and replaces them with the `__call` magic method.
- Changes the semantics of setting out-of-bounds integer values, instead of silently resetting to the default value, a `OutOfRangeException` is thrown.