### PR TITLE
Expand Wrap_URLs_Fix to allow for IRIs

### DIFF
--- a/src/fixes/token-fixes/class-wrap-urls-fix.php
+++ b/src/fixes/token-fixes/class-wrap-urls-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2014-2024 Peter Putzer.
+ *  Copyright 2014-2026 Peter Putzer.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -29,7 +29,6 @@ namespace PHP_Typography\Fixes\Token_Fixes;
 
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Hyphenator\Cache;
-use PHP_Typography\RE;
 use PHP_Typography\Settings;
 use PHP_Typography\Strings;
 use PHP_Typography\Text_Parser;
@@ -44,17 +43,109 @@ use PHP_Typography\U;
  * @since 5.0.0
  */
 class Wrap_URLs_Fix extends Hyphenate_Fix {
-	// Valid URL schemes.
-	const URL_SCHEME = '(?:https?|ftps?|file|nfs|feed|itms|itpc)'; // # spellchecker:disable-line
+	// Constants from the URI and IRI specifications.
+	const URI_SCHEME = '(?:[a-z][\-a-z0-9\+\.]*)';
+	const URI_PORT   = '[0-9]*';
 
-	const WRAP_URLS_DOMAIN_PARTS = '#(\-|\.)#';
+	const URI_HEX_DIGIT    = '0-9a-f';
+	const URI_SUB_DELIMS   = '!\$&\'\(\)\*\+,;=';
+	const URI_GEN_DELIMS   = ':/\?#\[\]@';
+	const URI_RESERVED     = self::URI_SUB_DELIMS . self::URI_GEN_DELIMS;
+	const URI_UNRESERVED   = 'a-z0-9\-\._~';
+	const URI_PCT_ENCODED  = '%[' . self::URI_HEX_DIGIT . '][' . self::URI_HEX_DIGIT . ']';
+	const URI_DEC_OCTET    = '[0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]'; // 0-255
+	const URI_IPV4_ADDRESS = self::URI_DEC_OCTET . '(?:\.' . self::URI_DEC_OCTET . '){3}';
+	const URI_H16          = '[' . self::URI_HEX_DIGIT . ']{1,4}';
+	const URI_LS32         = '(?:' . self::URI_H16 . ':' . self::URI_H16 . '|' . self::URI_IPV4_ADDRESS . ')';
+	const URI_H16_PART     = '(?:' . self::URI_H16 . ':)';
+	const URI_IPV6_ADDRESS = '(?:' .
+			self::URI_H16_PART . '{6}' . self::URI_LS32 . '|' .
+			'::' . self::URI_H16_PART . '{5}' . self::URI_LS32 . '|' .
+			'(?:' . self::URI_H16 . '?)::' . self::URI_H16_PART . '{4}' . self::URI_LS32 . '|' .
+			'(?:' . self::URI_H16_PART . self::URI_H16 . '?)::' . self::URI_H16_PART . '{3}' . self::URI_LS32 . '|' .
+			'(?:' . self::URI_H16_PART . '{0,2}' . self::URI_H16 . '?)::' . self::URI_H16_PART . '{2}' . self::URI_LS32 . '|' .
+			'(?:' . self::URI_H16_PART . '{0,3}' . self::URI_H16 . '?)::' . self::URI_H16_PART . '{1}' . self::URI_LS32 . '|' .
+			'(?:' . self::URI_H16_PART . '{0,4}' . self::URI_H16 . '?)::' . self::URI_LS32 . '|' .
+			'(?:' . self::URI_H16_PART . '{0,5}' . self::URI_H16 . '?)::' . self::URI_H16 . '|' .
+			'(?:' . self::URI_H16_PART . '{0,6}' . self::URI_H16 . '?)::' .
+		')';
+	const URI_IPV_FUTURE   = 'v[' . self::URI_HEX_DIGIT . ']+\.(?:' . self::URI_UNRESERVED . self::URI_SUB_DELIMS . ':)+';
+	const URI_IP_LITERAL   = '\[(?:' . self::URI_IPV6_ADDRESS . '|' . self::URI_IPV_FUTURE . ')\]';
 
 	/**
-	 * The URL matching regular expression.
-	 *
-	 * @var string
+	 * IRI_UCS_CHAR should be:
+	 *    '\x{A0}-\x{D7FF}\x{F900}-\x{FDCF}\x{FDF0}-\x{FFEF}' .
+	 *    '\x{10000}-\x{1FFFD}\x{20000}-\x{2FFFD}\x{30000}-\x{3FFFD}' .
+	 *    '\x{40000}-\x{4FFFD}\x{50000}-\x{5FFFD}\x{60000}-\x{6FFFD}' .
+	 *    '\x{70000}-\x{7FFFD}\x{80000}-\x{8FFFD}\x{90000}-\x{9FFFD}' .
+	 *    '\x{A0000}-\x{AFFFD}\x{B0000}-\x{BFFFD}\x{C0000}-\x{CFFFD}' .
+	 *    '\x{D0000}-\x{DFFFD}\x{E1000}-\x{EFFFD}'
+	 * according to the specification, but that pattern somehow stops
+	 * PCRE2 engine from correctly matching certain strings. Instead
+	 * we use a simpler range that includes a few non-character
+	 * code points that should be excluded, but probably won't make
+	 * meaningful difference in the real world.
 	 */
-	protected $url_pattern;
+	const IRI_UCS_CHAR   = '\x{A0}-\x{D7FF}\x{F900}-\x{FDCF}\x{FDF0}-\x{FFEF}\x{10000}-\x{DFFFD}\x{E1000}-\x{EFFFD}';
+	const IRI_PRIVATE    = '\x{E000}-\x{F8FF}\x{F0000}-\x{FFFFD}\x{100000}-\x{10FFFD}';
+	const IRI_UNRESERVED = 'a-z0-9\-\._~' . self::IRI_UCS_CHAR;
+
+	const IRI_PCHAR         = '(?:' . self::URI_PCT_ENCODED . '|[' . self::IRI_UNRESERVED . self::URI_SUB_DELIMS . ':@])';
+	const IRI_QUERY         = '(?:' . self::IRI_PCHAR . '|[' . self::IRI_PRIVATE . '\/\?])*';
+	const IRI_FRAGMENT      = '(?:' . self::IRI_PCHAR . '|[\/\?])*';
+	const IRI_SEGMENT       = self::IRI_PCHAR . '*';
+	const IRI_SEGMENT_NZ    = self::IRI_PCHAR . '+';
+	const IRI_SEGMENT_NZ_NC = '(?:' . self::URI_PCT_ENCODED . '|[' . self::IRI_UNRESERVED . self::URI_SUB_DELIMS . '@])+'; // non-zero-length segment without any colon ":".
+
+	const IRI_PATH_ABEMPTY  = '(?:\/' . self::IRI_SEGMENT . ')*';
+	const IRI_PATH_ABSOLUTE = '\/(?:(?:' . self::IRI_SEGMENT_NZ . ')(?:\/' . self::IRI_SEGMENT . ')*)?';
+	const IRI_PATH_NOSCHEME = self::IRI_SEGMENT_NZ_NC . '(?:\\/' . self::IRI_SEGMENT . ')*';
+	const IRI_PATH_ROOTLESS = self::IRI_SEGMENT_NZ . '(?:\\/' . self::IRI_SEGMENT . ')*';
+	const IRI_PATH_EMPTY    = '(?!' . self::IRI_PCHAR . ')';
+
+	const IRI_PATH = '(?:' .
+		self::IRI_PATH_ABEMPTY . '|' . // begins with "/" or is empty.
+		self::IRI_PATH_ABSOLUTE . '|' . // begins with "/" but not "//".
+		self::IRI_PATH_NOSCHEME . '|' . // begins with a non-colon segment.
+		self::IRI_PATH_ROOTLESS . '|' . // begins with a segment.
+		self::IRI_PATH_EMPTY . // zero characters.
+		')';
+
+	const IRI_REG_NAME  = '(?:' . self::URI_PCT_ENCODED . '|[' . self::IRI_UNRESERVED . self::URI_SUB_DELIMS . '])*';
+	const IRI_HOST      = '(?:' . self::URI_IP_LITERAL . '|' . self::URI_IPV4_ADDRESS . '|' . self::IRI_REG_NAME . ')';
+	const IRI_USER_INFO = '(?:' . self::URI_PCT_ENCODED . '|[' . self::IRI_UNRESERVED . self::URI_SUB_DELIMS . ':])*';
+	const IRI_AUTHORITY = '(?:' . self::IRI_USER_INFO . '@)?' . self::IRI_HOST . '(?::' . self::URI_PORT . ')?';
+
+	const IRI_RELATIVE_PART = '(?:' .
+		'\/\/' . self::IRI_AUTHORITY . self::IRI_PATH_ABEMPTY . '|' .
+		self::IRI_PATH_ABSOLUTE . '|' .
+		self::IRI_PATH_NOSCHEME . '|' .
+		self::IRI_PATH_EMPTY .
+		')';
+	const IRI_HIER_PART     = '(?:' .
+		'\/\/' . self::IRI_AUTHORITY . self::IRI_PATH_ABEMPTY . '|' .
+		self::IRI_PATH_ABSOLUTE . '|' .
+		self::IRI_PATH_ROOTLESS . '|' .
+		self::IRI_PATH_EMPTY .
+		')';
+	const IRI_RELATIVE_REF  = self::IRI_RELATIVE_PART . '(?:?' . self::IRI_QUERY . ')?(?:#' . self::IRI_FRAGMENT . ')?';
+	const IRI               = self::URI_SCHEME . ':' . self::IRI_HIER_PART . '(?:\?' . self::IRI_QUERY . ')?(?:#' . self::IRI_FRAGMENT . ')?';
+	const IRI_REFERENCE     = '(?:' . self::IRI . ')|(?:' . self::IRI_RELATIVE_REF . ')';
+	const IRI_ABSOLUTE_IRI  = self::URI_SCHEME . ':' . self::IRI_HIER_PART . '(?:\?' . self::IRI_QUERY . ')?';
+
+	// Patterns for this fix.
+	const DOMAIN_PARTS_PATTERN = '#(\-|\.)#';
+	const IRI_PATTERN          = '`(?:
+			\A
+			(?<scheme>' . self::URI_SCHEME . ':\/\/)?	        # Subpattern 1: optional scheme ("https://")
+			(?<userinfo>' . self::IRI_USER_INFO . '@)?          # Subpattern 2: optional username ("user@")
+			(?<domain>' . self::IRI_HOST . ')                   # Subpattern 3: host/domain name ("subdomains.domain.tld")
+			(?<port>:' . self::URI_PORT . ')?                   # Subpattern 4: optional port number (":8080")
+			(?<path>' . self::IRI_PATH_ABEMPTY . ')             # Subpattern 5: path ("/some/path", non-optional, but can be empty)
+			(?<query>\?' . self::IRI_QUERY . ')?                # Subpattern 6: optional query string ("?some=query")
+			(?<fragment>\#' . self::IRI_FRAGMENT . ')?          # Subpattern 7: optional fragment ID ("#fragment")
+			\Z
+		)`xui'; // required modifiers: x (multiline pattern) i (case insensitive).
 
 	/**
 	 * Creates a new fix instance.
@@ -64,38 +155,6 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 	 */
 	public function __construct( ?Cache $cache = null, $feed_compatible = false ) {
 		parent::__construct( $cache, Token_Fix::OTHER, $feed_compatible );
-
-		// Combined URL pattern.
-		$this->url_pattern = '`(?:
-			\A
-			(?<scheme>' . self::URL_SCHEME . ':\/\/)?	        # Subpattern 1: contains _http://_ if it exists
-			(?<domain>											# Subpattern 2: contains subdomains.domain.tld
-				(?:
-					[a-z0-9]									# first chr of (sub)domain can not be a hyphen
-					[a-z0-9\-]{0,61}							# middle chrs of (sub)domain may be a hyphen;
-																# limit qty of middle chrs so total domain does not exceed 63 chrs
-					[a-z0-9]									# last chr of (sub)domain can not be a hyphen
-					\.											# dot separator
-				)+
-				(?:
-					' . RE::top_level_domains() . '             # validates top level domain
-				)
-				(?:												# optional port numbers
-					:
-					(?:
-						[1-5]?[0-9]{1,4} | 6[0-4][0-9]{3} | 65[0-4][0-9]{2} | 655[0-2][0-9] | 6553[0-5]
-					)
-				)?
-			)
-			(?<path>											# Subpattern 3: contains path following domain
-				(?:
-					\/											# marks nested directory
-					[a-z0-9\"\$\-_\.\+!\*\'\(\),;\?:@=&\#]+		# valid characters within directory structure
-				)*
-				[\/]?											# trailing slash if any
-			)
-			\Z
-		)`xi'; // required modifiers: x (multiline pattern) i (case insensitive).
 	}
 
 	/**
@@ -115,27 +174,75 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 			return $tokens;
 		}
 
-		// Test for and parse urls.
+		// Test for and parse IRIs.
 		foreach ( $tokens as $token_index => $text_token ) {
-			if ( \preg_match( $this->url_pattern, $text_token->value, $url_match ) ) {
+			if ( \preg_match( self::IRI_PATTERN, $text_token->value, $url_match ) ) {
 				/**
-				 * The URL is split into three parts:
-				 *  - $url_match['scheme'] holds "http://".
-				 *  - $url_match['domain'] holds "subdomains.domain.tld".
-				 *  - $url_match['path']   holds the path after the domain.
-				 *
-				 * @var array{ 'scheme' : string, 'domain' : string,'path' : string } $url_match
+				 * The URL is split into seven parts:
+				 *  - $url_match['scheme']   holds "http://".
+				 *  - $url_match['userinfo'] holds "foo@".
+				 *  - $url_match['domain']   holds "subdomains.domain.tld".
+				 *  - $url_match['port'].    holds ":8080".
+				 *  - $url_match['path']     holds "/some/path".
+				 *  - $url_match['query]     holds "?foo=bar".
+				 *  - $url_match['fragment]  holds "#frag".
 				 */
 
-				$scheme = ! empty( $url_match['scheme'] ) ? $url_match['scheme'] . U::ZERO_WIDTH_SPACE : '';
-				$domain = $this->split_domain( $url_match['domain'], $settings );
-				$path   = $this->split_path( $url_match['path'], $settings );
+				// Bail early if this is an e-mail address.
+				if ( $this->is_email_address( $url_match ) ) {
+					$tokens[ $token_index ] = $text_token;
+					continue;
+				}
 
-				$tokens[ $token_index ] = $text_token->with_value( $scheme . $domain . $path );
+				$tokens[ $token_index ] = $text_token->with_value( $this->wrap_iri( $url_match, $settings ) );
 			}
 		}
 
 		return $tokens;
+	}
+
+	/**
+	 * Tests if the matched "IRI" is an e-mail address.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string[] $iri The matched IRI parts.
+	 *
+	 * @return bool
+	 */
+	private function is_email_address( array $iri ): bool {
+		return (
+			! empty( $iri['userinfo'] ) &&
+			! empty( $iri['domain'] ) &&
+			empty( $iri['scheme'] ) &&
+			empty( $iri['port'] ) &&
+			empty( $iri['path'] ) &&
+			empty( $iri['query'] ) &&
+			empty( $iri['fragment'] )
+		);
+	}
+
+	/**
+	 * Inserts zero-width spaces into IRIs (and regular URLs) to allow
+	 * them to wrap properly.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string[] $iri      The matched IRI parts.
+	 * @param Settings $settings The settings to apply.
+	 *
+	 * @return string
+	 */
+	private function wrap_iri( array $iri, Settings $settings ): string {
+		$scheme   = ! empty( $iri['scheme'] ) ? $iri['scheme'] . U::ZERO_WIDTH_SPACE : '';
+		$userinfo = ! empty( $iri['userinfo'] ) ? $iri['userinfo'] . U::ZERO_WIDTH_SPACE : '';
+		$domain   = $this->split_domain( $iri['domain'], $settings );
+		$port     = ! empty( $iri['port'] ) ? U::ZERO_WIDTH_SPACE . $iri['port'] : '';
+		$path     = $this->split_path( $iri['path'], $settings );
+		$query    = ! empty( $iri['query'] ) ? U::ZERO_WIDTH_SPACE . $iri['query'] : '';
+		$fragment = ! empty( $iri['fragment'] ) ? U::ZERO_WIDTH_SPACE . $iri['fragment'] : '';
+
+		return $scheme . $userinfo . $domain . $port . $path . $query . $fragment;
 	}
 
 	/**
@@ -150,7 +257,12 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 	 * @return string             The hyphenated domain name.
 	 */
 	protected function split_domain( string $domain, Settings $settings ): string {
-		$domain_parts = \preg_split( self::WRAP_URLS_DOMAIN_PARTS, $domain, -1, PREG_SPLIT_DELIM_CAPTURE );
+		if ( \preg_match( '/' . self::URI_IP_LITERAL . '|' . self::URI_IPV4_ADDRESS . '/xui', $domain ) ) {
+			// Don't split IP literals.
+			return $domain;
+		}
+
+		$domain_parts = \preg_split( self::DOMAIN_PARTS_PATTERN, $domain, -1, PREG_SPLIT_DELIM_CAPTURE );
 		if ( false === $domain_parts ) {
 			// Should not happen.
 			return $domain;  // @codeCoverageIgnore
@@ -190,23 +302,40 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 	 * @param  string   $path     A URL path.
 	 * @param  Settings $settings The settings to apply.
 	 *
-	 * @return string             The hyphenated domain name.
+	 * @return string             The path with added zero-width break points.
 	 */
 	protected function split_path( string $path, Settings $settings ): string {
+		if ( empty( $path ) ) {
+			return $path;
+		}
 
-		$str_split = Strings::functions( $path )['str_split'];
+		$strlen = Strings::functions( $path )['strlen'];
 
-		// Break up the URL path to individual characters.
-		$path_parts = $str_split( $path, 1 );
+		// Break up the URL path into individual parts at the path separator.
+		$path_parts = \explode( '/', $path );
 		$path_count = \count( $path_parts );
 		$split_path = '';
 
-		foreach ( $path_parts as $index => $part ) {
-			if ( 0 === $index || $path_count - $index < $settings->min_after_url_wrap ) {
-				$split_path .= $part;
-			} else {
-				$split_path .= U::ZERO_WIDTH_SPACE . $part;
+		for ( $index = $path_count - 1; $index >= 0; --$index ) {
+			switch ( $index ) {
+				case 0:
+					$joiner = '/';
+					break;
+
+				case $path_count - 1:
+					$joiner = '';
+					break;
+
+				default:
+					$joiner = U::ZERO_WIDTH_SPACE . '/';
+
 			}
+
+			if ( ! empty( $joiner ) && $strlen( $split_path ) < $settings->min_after_url_wrap ) {
+				$joiner = '/';
+			}
+
+			$split_path = $path_parts[ $index ] . $joiner . $split_path;
 		}
 
 		return $split_path;

--- a/src/fixes/token-fixes/class-wrap-urls-fix.php
+++ b/src/fixes/token-fixes/class-wrap-urls-fix.php
@@ -184,15 +184,19 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 	 * Splits the given URL path.
 	 *
 	 * @since  6.7.0
+	 * @since  7.0.0 Method is now protected to allow for unit testing.
 	 *
 	 * @param  string   $path     A URL path.
 	 * @param  Settings $settings The settings to apply.
 	 *
 	 * @return string             The hyphenated domain name.
 	 */
-	private function split_path( string $path, Settings $settings ): string {
+	protected function split_path( string $path, Settings $settings ): string {
+
+		$str_split = Strings::functions( $path )['str_split'];
+
 		// Break up the URL path to individual characters.
-		$path_parts = \str_split( $path, 1 ); // TODO: Does not work with non-ASCII paths.
+		$path_parts = $str_split( $path, 1 );
 		$path_count = \count( $path_parts );
 		$split_path = '';
 

--- a/src/fixes/token-fixes/class-wrap-urls-fix.php
+++ b/src/fixes/token-fixes/class-wrap-urls-fix.php
@@ -142,13 +142,14 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 	 * Splits the given domain name.
 	 *
 	 * @since  6.7.0
+	 * @since  7.0.0 Method is now protected to allow for unit testing.
 	 *
 	 * @param  string   $domain   A domain/host name.
 	 * @param  Settings $settings The settings to apply.
 	 *
 	 * @return string             The hyphenated domain name.
 	 */
-	private function split_domain( string $domain, Settings $settings ): string {
+	protected function split_domain( string $domain, Settings $settings ): string {
 		$domain_parts = \preg_split( self::WRAP_URLS_DOMAIN_PARTS, $domain, -1, PREG_SPLIT_DELIM_CAPTURE );
 		if ( false === $domain_parts ) {
 			// Should not happen.

--- a/tests/class-php-typography-test.php
+++ b/tests/class-php-typography-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2024 Peter Putzer.
+ *  Copyright 2015-2026 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -2268,8 +2268,8 @@ class PHP_Typography_Test extends Testcase {
 			[ 'https://example.org/',                'https://&#8203;example&#8203;.org/',          2 ],
 			[ 'http://example.org/',                 'http://&#8203;example&#8203;.org/',           2 ],
 			[ 'https://my-example.org',              'https://&#8203;my&#8203;-example&#8203;.org', 2 ],
-			[ 'https://example.org/some/long/path/', 'https://&#8203;example&#8203;.org/&#8203;s&#8203;o&#8203;m&#8203;e&#8203;/&#8203;l&#8203;o&#8203;n&#8203;g&#8203;/&#8203;path/', 5 ],
-			[ 'https://example.org:8080/',           'https://&#8203;example&#8203;.org:8080/',     2 ],
+			[ 'https://example.org/some/long/path/', 'https://&#8203;example&#8203;.org/some&#8203;/long&#8203;/path/', 5 ],
+			[ 'https://example.org:8080/',           'https://&#8203;example&#8203;.org&#8203;:8080/',     2 ],
 		];
 	}
 

--- a/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2015-2024 Peter Putzer.
+ *  Copyright 2015-2026 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -81,9 +81,26 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 		return [
 			[ 'https://example.org/',                'https://&#8203;example&#8203;.org/',          2 ],
 			[ 'http://example.org/',                 'http://&#8203;example&#8203;.org/',           2 ],
+			[ 'http://someone@example.org/',         'http://&#8203;someone@&#8203;example&#8203;.org/', 2 ],
+			[ 'foo@example.org',                     'foo@example.org',                             2 ], // this is an e-mail address, not a URL.
+			[ 'www.example.org/',                    'www&#8203;.example&#8203;.org/',              2 ],
 			[ 'https://my-example.org',              'https://&#8203;my&#8203;-example&#8203;.org', 2 ],
-			[ 'https://example.org/some/long/path/', 'https://&#8203;example&#8203;.org/&#8203;s&#8203;o&#8203;m&#8203;e&#8203;/&#8203;l&#8203;o&#8203;n&#8203;g&#8203;/&#8203;path/', 5 ],
-			[ 'https://example.org:8080/',           'https://&#8203;example&#8203;.org:8080/',     2 ],
+			[ 'https://example.org/some/long/path/', 'https://&#8203;example&#8203;.org/some&#8203;/long&#8203;/path/', 5 ],
+			[ 'https://example.org:8080/',           'https://&#8203;example&#8203;.org&#8203;:8080/',     2 ],
+			[ 'https://example.org:443/some/long/path/', 'https://&#8203;example&#8203;.org&#8203;:443/some&#8203;/long/path/', 10 ],
+			[ 'https://10.0.0.1:443/some/long/path/', 'https://&#8203;10.0.0.1&#8203;:443/some&#8203;/long&#8203;/path/', 3 ],
+			[ 'https://10.0.0.1:443/some/long/path/#with-a-fragment', 'https://&#8203;10.0.0.1&#8203;:443/some&#8203;/long/path/&#8203;#with-a-fragment', 10 ],
+			[ 'https://καληνύχτα.gr',                'https://&#8203;&kappa;&alpha;&lambda;&eta;&nu;&#973;&chi;&tau;&alpha;&#8203;.gr', 2 ],
+			[ 'https://καληνύχτα.gr/Γεια/Καληνύχτα', 'https://&#8203;&kappa;&alpha;&lambda;&eta;&nu;&#973;&chi;&tau;&alpha;&#8203;.gr/&Gamma;&epsilon;&iota;&alpha;&#8203;/&Kappa;&alpha;&lambda;&eta;&nu;&#973;&chi;&tau;&alpha;', 5 ],
+			[ 'https://[2001:db8::1]/',              'https://&#8203;[2001:db8::1]/', 2 ],
+			[ 'https://[2001:db8::1]/with/path',     'https://&#8203;[2001:db8::1]/with&#8203;/path', 2 ],
+			[ 'https://example.org:8080/my/own/path?with=query#frag', 'https://&#8203;example&#8203;.org&#8203;:8080/my&#8203;/own/path&#8203;?with=query&#8203;#frag', 5 ],
+			[ 'https://example.org:8080/my/own/path2?with=query', 'https://&#8203;example&#8203;.org&#8203;:8080/my&#8203;/own&#8203;/path2&#8203;?with=query', 5 ],
+			[ 'http://example.org/#frag',            'http://&#8203;example&#8203;.org/&#8203;#frag', 2 ],
+			[ 'http://JP納豆.例.jp',                  'http://&#8203;JP納豆&#8203;.例&#8203;.jp', 2 ],
+			[ 'ftp://kärnten.at',                    'ftp://&#8203;k&auml;rnten&#8203;.at', 2 ],
+			[ ' ',                                    ' ', 2 ],
+			[ '/a',                                   '/a', 1 ],
 		];
 	}
 
@@ -91,6 +108,8 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 	 * Test apply.
 	 *
 	 * @covers ::apply
+	 * @covers ::is_email_address
+	 * @covers ::wrap_iri
 	 *
 	 * @uses ::split_domain
 	 * @uses ::split_path
@@ -172,8 +191,8 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 		return [
 			[ '', '', 2 ],
 			[ '/', '/', 2 ],
-			[ '/some/long/path/', '/&#8203;s&#8203;o&#8203;m&#8203;e&#8203;/&#8203;l&#8203;o&#8203;n&#8203;g&#8203;/&#8203;path/', 5 ],
-			[ '/Γεια/Καληνύχτα/', '/&#8203;&Gamma;&#8203;&epsilon;&#8203;&iota;&#8203;&alpha;&#8203;/&#8203;&Kappa;&#8203;&alpha;&#8203;&lambda;&#8203;&eta;&#8203;&nu;&#8203;&#973;&chi;&tau;&alpha;/', 5 ],
+			[ '/some/long/path/', '/some&#8203;/long&#8203;/path/', 5 ],
+			[ '/Γεια/Καληνύχτα/', '/&Gamma;&epsilon;&iota;&alpha;&#8203;/&Kappa;&alpha;&lambda;&eta;&nu;&#973;&chi;&tau;&alpha;/', 5 ],
 		];
 	}
 

--- a/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
@@ -27,6 +27,8 @@ namespace PHP_Typography\Tests\Fixes\Token_Fixes;
 use PHP_Typography\Fixes\Token_Fix;
 use PHP_Typography\Fixes\Token_Fixes;
 
+use Mockery as m;
+
 /**
  * Wrap_URLs_Fix unit test.
  *
@@ -55,7 +57,7 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->fix = new Token_Fixes\Wrap_URLs_Fix();
+		$this->fix = m::mock( Token_Fixes\Wrap_URLs_Fix::class, [] )->shouldAllowMockingProtectedMethods()->makePartial();
 	}
 
 	/**
@@ -75,7 +77,7 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 	 *
 	 * @return array
 	 */
-	public function provide_wrap_urls_data() {
+	public function provide_wrap_urls_data(): array {
 		return [
 			[ 'https://example.org/',                'https://&#8203;example&#8203;.org/',          2 ],
 			[ 'http://example.org/',                 'http://&#8203;example&#8203;.org/',           2 ],
@@ -90,8 +92,8 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 	 *
 	 * @covers ::apply
 	 * @covers ::split_domain
-	 * @covers ::split_path
 	 *
+	 * @uses ::split_path
 	 * @uses PHP_Typography\Text_Parser
 	 * @uses PHP_Typography\Text_Parser\Token
 	 *
@@ -127,5 +129,40 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 		$this->s->set_min_after_url_wrap( $min_after );
 
 		$this->assertFixResultSame( $input, $input, false, $this->getTextnode( 'foo', $input ) );
+	}
+
+	/**
+
+	/**
+	 * Provide data for testing split_path.
+	 *
+	 * @return array
+	 */
+	public function provide_split_path_data(): array {
+		return [
+			[ '', '', 2 ],
+			[ '/', '/', 2 ],
+			[ '/some/long/path/', '/&#8203;s&#8203;o&#8203;m&#8203;e&#8203;/&#8203;l&#8203;o&#8203;n&#8203;g&#8203;/&#8203;path/', 5 ],
+			[ '/Γεια/Καληνύχτα/', '/&#8203;&Gamma;&#8203;&epsilon;&#8203;&iota;&#8203;&alpha;&#8203;/&#8203;&Kappa;&#8203;&alpha;&#8203;&lambda;&#8203;&eta;&#8203;&nu;&#8203;&#973;&chi;&tau;&alpha;/', 5 ],
+		];
+	}
+
+	/**
+	 * Test split_path.
+	 *
+	 * @covers ::split_path
+	 *
+	 * @uses PHP_Typography\Text_Parser
+	 * @uses PHP_Typography\Text_Parser\Token
+	 *
+	 * @dataProvider provide_split_path_data
+	 *
+	 * @param string $input     HTML input.
+	 * @param string $result    Expected result.
+	 * @param int    $min_after Minimum number of characters after URL wrapping.
+	 */
+	public function test_split_path( $input, $result, $min_after ) {
+		$this->s->set_min_after_url_wrap( $min_after );
+		$this->assertSame( $result, $this->clean_html( $this->fix->split_path( $input, $this->s ) ) );
 	}
 }

--- a/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
+++ b/tests/fixes/token-fixes/class-wrap-urls-fix-test.php
@@ -91,8 +91,8 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 	 * Test apply.
 	 *
 	 * @covers ::apply
-	 * @covers ::split_domain
 	 *
+	 * @uses ::split_domain
 	 * @uses ::split_path
 	 * @uses PHP_Typography\Text_Parser
 	 * @uses PHP_Typography\Text_Parser\Token
@@ -132,6 +132,36 @@ class Wrap_URLs_Fix_Test extends Token_Fix_Testcase {
 	}
 
 	/**
+	 * Provide data for testing split_domain.
+	 *
+	 * @return array
+	 */
+	public function provide_split_domain_data(): array {
+		return [
+			[ '', '' ],
+			[ 'example.org', 'example&#8203;.org' ],
+			[ 'my-example.org', 'my&#8203;-example&#8203;.org' ],
+			[ 'some.example.org', 'some&#8203;.example&#8203;.org' ],
+			[ 'καληνύχτα.gr', '&kappa;&alpha;&lambda;&eta;&nu;&#973;&chi;&tau;&alpha;&#8203;.gr' ],
+		];
+	}
+
+	/**
+	 * Test split_domain.
+	 *
+	 * @covers ::split_domain
+	 *
+	 * @uses PHP_Typography\Text_Parser
+	 * @uses PHP_Typography\Text_Parser\Token
+	 *
+	 * @dataProvider provide_split_domain_data
+	 *
+	 * @param string $input  HTML input.
+	 * @param string $result Expected result.
+	 */
+	public function test_split_domain( $input, $result ) {
+		$this->assertSame( $result, $this->clean_html( $this->fix->split_domain( $input, $this->s ) ) );
+	}
 
 	/**
 	 * Provide data for testing split_path.


### PR DESCRIPTION
- Adds optional support for IRIs (basically non-ASCII URIs).
- Makes `Wrap_URLs_Fix::split_domain` and `::split_path` protected and adds unit tests for them.