### PR TITLE
Clean up `use` statements

### DIFF
--- a/src/class-text-parser.php
+++ b/src/class-text-parser.php
@@ -27,7 +27,6 @@
 
 namespace PHP_Typography;
 
-use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 use PHP_Typography\Text_Parser\Token;
 
 /**

--- a/src/fixes/class-default-registry.php
+++ b/src/fixes/class-default-registry.php
@@ -26,13 +26,10 @@
 
 namespace PHP_Typography\Fixes;
 
-use PHP_Typography\Settings;
+use PHP_Typography\Hyphenator\Cache;
 
 use PHP_Typography\Fixes\Node_Fix;
 use PHP_Typography\Fixes\Token_Fix;
-
-use PHP_Typography\Hyphenator\Cache;
-
 
 /**
  * A registry implementation containing the default fixes for PHP_Typography.

--- a/src/fixes/class-registry.php
+++ b/src/fixes/class-registry.php
@@ -32,7 +32,6 @@ use PHP_Typography\Hyphenator\Cache;
 
 use PHP_Typography\Fixes\Node_Fix;
 use PHP_Typography\Fixes\Token_Fix;
-use PHP_Typography\Fixes\Token_Fixes\Hyphenate_Fix;
 
 /**
  * Manages the fixes used by PHP_Typography.

--- a/src/fixes/node-fixes/class-abstract-node-fix.php
+++ b/src/fixes/node-fixes/class-abstract-node-fix.php
@@ -28,7 +28,6 @@ namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fix;
 use PHP_Typography\Settings;
-use PHP_Typography\Strings;
 
 /**
  * All fixes that apply to textnodes should implement this interface.

--- a/src/fixes/node-fixes/class-classes-dependent-fix.php
+++ b/src/fixes/node-fixes/class-classes-dependent-fix.php
@@ -28,7 +28,6 @@ namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\Settings;
 use PHP_Typography\DOM;
-use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 
 /**
  * All fixes that depend on certain HTML classes not being present should extend this baseclass.

--- a/src/fixes/node-fixes/class-dash-spacing-fix.php
+++ b/src/fixes/node-fixes/class-dash-spacing-fix.php
@@ -27,7 +27,6 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\Settings;
 use PHP_Typography\U;
 

--- a/src/fixes/node-fixes/class-dewidow-fix.php
+++ b/src/fixes/node-fixes/class-dewidow-fix.php
@@ -28,7 +28,6 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\DOM;
-use PHP_Typography\RE;
 use PHP_Typography\Settings;
 use PHP_Typography\Strings;
 use PHP_Typography\U;

--- a/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
+++ b/src/fixes/node-fixes/class-french-punctuation-spacing-fix.php
@@ -27,7 +27,6 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\DOM;
-use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 use PHP_Typography\Settings;
 use PHP_Typography\Strings;
 use PHP_Typography\U;

--- a/src/fixes/node-fixes/class-numbered-abbreviation-spacing-fix.php
+++ b/src/fixes/node-fixes/class-numbered-abbreviation-spacing-fix.php
@@ -26,7 +26,6 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\Settings;
 use PHP_Typography\U;
 use PHP_Typography\RE;

--- a/src/fixes/node-fixes/class-process-words-fix.php
+++ b/src/fixes/node-fixes/class-process-words-fix.php
@@ -28,7 +28,6 @@ namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\Text_Parser;
 use PHP_Typography\Settings;
-use PHP_Typography\DOM;
 use PHP_Typography\Hyphenator\Cache;
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes\Hyphenate_Fix;

--- a/src/fixes/node-fixes/class-simple-regex-replacement-fix.php
+++ b/src/fixes/node-fixes/class-simple-regex-replacement-fix.php
@@ -27,7 +27,6 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\Settings;
-use PHP_Typography\DOM;
 
 /**
  * An abstract base class for providing simple fixes via a single regular expression replacement.

--- a/src/fixes/node-fixes/class-simple-style-fix.php
+++ b/src/fixes/node-fixes/class-simple-style-fix.php
@@ -26,7 +26,6 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\RE;
 use PHP_Typography\Settings;
 

--- a/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
+++ b/src/fixes/node-fixes/class-single-character-word-spacing-fix.php
@@ -27,7 +27,6 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\DOM;
-use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
 use PHP_Typography\RE;
 use PHP_Typography\Settings;
 use PHP_Typography\Strings;

--- a/src/fixes/node-fixes/class-smart-area-units-fix.php
+++ b/src/fixes/node-fixes/class-smart-area-units-fix.php
@@ -26,9 +26,7 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\Settings;
-use PHP_Typography\U;
 
 /**
  * Applies smart area units (if enabled).

--- a/src/fixes/node-fixes/class-smart-dashes-fix.php
+++ b/src/fixes/node-fixes/class-smart-dashes-fix.php
@@ -27,7 +27,6 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\RE;
 use PHP_Typography\Settings;
 use PHP_Typography\U;

--- a/src/fixes/node-fixes/class-smart-diacritics-fix.php
+++ b/src/fixes/node-fixes/class-smart-diacritics-fix.php
@@ -27,7 +27,6 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\Settings;
-use PHP_Typography\DOM;
 
 /**
  * Applies smart diacritics (if enabled).

--- a/src/fixes/node-fixes/class-smart-ellipses-fix.php
+++ b/src/fixes/node-fixes/class-smart-ellipses-fix.php
@@ -26,7 +26,6 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\Settings;
 use PHP_Typography\U;
 

--- a/src/fixes/node-fixes/class-smart-exponents-fix.php
+++ b/src/fixes/node-fixes/class-smart-exponents-fix.php
@@ -27,7 +27,6 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\RE;
 use PHP_Typography\Settings;
 

--- a/src/fixes/node-fixes/class-smart-fractions-fix.php
+++ b/src/fixes/node-fixes/class-smart-fractions-fix.php
@@ -26,7 +26,6 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\RE;
 use PHP_Typography\Settings;
 use PHP_Typography\U;

--- a/src/fixes/node-fixes/class-smart-maths-fix.php
+++ b/src/fixes/node-fixes/class-smart-maths-fix.php
@@ -26,7 +26,6 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\Settings;
 use PHP_Typography\U;
 

--- a/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
+++ b/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
@@ -27,7 +27,6 @@
 
 namespace PHP_Typography\Fixes\Node_Fixes;
 
-use PHP_Typography\DOM;
 use PHP_Typography\RE;
 use PHP_Typography\Settings;
 use PHP_Typography\U;

--- a/src/fixes/node-fixes/class-space-collapse-fix.php
+++ b/src/fixes/node-fixes/class-space-collapse-fix.php
@@ -30,7 +30,6 @@ namespace PHP_Typography\Fixes\Node_Fixes;
 use PHP_Typography\DOM;
 use PHP_Typography\RE;
 use PHP_Typography\Settings;
-use PHP_Typography\Strings;
 use PHP_Typography\U;
 
 /**

--- a/src/fixes/node-fixes/class-style-ampersands-fix.php
+++ b/src/fixes/node-fixes/class-style-ampersands-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\Settings;
-use PHP_Typography\DOM;
 
 /**
  * Wraps ampersands in <span class="amp"> (i.e. H&amp;J becomes H<span class="amp">&amp;</span>J),

--- a/src/fixes/node-fixes/class-style-numbers-fix.php
+++ b/src/fixes/node-fixes/class-style-numbers-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2019 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\Settings;
-use PHP_Typography\DOM;
 
 /**
  * Wraps numbers in <span class="numbers"> (even numbers that appear inside a word,

--- a/src/fixes/node-fixes/class-unit-spacing-fix.php
+++ b/src/fixes/node-fixes/class-unit-spacing-fix.php
@@ -28,7 +28,6 @@
 namespace PHP_Typography\Fixes\Node_Fixes;
 
 use PHP_Typography\Settings;
-use PHP_Typography\DOM;
 use PHP_Typography\U;
 
 /**

--- a/src/fixes/token-fixes/class-wrap-urls-fix.php
+++ b/src/fixes/token-fixes/class-wrap-urls-fix.php
@@ -31,6 +31,7 @@ use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Hyphenator\Cache;
 use PHP_Typography\RE;
 use PHP_Typography\Settings;
+use PHP_Typography\Strings;
 use PHP_Typography\Text_Parser;
 use PHP_Typography\Text_Parser\Token;
 use PHP_Typography\U;
@@ -190,10 +191,13 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 	 * @return string             The hyphenated domain name.
 	 */
 	private function split_path( string $path, Settings $settings ): string {
+		$str_split = Strings::functions( $path )['str_split'];
+
 		// Break up the URL path to individual characters.
-		$path_parts = \str_split( $path, 1 ); // TODO: Does not work with non-ASCII paths.
+		$path_parts = $str_split( $path, 1 );
 		$path_count = \count( $path_parts );
 		$split_path = '';
+
 		foreach ( $path_parts as $index => $part ) {
 			if ( 0 === $index || $path_count - $index < $settings->min_after_url_wrap ) {
 				$split_path .= $part;

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -27,14 +27,11 @@ namespace PHP_Typography\Tests;
 use PHP_Typography\DOM;
 use PHP_Typography\PHP_Typography;
 use PHP_Typography\Settings;
-use PHP_Typography\Strings;
 use PHP_Typography\U;
 
 use PHP_Typography\Settings\Quote_Style;
 
 use PHP_Typography\Fixes\Default_Registry;
-use PHP_Typography\Fixes\Node_Fix;
-use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Registry;
 
 use PHP_Typography\Hyphenator\Cache as Hyphenator_Cache;

--- a/tests/class-testcase.php
+++ b/tests/class-testcase.php
@@ -24,7 +24,6 @@
 
 namespace PHP_Typography\Tests;
 
-use PHP_Typography\Strings;
 use PHP_Typography\U;
 use PHP_Typography\Text_Parser\Token;
 

--- a/tests/class-text-parser-test.php
+++ b/tests/class-text-parser-test.php
@@ -25,8 +25,9 @@
 namespace PHP_Typography\Tests;
 
 use PHP_Typography\Exceptions\Invalid_Encoding_Exception;
-use PHP_Typography\Text_Parser\Token;
+
 use PHP_Typography\Text_Parser;
+use PHP_Typography\Text_Parser\Token;
 
 /**
  * Unit test for \PHP_Typography\Text_Parser class.

--- a/tests/fixes/class-default-registry-test.php
+++ b/tests/fixes/class-default-registry-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2022 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@ use Mockery as m;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-class Default_Registry_Test extends \PHP_Typography\Tests\Testcase {
+class Default_Registry_Test extends Testcase {
 
 	/**
 	 * Tests constructor.

--- a/tests/fixes/class-registry-test.php
+++ b/tests/fixes/class-registry-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2022 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,14 +24,12 @@
 
 namespace PHP_Typography\Tests\Fixes;
 
-use PHP_Typography\Fixes\Registry;
-use PHP_Typography\Hyphenator\Cache as Hyphenator_Cache;
 use PHP_Typography\Settings;
+
 use PHP_Typography\Fixes\Node_Fix;
 use PHP_Typography\Fixes\Token_Fix;
+use PHP_Typography\Fixes\Registry;
 use PHP_Typography\Fixes\Node_Fixes\Process_Words_Fix;
-use PHP_Typography\Strings;
-use PHP_Typography\U;
 
 use PHP_Typography\Tests\Testcase;
 

--- a/tests/fixes/node-fixes/class-abstract-node-fix-test.php
+++ b/tests/fixes/node-fixes/class-abstract-node-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Abstract_Node_Fix unit test.

--- a/tests/fixes/node-fixes/class-classes-dependent-fix-test.php
+++ b/tests/fixes/node-fixes/class-classes-dependent-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Classes_Dependent_Fix unit test.

--- a/tests/fixes/node-fixes/class-dash-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-dash-spacing-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes\Dash_Spacing_Fix;
-use PHP_Typography\Settings;
 
 /**
  * Dash_Spacing_Fix unit test.

--- a/tests/fixes/node-fixes/class-dewidow-fix-test.php
+++ b/tests/fixes/node-fixes/class-dewidow-fix-test.php
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes\Dewidow_Fix;
-use PHP_Typography\Settings;
 use PHP_Typography\U;
 
 /**

--- a/tests/fixes/node-fixes/class-french-punctuation-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-french-punctuation-spacing-fix-test.php
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes\French_Punctuation_Spacing_Fix;
-use PHP_Typography\Settings;
 
 /**
  * French_Punctuation_Spacing_Fix unit test.

--- a/tests/fixes/node-fixes/class-numbered-abbreviation-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-numbered-abbreviation-spacing-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Numbered_Abbreviation_Spacing_Fix unit test.

--- a/tests/fixes/node-fixes/class-process-words-fix-test.php
+++ b/tests/fixes/node-fixes/class-process-words-fix-test.php
@@ -28,7 +28,6 @@ use PHP_Typography\Fixes\Node_Fixes;
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes\Hyphenate_Fix;
 use PHP_Typography\Hyphenator\Cache;
-use PHP_Typography\Settings;
 
 /**
  * Process_Words_Fix unit test.

--- a/tests/fixes/node-fixes/class-simple-regex-replacement-fix-test.php
+++ b/tests/fixes/node-fixes/class-simple-regex-replacement-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Simple_Regex_Replacement_Fix unit test.

--- a/tests/fixes/node-fixes/class-simple-style-fix-test.php
+++ b/tests/fixes/node-fixes/class-simple-style-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Simple_Style_Fix unit test.

--- a/tests/fixes/node-fixes/class-single-character-word-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-single-character-word-spacing-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Single_Character_Word_Spacing_Fix unit test.

--- a/tests/fixes/node-fixes/class-smart-area-units-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-area-units-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2019 Peter Putzer.
+ *  Copyright 2019-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Smart_Area_Units_Fix unit test.

--- a/tests/fixes/node-fixes/class-smart-dashes-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-dashes-fix-test.php
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Smart_Dashes_Fix unit test.

--- a/tests/fixes/node-fixes/class-smart-ellipses-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-ellipses-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Smart_Ellipses_Fix unit test.

--- a/tests/fixes/node-fixes/class-smart-exponents-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-exponents-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Smart_Exponents_Fix unit test.

--- a/tests/fixes/node-fixes/class-smart-fractions-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-fractions-fix-test.php
@@ -26,7 +26,6 @@ namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
 use PHP_Typography\RE;
-use PHP_Typography\Settings;
 use PHP_Typography\U;
 
 /**

--- a/tests/fixes/node-fixes/class-smart-marks-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-marks-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Smart_Marks_Fix unit test.

--- a/tests/fixes/node-fixes/class-smart-maths-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-maths-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Smart_Maths_Fix unit test.

--- a/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-ordinal-suffix-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,7 +26,6 @@ namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
 use PHP_Typography\RE;
-use PHP_Typography\Settings;
 
 /**
  * Smart_Ordinal_Suffix_Fix unit test.

--- a/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
+++ b/tests/fixes/node-fixes/class-smart-quotes-fix-test.php
@@ -25,9 +25,7 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes\Smart_Quotes_Fix;
-use PHP_Typography\Settings;
 use PHP_Typography\Settings\Quote_Style;
-use PHP_Typography\Strings;
 
 /**
  * Smart_Quotes_Fix unit test.

--- a/tests/fixes/node-fixes/class-space-collapse-fix-test.php
+++ b/tests/fixes/node-fixes/class-space-collapse-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Space_Collapse_Fix unit test.

--- a/tests/fixes/node-fixes/class-style-ampersands-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-ampersands-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Style_Ampersands_Fix unit test.

--- a/tests/fixes/node-fixes/class-style-caps-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-caps-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Style_Caps_Fix unit test.

--- a/tests/fixes/node-fixes/class-style-hanging-punctuation-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-hanging-punctuation-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Style_Hanging_Punctuation_Fix unit test.

--- a/tests/fixes/node-fixes/class-style-initial-quotes-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-initial-quotes-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2020 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 use PHP_Typography\U;
 
 /**

--- a/tests/fixes/node-fixes/class-style-numbers-fix-test.php
+++ b/tests/fixes/node-fixes/class-style-numbers-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2019 Peter Putzer.
+ *  Copyright 2015-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Style_Numbers_Fix unit test.

--- a/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
+++ b/tests/fixes/node-fixes/class-unit-spacing-fix-test.php
@@ -25,7 +25,6 @@
 namespace PHP_Typography\Tests\Fixes\Node_Fixes;
 
 use PHP_Typography\Fixes\Node_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Unit_Spacing_Fix unit test.

--- a/tests/fixes/token-fixes/class-abstract-token-fix-test.php
+++ b/tests/fixes/token-fixes/class-abstract-token-fix-test.php
@@ -26,7 +26,6 @@ namespace PHP_Typography\Tests\Fixes\Token_Fixes;
 
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Abstract_Token_Fix unit test.

--- a/tests/fixes/token-fixes/class-hyphenate-compounds-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-compounds-fix-test.php
@@ -26,7 +26,6 @@ namespace PHP_Typography\Tests\Fixes\Token_Fixes;
 
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Hyphenate_Compounds_Fix unit test.

--- a/tests/fixes/token-fixes/class-hyphenate-fix-test.php
+++ b/tests/fixes/token-fixes/class-hyphenate-fix-test.php
@@ -197,7 +197,7 @@ class Hyphenate_Fix_Test extends Token_Fix_Testcase {
 		$h = $this->fix->get_hyphenator( $s );
 		$this->assertInstanceOf( \PHP_Typography\Hyphenator::class, $h );
 
-		$settings_data                                            = $this->get_value( $s, 'data' );
+		$settings_data = $this->get_value( $s, 'data' );
 		$settings_data[ Settings::HYPHENATION_CUSTOM_EXCEPTIONS ] = [ 'bar-foo' ];
 		$this->set_value( $s, 'data', $settings_data );
 

--- a/tests/fixes/token-fixes/class-smart-dashes-hyphen-fix-test.php
+++ b/tests/fixes/token-fixes/class-smart-dashes-hyphen-fix-test.php
@@ -26,7 +26,6 @@ namespace PHP_Typography\Tests\Fixes\Token_Fixes;
 
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Smart_Dashes_Hyphen_Fix unit test.

--- a/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-emails-fix-test.php
@@ -26,7 +26,6 @@ namespace PHP_Typography\Tests\Fixes\Token_Fixes;
 
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Wrap_Emails_Fix unit test.

--- a/tests/fixes/token-fixes/class-wrap-hard-hyphens-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-hard-hyphens-fix-test.php
@@ -26,7 +26,6 @@ namespace PHP_Typography\Tests\Fixes\Token_Fixes;
 
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Wrap_Hard_Hyphens_Fix unit test.

--- a/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
@@ -26,7 +26,6 @@ namespace PHP_Typography\Tests\Fixes\Token_Fixes;
 
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes;
-use PHP_Typography\Settings;
 
 /**
  * Wrap_URLs_Fix unit test.

--- a/tests/settings/class-simple-dashes-test.php
+++ b/tests/settings/class-simple-dashes-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2020 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,9 +26,7 @@ namespace PHP_Typography\Tests\Settings;
 
 use PHP_Typography\Tests\Testcase;
 
-use PHP_Typography\Settings\Quotes;
 use PHP_Typography\Settings\Simple_Dashes;
-use PHP_Typography\U;
 
 /**
  * Simple_Dashes unit test.

--- a/tests/settings/class-simple-quotes-test.php
+++ b/tests/settings/class-simple-quotes-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2020 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,9 +26,7 @@ namespace PHP_Typography\Tests\Settings;
 
 use PHP_Typography\Tests\Testcase;
 
-use PHP_Typography\Settings\Quotes;
 use PHP_Typography\Settings\Simple_Quotes;
-use PHP_Typography\U;
 
 /**
  * Simple_Quotes unit test.


### PR DESCRIPTION
- Removes unused `use` statements.
- Cleans up unnecessary usage of a fully qualified class name in tests.
- Fixes a small whitespace alignment issue.