### PR TITLE
Fully initialize Settings even when $use_defaults is set to false

### DIFF
--- a/src/class-settings.php
+++ b/src/class-settings.php
@@ -619,12 +619,8 @@ class Settings {
 	/**
 	 * Sets up a new Settings object.
 	 *
-	 * @since 6.0.0 If $set_defaults is `false`, the settings object is not fully
-	 *              initialized unless `set_smart_quotes_primary`,
-	 *              `set_smart_quotes_secondary`, `set_smart_dashes_style` and
-	 *              `set_true_no_break_narrow_space` are called explicitly.
-	 * @since 6.5.0 A (partial) character mapping can be given to remap certain
-	 *              characters.
+	 * @since 6.5.0 A (partial) character mapping can be given to remap certain characters.
+	 * @since 7.0.0 The object is no fully initialized again even when `$set_defaults` is `false`.
 	 *
 	 * @param bool     $set_defaults Optional. If true, set default values for various properties. Default true.
 	 * @param string[] $mapping      Optional. Unicode characters to remap. The default maps the narrow no-break space to the normal NO-BREAK SPACE and the apostrophe to the RIGHT SINGLE QUOTATION MARK.
@@ -646,6 +642,12 @@ class Settings {
 			$this->set_defaults();
 		} else {
 			$this->data[ self::CUSTOM_UNITS ] = '';
+
+			$null_quotes                                      = Quote_Style::get_styled_quotes( Quote_Style::NONE );
+			$this->data[ self::SMART_QUOTES_PRIMARY_STYLE ]   = $null_quotes;
+			$this->data[ self::SMART_QUOTES_SECONDARY_STYLE ] = $null_quotes;
+
+			$this->data[ self::SMART_DASHES_STYLE ] = Dash_Style::get_styled_dashes( Dash_Style::NONE );
 		}
 
 		// Merge default character mapping with given mapping.

--- a/src/settings/class-dash-style.php
+++ b/src/settings/class-dash-style.php
@@ -54,6 +54,13 @@ abstract class Dash_Style {
 	const INTERNATIONAL_NO_HAIR_SPACES = 'internationalNoHairSpaces';
 
 	/**
+	 * Empty dash style.
+	 *
+	 * @since 7.0.0
+	 */
+	const NONE = 'noneAtAll';
+
+	/**
 	 * Available dash styles.
 	 *
 	 * @since 7.0.0 Now a private constant instead of a private property.
@@ -77,6 +84,12 @@ abstract class Dash_Style {
 			self::PARENTHETICAL       => U::EN_DASH,
 			self::PARENTHETICAL_SPACE => ' ',
 			self::INTERVAL            => U::EN_DASH,
+			self::INTERVAL_SPACE      => '',
+		],
+		self::NONE                         => [
+			self::PARENTHETICAL       => '',
+			self::PARENTHETICAL_SPACE => '',
+			self::INTERVAL            => '',
 			self::INTERVAL_SPACE      => '',
 		],
 	];

--- a/src/settings/class-quote-style.php
+++ b/src/settings/class-quote-style.php
@@ -54,6 +54,7 @@ abstract class Quote_Style {
 	const SINGLE_GUILLEMETS_REVERSED = 'singleGuillemetsReversed';
 	const CORNER_BRACKETS            = 'cornerBrackets';
 	const WHITE_CORNER_BRACKETS      = 'whiteCornerBracket';
+	const NONE                       = 'noneAtAll';
 
 	/**
 	 * Available quote styles.
@@ -122,6 +123,10 @@ abstract class Quote_Style {
 		self::WHITE_CORNER_BRACKETS      => [
 			self::OPEN  => U::LEFT_WHITE_CORNER_BRACKET,
 			self::CLOSE => U::RIGHT_WHITE_CORNER_BRACKET,
+		],
+		self::NONE                       => [
+			self::OPEN  => '',
+			self::CLOSE => '',
 		],
 	];
 

--- a/tests/class-settings-test.php
+++ b/tests/class-settings-test.php
@@ -75,7 +75,7 @@ class Settings_Test extends Testcase {
 	 */
 	public function test_set_defaults() {
 		$second_settings = new \PHP_Typography\Settings( false );
-		$this->assert_attribute_count( 2, 'data', $second_settings );
+		$this->assert_attribute_count( 5, 'data', $second_settings );
 		$second_settings->set_defaults();
 		$this->assert_attribute_count( 55, 'data', $second_settings );
 	}
@@ -94,11 +94,11 @@ class Settings_Test extends Testcase {
 		$s = $this->settings;
 
 		// No defaults.
-		$this->assert_attribute_count( 2, 'data', $s );
+		$this->assert_attribute_count( 5, 'data', $s );
 
 		// After set_defaults().
 		$s->set_defaults();
-		$this->assert_attribute_not_count( 2, 'data', $s );
+		$this->assert_attribute_count( 55, 'data', $s );
 
 		$second_settings = new \PHP_Typography\Settings( true );
 		$this->assert_attribute_count( 55, 'data', $second_settings );
@@ -340,6 +340,7 @@ class Settings_Test extends Testcase {
 			'singleGuillemetsReversed',
 			'cornerBrackets',
 			'whiteCornerBracket',
+			'noneAtAll',
 		];
 
 		foreach ( $quote_styles as $style ) {
@@ -410,6 +411,7 @@ class Settings_Test extends Testcase {
 			'singleGuillemetsReversed',
 			'cornerBrackets',
 			'whiteCornerBracket',
+			'noneAtAll',
 		];
 
 		foreach ( $quote_styles as $style ) {
@@ -519,6 +521,14 @@ class Settings_Test extends Testcase {
 		$this->assertSame( U::EN_DASH, $dashes->parenthetical_dash() );
 		$this->assertSame( U::EN_DASH, $dashes->interval_dash() );
 		$this->assertSame( ' ', $dashes->parenthetical_space() );
+		$this->assertSame( '', $dashes->interval_space() );
+
+		$s->set_smart_dashes_style( 'noneAtAll' );
+		$dashes = $s->dash_style;
+
+		$this->assertSame( '', $dashes->parenthetical_dash() );
+		$this->assertSame( '', $dashes->interval_dash() );
+		$this->assertSame( '', $dashes->parenthetical_space() );
 		$this->assertSame( '', $dashes->interval_space() );
 	}
 
@@ -1435,11 +1445,6 @@ class Settings_Test extends Testcase {
 	 */
 	public function test_get_hash() {
 		$s = $this->settings;
-
-		// Finish initialization.
-		$s->set_smart_quotes_primary();
-		$s->set_smart_quotes_secondary();
-		$s->set_smart_dashes_style();
 
 		$s->set_smart_quotes( true );
 		$hash1 = $s->get_hash( 10 );

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -242,6 +242,11 @@ abstract class Testcase extends \Mundschenk\PHPUnit_Cross_Version\TestCase {
 				$this->assertSame( U::RIGHT_WHITE_CORNER_BRACKET, $close, "Closing quote $close did not match quote style $style." );
 				break;
 
+			case 'noneAtAll':
+				$this->assertSame( '', $open, "Opening quote $open did not match quote style $style." );
+				$this->assertSame( '', $close, "Closing quote $close did not match quote style $style." );
+				break;
+
 			default:
 				$this->assertTrue( false, "Invalid quote style $style." );
 		}


### PR DESCRIPTION
Makes sure that the `Settings` object is fully usable even when `$use_defaults` is set to `false` in the constructor.