### PR TITLE
Properly follow PCRE specs for space characters in patterns with `x` modifier

### DIFF
--- a/src/fixes/node-fixes/class-smart-dashes-fix.php
+++ b/src/fixes/node-fixes/class-smart-dashes-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2014-2024 Peter Putzer.
+ *  Copyright 2014-2026 Peter Putzer.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or modify modify
@@ -62,7 +62,7 @@ class Smart_Dashes_Fix extends Abstract_Node_Fix {
 	// Date handling.
 	const DATE_YYYY_MM_DD = '/
 		(
-			(?<=\s|\A|' . U::NO_BREAK_SPACE . ')
+			(?<=\s|\A|[' . U::NO_BREAK_SPACE . '])
 			[12][0-9]{3}
 		)
 		[\-' . U::EN_DASH . ']
@@ -72,7 +72,7 @@ class Smart_Dashes_Fix extends Abstract_Node_Fix {
 		[\-' . U::EN_DASH . "]
 			(
 				(?:[0][1-9]|[12][0-9]|[3][0-1])
-				(?=\s|\Z|\)|\]|\.|\,|\?|\;|\:|\'|\"|\!|" . U::NO_BREAK_SPACE . ')
+				(?=\s|\Z|\)|\]|\.|\,|\?|\;|\:|\'|\"|\!|[" . U::NO_BREAK_SPACE . '])
 		)
 	/xu';
 
@@ -80,7 +80,7 @@ class Smart_Dashes_Fix extends Abstract_Node_Fix {
 		(?:
 			(?:
 				(
-					(?<=\s|\A|' . U::NO_BREAK_SPACE . ')
+					(?<=\s|\A|[' . U::NO_BREAK_SPACE . '])
 					(?:[0]?[1-9]|[1][0-2])
 				)
 				[\-' . U::EN_DASH . ']
@@ -91,7 +91,7 @@ class Smart_Dashes_Fix extends Abstract_Node_Fix {
 			|
 			(?:
 				(
-					(?<=\s|\A|' . U::NO_BREAK_SPACE . ')
+					(?<=\s|\A|[' . U::NO_BREAK_SPACE . '])
 					(?:[0]?[1-9]|[12][0-9]|[3][0-1])
 				)
 				[\-' . U::EN_DASH . ']
@@ -103,13 +103,13 @@ class Smart_Dashes_Fix extends Abstract_Node_Fix {
 		[\-' . U::EN_DASH . "]
 		(
 			[12][0-9]{3}
-			(?=\s|\Z|\)|\]|\.|\,|\?|\;|\:|\'|\"|\!|" . U::NO_BREAK_SPACE . ')
+			(?=\s|\Z|\)|\]|\.|\,|\?|\;|\:|\'|\"|\!|[" . U::NO_BREAK_SPACE . '])
 		)
 	/xu';
 
 	const DATE_YYYY_MM = '/
 		(
-			(?<=\s|\A|' . U::NO_BREAK_SPACE . ')
+			(?<=\s|\A|[' . U::NO_BREAK_SPACE . '])
 			[12][0-9]{3}
 		)
 		[\-' . U::EN_DASH . "]
@@ -119,7 +119,7 @@ class Smart_Dashes_Fix extends Abstract_Node_Fix {
 				|
 				(?:[0][0-9][1-9]|[1-2][0-9]{2}|[3][0-5][0-9]|[3][6][0-6])
 			)
-			(?=\s|\Z|\)|\]|\.|\,|\?|\;|\:|\'|\"|\!|" . U::NO_BREAK_SPACE . ')
+			(?=\s|\Z|\)|\]|\.|\,|\?|\;|\:|\'|\"|\!|[" . U::NO_BREAK_SPACE . '])
 		)
 	/xu';
 

--- a/src/fixes/node-fixes/class-smart-fractions-fix.php
+++ b/src/fixes/node-fixes/class-smart-fractions-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2024 Peter Putzer.
+ *  Copyright 2017-2026 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify modify
  *  it under the terms of the GNU General Public License as published by
@@ -46,12 +46,12 @@ class Smart_Fractions_Fix extends Abstract_Node_Fix {
 
 	const FRACTION_MATCHING = '/
 		# lookbehind assertion: makes sure we are not messing up a url
-		(?<=\A|\s|' . U::NO_BREAK_SPACE . '|' . U::NO_BREAK_NARROW_SPACE . ')
+		(?<=\A|\s|[' . U::NO_BREAK_SPACE . U::NO_BREAK_NARROW_SPACE . '])
 
 		(\d+)
 
 		# strip out any zero-width spaces inserted by wrap_hard_hyphens
-		(?:\s?\/\s?' . U::ZERO_WIDTH_SPACE . '?)
+		(?:\s?\/\s?[' . U::ZERO_WIDTH_SPACE . ']?)
 
 		(
 			# lookahead assertion: do not make fractions from x:x if x > 1
@@ -74,7 +74,7 @@ class Smart_Fractions_Fix extends Abstract_Node_Fix {
 			(?:\<sup\>(?:st|nd|rd|th)<\/sup\>)? # spellchecker:disable-line
 
 			# makes sure we are not messing up a url
-			(?:\Z|\s|' . U::NO_BREAK_SPACE . '|' . U::NO_BREAK_NARROW_SPACE . '|\.|,|\!|\?|\)|\;|\:|\'|")
+			(?:\Z|\s|[' . U::NO_BREAK_SPACE . U::NO_BREAK_NARROW_SPACE . ']|\.|,|\!|\?|\)|\;|\:|\'|")
 		)
 		/Sxu';
 
@@ -83,7 +83,7 @@ class Smart_Fractions_Fix extends Abstract_Node_Fix {
 			( \b (?: 0?[1-9] | 1[0-2] ) )
 
 			# capture any zero-width spaces inserted by wrap_hard_hyphens
-			(\s?\/\s?' . U::ZERO_WIDTH_SPACE . '?)
+			(\s?\/\s?[' . U::ZERO_WIDTH_SPACE . ']?)
 
 			# handle 4-decimal years
 			( [12][0-9]{3}\b )

--- a/src/fixes/node-fixes/class-smart-maths-fix.php
+++ b/src/fixes/node-fixes/class-smart-maths-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2017-2024 Peter Putzer.
+ *  Copyright 2017-2026 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -87,7 +87,7 @@ class Smart_Maths_Fix extends Abstract_Node_Fix {
 
 	// Revert fractions to basic slash.
 	const REVERT_FRACTION = "/
-		(?<=\s|\A|\'|\"|" . U::NO_BREAK_SPACE . ')
+		(?<=\s|\A|\'|\"|[" . U::NO_BREAK_SPACE . '])
 		(
 			\d+
 		)

--- a/src/fixes/node-fixes/class-space-collapse-fix.php
+++ b/src/fixes/node-fixes/class-space-collapse-fix.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of PHP-Typography.
  *
- *  Copyright 2014-2024 Peter Putzer.
+ *  Copyright 2014-2026 Peter Putzer.
  *  Copyright 2009-2011 KINGdesk, LLC.
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -42,7 +42,7 @@ use PHP_Typography\U;
 class Space_Collapse_Fix extends Abstract_Node_Fix {
 
 	const COLLAPSE_NORMAL_SPACES            = '/[' . RE::NORMAL_SPACES . ']+/Sxu';
-	const COLLAPSE_NON_BREAKABLE_SPACES     = '/(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*' . U::NO_BREAK_SPACE . '(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*/Sxu';
+	const COLLAPSE_NON_BREAKABLE_SPACES     = '/(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*[' . U::NO_BREAK_SPACE . '](?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*/Sxu';
 	const COLLAPSE_OTHER_SPACES             = '/(?:[' . RE::NORMAL_SPACES . '])*(' . RE::HTML_SPACES . ')(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')*/Sxu';
 	const COLLAPSE_SPACES_AT_START_OF_BLOCK = '/\A(?:[' . RE::NORMAL_SPACES . ']|' . RE::HTML_SPACES . ')+/Sxu';
 


### PR DESCRIPTION
Kudos to @wvell for the bug report (and a lot of stamina to get me to follow through) via https://github.com/mundschenk-at/php-typography/pull/188.

The PCRE spec requires space characters in patterns with the `x` modifier (`PCRE_EXTEND`) to be either

1. contained in a character class, or
2. PCRE-escaped (otherwise they are ignored).

This PR moves all occurrences of `U::NO_BREAK_SPACE` and `U::NARROW_NO_BREAK_SPACE` to character classes in REs with the `x` modifier.