### PR TITLE
Use the PCRE-escaped non-breaking space so the /x modifier doesn’t strip it out

### DIFF
--- a/src/fixes/node-fixes/class-space-collapse-fix.php
+++ b/src/fixes/node-fixes/class-space-collapse-fix.php
@@ -41,8 +41,11 @@ use PHP_Typography\U;
  */
 class Space_Collapse_Fix extends Abstract_Node_Fix {
 
+	// Use the PCRE-escaped non-breaking space so the /x modifier doesn’t strip it out.
+	const PCRE_ESCAPED_NO_BREAK_SPACE = "\\x{00A0}";
+
 	const COLLAPSE_NORMAL_SPACES            = '/[' . RE::NORMAL_SPACES . ']+/Sxu';
-	const COLLAPSE_NON_BREAKABLE_SPACES     = '/(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*' . U::NO_BREAK_SPACE . '(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*/Sxu';
+	const COLLAPSE_NON_BREAKABLE_SPACES     = '/(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*' . self::PCRE_ESCAPED_NO_BREAK_SPACE . '(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*/Sxu';
 	const COLLAPSE_OTHER_SPACES             = '/(?:[' . RE::NORMAL_SPACES . '])*(' . RE::HTML_SPACES . ')(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*/Sxu';
 	const COLLAPSE_SPACES_AT_START_OF_BLOCK = '/\A(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')+/Sxu';
 


### PR DESCRIPTION
We encountered weird behaviour on our mac development stations where the space-collapse-fix would add a space between every character.

The reason seems to be that the /x modifier strips the U::NO_BREAK_SPACE. This only seems to happen on mac when using setlocale before running this function. On ubuntu with all the versions the same(php/pcre) it works normally.

I have attached a small test script that shows the error on my system.

There are multiple issues touching this issue:
- https://github.com/nystudio107/craft-typogrify/issues/33
- https://github.com/mundschenk-at/php-typography/issues/109

PHP version: 8.4.8
PCRE library: 10.45 2025-02-05

```php
<?php

$nbsp  = "\xC2\xA0";
$nbspEscaped  = "\\x{00A0}";
$input = "a{$nbsp}b";

// The result should become: a-b
// First without setlocale (the default locale is C.UTF-8 on my mac).
echo preg_replace("/{$nbsp}/xu", '-', $input) . "\n"; // This works and outputs a-b

// Set the locale to the same that i currently have.
setlocale(LC_CTYPE, "C.UTF-8");
echo preg_replace("/{$nbsp}/xu", '-', $input) . "\n"; // Wrong output -a-b-
echo preg_replace("/{$nbspEscaped}/xu", '-', $input) . "\n"; // Correct output a-b

// It looks like any locale i set triggers the error.
setlocale(LC_CTYPE, "en_US.UTF-8");
echo preg_replace("/{$nbsp}/xu", '-', $input) . "\n"; // Wrong output -a-b-
echo preg_replace("/{$nbspEscaped}/xu", '-', $input) . "\n"; // Correct output a-b
```