### PR TITLE
added null `?` to type-hints in method arguments

### DIFF
--- a/src/class-dom.php
+++ b/src/class-dom.php
@@ -395,7 +395,7 @@ abstract class DOM {
 	 *
 	 * @return DOMText|null The first child of type DOMText, the element itself if it is of type DOMText or null.
 	 */
-	public static function get_first_textnode( DOMNode $node = null, bool $recursive = false ): ?DOMText {
+	public static function get_first_textnode( ?DOMNode $node = null, bool $recursive = false ): ?DOMText {
 		/**
 		 * We only allow textnodes in our `is_acceptable` callable.
 		 *
@@ -432,7 +432,7 @@ abstract class DOM {
 	 *
 	 * @return DOMNode|null The last acceptable child node, the element itself if it is acceptable or null.
 	 */
-	public static function get_last_acceptable_node( callable $is_acceptable, DOMNode $node = null, bool $recursive = false ): ?DOMNode {
+	public static function get_last_acceptable_node( callable $is_acceptable, ?DOMNode $node = null, bool $recursive = false ): ?DOMNode {
 		return self::get_edge_node( $is_acceptable, [ __CLASS__, __FUNCTION__ ], $node, $recursive, true );
 	}
 

--- a/src/class-php-typography.php
+++ b/src/class-php-typography.php
@@ -82,7 +82,7 @@ class PHP_Typography {
 	 * @param Registry|null $registry Optional. A fix registry instance. Default null,
 	 *                                meaning the default fixes are used.
 	 */
-	public function __construct( Registry $registry = null ) {
+	public function __construct( ?Registry $registry = null ) {
 		$this->registry              = $registry;
 		$this->update_registry_cache = ! empty( $registry );
 	}

--- a/src/fixes/class-default-registry.php
+++ b/src/fixes/class-default-registry.php
@@ -64,7 +64,7 @@ class Default_Registry extends Registry {
 	 * @param Cache|null $cache       Optional. A hyphenatation cache instance to use. Default null.
 	 * @param string[]   $css_classes Optional. An array of CSS classes to use. Defaults to null (i.e. use the predefined classes).
 	 */
-	public function __construct( Cache $cache = null, array $css_classes = [] ) {
+	public function __construct( ?Cache $cache = null, array $css_classes = [] ) {
 		parent::__construct();
 
 		if ( empty( $css_classes ) ) {

--- a/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
+++ b/src/fixes/node-fixes/class-smart-ordinal-suffix-fix.php
@@ -96,7 +96,7 @@ class Smart_Ordinal_Suffix_Fix extends Abstract_Node_Fix {
 	 * @param string|null $css_class       Optional. Default null.
 	 * @param bool        $feed_compatible Optional. Default false.
 	 */
-	public function __construct( $css_class = null, $feed_compatible = false ) {
+	public function __construct( ?string $css_class = null, $feed_compatible = false ) {
 		parent::__construct( $feed_compatible );
 
 		$ordinal_class     = empty( $css_class ) ? '' : ' class="' . $css_class . '"';

--- a/src/fixes/token-fixes/class-hyphenate-compounds-fix.php
+++ b/src/fixes/token-fixes/class-hyphenate-compounds-fix.php
@@ -49,7 +49,7 @@ class Hyphenate_Compounds_Fix extends Hyphenate_Fix {
 	 * @param Cache|null $cache           Optional. Default null.
 	 * @param bool       $feed_compatible Optional. Default false.
 	 */
-	public function __construct( Cache $cache = null, $feed_compatible = false ) {
+	public function __construct( ?Cache $cache = null, $feed_compatible = false ) {
 		parent::__construct( $cache, Token_Fix::COMPOUND_WORDS, $feed_compatible );
 	}
 

--- a/src/fixes/token-fixes/class-hyphenate-fix.php
+++ b/src/fixes/token-fixes/class-hyphenate-fix.php
@@ -70,7 +70,7 @@ class Hyphenate_Fix extends Abstract_Token_Fix {
 	 * @param int        $target          Optional. Default Token_Fix::WORDS.
 	 * @param bool       $feed_compatible Optional. Default false.
 	 */
-	public function __construct( Cache $cache = null, $target = Token_Fix::WORDS, $feed_compatible = false ) {
+	public function __construct( ?Cache $cache = null, $target = Token_Fix::WORDS, $feed_compatible = false ) {
 		parent::__construct( $target, $feed_compatible );
 
 		if ( null === $cache ) {

--- a/src/fixes/token-fixes/class-wrap-urls-fix.php
+++ b/src/fixes/token-fixes/class-wrap-urls-fix.php
@@ -62,7 +62,7 @@ class Wrap_URLs_Fix extends Hyphenate_Fix {
 	 * @param Cache|null $cache           Optional. Default null.
 	 * @param bool       $feed_compatible Optional. Default false.
 	 */
-	public function __construct( Cache $cache = null, $feed_compatible = false ) {
+	public function __construct( ?Cache $cache = null, $feed_compatible = false ) {
 		parent::__construct( $cache, Token_Fix::OTHER, $feed_compatible );
 
 		// Combined URL pattern.


### PR DESCRIPTION
### Problem this PR solves
I tried to use this library in my project (PHP 8.4) to hyphenate words. Hyphenation works fine, but when I run scripts I get a lot of messages of this type
```
Deprecated: PHP_Typography\Fixes\Token_Fixes\Wrap_Emails_Fix::apply(): Implicitly marking parameter $textnode as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/mundschenk-at/php-typography/src/fixes/token-fixes/class-wrap-emails-fix.php on line 90
```

To fix this behavior I added null `?` symbol in every place I found which can cause such deprecation message, .i.e. places with `null` default value for arguments, like
```php
function (?string $a = null) {}
```

This should help the library work without any non-relevant messages in stdOut